### PR TITLE
Combiner should not create new rows for aggregates with no GROUP BY

### DIFF
--- a/src/include/pipeline/combiner.h
+++ b/src/include/pipeline/combiner.h
@@ -26,12 +26,5 @@ typedef struct CombinerDesc
 
 CombinerDesc *CreateCombinerDesc(QueryDesc *query);
 void ContinuousQueryCombinerRun(Portal portal, CombinerDesc *combiner, QueryDesc *queryDesc, ResourceOwner owner);
-PlannedStmt *GetCombinePlan(PlannedStmt *plan, Tuplestorestate *store, TupleDesc *desc);
-void GetTuplesToCombineWith(char *cvname, TupleDesc desc,
-		Tuplestorestate *incoming_merges, AttrNumber merge_attr,
-		TupleHashTable merge_targets);
-void SyncCombine(char *cvname, Tuplestorestate *results,
-		TupleTableSlot *slot, AttrNumber merge_attr, TupleHashTable merge_targets);
-void Combine(PlannedStmt *plan, TupleDesc cvdesc, Tuplestorestate *store, MemoryContext tmpctx);
 
 #endif /* COMBINER_H */

--- a/src/test/regress/expected/cqsanity.out
+++ b/src/test/regress/expected/cqsanity.out
@@ -59,6 +59,17 @@ SELECT * FROM cv_weird_tl;
      2 | x   |  30
 (2 rows)
 
+CREATE CONTINUOUS VIEW cv_no_grp AS SELECT COUNT(*), SUM(value::integer) FROM stream;
+ACTIVATE cv_no_grp;
+INSERT INTO stream (key, value) VALUES ('x', 10), ('x', 20), ('y', 200);
+DEACTIVATE cv_no_grp;
+SELECT * FROM cv_no_grp;
+ count | sum 
+-------+-----
+     3 | 230
+(1 row)
+
 DROP CONTINUOUS VIEW test_avg;
 DROP CONTINUOUS VIEW cv;
 DROP CONTINUOUS VIEW cv_weird_tl;
+DROP CONTINUOUS VIEW cv_no_grp;

--- a/src/test/regress/sql/cqsanity.sql
+++ b/src/test/regress/sql/cqsanity.sql
@@ -40,6 +40,17 @@ DEACTIVATE cv_weird_tl;
 
 SELECT * FROM cv_weird_tl;
 
+CREATE CONTINUOUS VIEW cv_no_grp AS SELECT COUNT(*), SUM(value::integer) FROM stream;
+
+ACTIVATE cv_no_grp;
+
+INSERT INTO stream (key, value) VALUES ('x', 10), ('x', 20), ('y', 200);
+
+DEACTIVATE cv_no_grp;
+
+SELECT * FROM cv_no_grp;
+
 DROP CONTINUOUS VIEW test_avg;
 DROP CONTINUOUS VIEW cv;
 DROP CONTINUOUS VIEW cv_weird_tl;
+DROP CONTINUOUS VIEW cv_no_grp;


### PR DESCRIPTION
Sorry most of the changes are code reorganization and make some public functions into private ones. The only real changes are in `get_tuples_to_combine_with`. Fixes #340.
