### PR TITLE
Bug fix in CQ's SelectStmt analyzer

### DIFF
--- a/src/test/regress/expected/cqanalyze.out
+++ b/src/test/regress/expected/cqanalyze.out
@@ -136,3 +136,9 @@ CREATE CONTINUOUS VIEW cqanalyze42 AS SELECT COUNT(*) FROM stream WHERE arrival_
 ERROR:  clock_timestamp may only appear once in a WHERE clause
 LINE 1: ...amp() - interval '1 hour' AND arrival_timestamp > clock_time...
                                                              ^
+-- Regression
+CREATE CONTINUOUS VIEW cqanalyze43 AS SELECT date_trunc('hour', ts) AS ts FROM stream;
+ERROR:  column reference "ts" has an ambiguous type
+LINE 1: ...OUS VIEW cqanalyze43 AS SELECT date_trunc('hour', ts) AS ts ...
+                                                             ^
+HINT:  Explicitly cast to the desired type. For example, ts::integer.

--- a/src/test/regress/sql/cqanalyze.sql
+++ b/src/test/regress/sql/cqanalyze.sql
@@ -111,3 +111,6 @@ CREATE CONTINUOUS VIEW cqanalyze39 AS SELECT COUNT(*) FROM stream WHERE arrival_
 CREATE CONTINUOUS VIEW cqanalyze40 AS SELECT COUNT(*) FROM stream WHERE NOT arrival_timestamp < clock_timestamp() - interval '1 hour';
 CREATE CONTINUOUS VIEW cqanalyze41 AS SELECT COUNT(*) FROM stream WHERE arrival_timestamp < clock_timestamp() - interval '1 hour' OR key::text='pipelinedb';
 CREATE CONTINUOUS VIEW cqanalyze42 AS SELECT COUNT(*) FROM stream WHERE arrival_timestamp < clock_timestamp() - interval '1 hour' AND arrival_timestamp > clock_timestamp() - interval '5 hour';
+
+-- Regression
+CREATE CONTINUOUS VIEW cqanalyze43 AS SELECT date_trunc('hour', ts) AS ts FROM stream;


### PR DESCRIPTION
Previously we got:

```
usmanm=# CREATE CONTINUOUS VIEW test_view2 AS SELECT date_trunc('hour', ts) AS ts FROM stream;
ERROR:  column "ts" does not exist
```

Now:

```
usmanm=# CREATE CONTINUOUS VIEW test_view2 AS SELECT date_trunc('hour', ts) AS ts FROM stream;
ERROR:  column reference "ts" has an ambiguous type
LINE 1: ...UOUS VIEW test_view2 AS SELECT date_trunc('hour', ts) AS ts ...
                                                             ^
HINT:  Explicitly cast to the desired type. For example, ts::integer.
```
