### PR TITLE
Make literals work for booleans

### DIFF
--- a/src/test/regress/expected/cqdecode.out
+++ b/src/test/regress/expected/cqdecode.out
@@ -1,0 +1,15 @@
+-- Decode all boolean literal types.
+SET debug_sync_stream_insert = 'on';
+CREATE CONTINUOUS VIEW test_bool AS SELECT b::boolean FROM stream;
+ACTIVATE test_bool;
+INSERT INTO stream (b) VALUES (TRUE), (true), ('true'), ('t'), ('y'), ('on'), ('1'), (1);
+INSERT INTO stream (b) VALUES (FALSE), (false), ('false'), ('f'), ('n'), ('off'), ('0'), (0);
+DEACTIVATE;
+SELECT b, COUNT(*) FROM test_bool GROUP BY b;
+ b | count 
+---+-------
+ f |     8
+ t |     8
+(2 rows)
+
+DROP CONTINUOUS VIEW test_bool;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -122,3 +122,4 @@ test: cqsum
 test: cqavg
 test: cqcount
 test: cqlatch
+test: cqdecode

--- a/src/test/regress/sql/cqdecode.sql
+++ b/src/test/regress/sql/cqdecode.sql
@@ -1,0 +1,16 @@
+-- Decode all boolean literal types.
+
+SET debug_sync_stream_insert = 'on';
+
+CREATE CONTINUOUS VIEW test_bool AS SELECT b::boolean FROM stream;
+
+ACTIVATE test_bool;
+
+INSERT INTO stream (b) VALUES (TRUE), (true), ('true'), ('t'), ('y'), ('on'), ('1'), (1);
+INSERT INTO stream (b) VALUES (FALSE), (false), ('false'), ('f'), ('n'), ('off'), ('0'), (0);
+
+DEACTIVATE;
+
+SELECT b, COUNT(*) FROM test_bool GROUP BY b;
+
+DROP CONTINUOUS VIEW test_bool;


### PR DESCRIPTION
Fixes #472.

<!---
@huboard:{"order":475.0,"milestone_order":480,"custom_state":""}
-->
