### PR TITLE
Use heap_beginscan_catalog for scanning pipeline_queries table

### DIFF
--- a/src/backend/catalog/pipeline_queries.c
+++ b/src/backend/catalog/pipeline_queries.c
@@ -55,7 +55,7 @@ get_next_id(void)
 	int32 id = -1;
 
 	rel = heap_open(PipelineQueriesRelationId, AccessExclusiveLock);
-	scandesc = heap_beginscan(rel, SnapshotAny, 0, NULL);
+	scandesc = heap_beginscan_catalog(rel, 0, NULL);
 
 	while ((tup = heap_getnext(scandesc, ForwardScanDirection)) != NULL)
 	{

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -607,7 +607,7 @@ pg_parse_query(const char *query_string)
 				 * registered CONTINUOUS VIEWS.
 				 */
 				Relation pipeline_queries = heap_open(PipelineQueriesRelationId, RowShareLock);
-				HeapScanDesc scan_desc = heap_beginscan(pipeline_queries, SnapshotAny, 0, NULL);
+				HeapScanDesc scan_desc = heap_beginscan_catalog(pipeline_queries, 0, NULL);
 				HeapTuple tup;
 				Form_pipeline_queries row;
 				views = NIL;


### PR DESCRIPTION
Not using it results in weird behavior where deleted rows are yielded and/or the same row is yielded multiple times.
