### PR TITLE
460 python tests

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -12,6 +12,6 @@ subdir = src/test
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 
-SUBDIRS = regress isolation
+SUBDIRS = regress isolation py
 
 $(recurse)

--- a/src/test/py/.gitignore
+++ b/src/test/py/.gitignore
@@ -1,0 +1,3 @@
+/__pycache__
+/.pdb*
+/*.pyc

--- a/src/test/py/GNUmakefile
+++ b/src/test/py/GNUmakefile
@@ -1,0 +1,25 @@
+#-------------------------------------------------------------------------
+#
+# GNUmakefile--
+#    Makefile for src/test/py
+#
+# src/test/py/GNUmakefile
+# 
+# This just creates a phony check target so that we can run this test
+# suite in a way that's consistent with the rest of the code base, and
+# so that these tests are recognized we run `make check` from the source
+# root.
+#-------------------------------------------------------------------------
+
+subdir = src/test/py
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+.PHONY: check
+	
+check: all
+	py.test -v
+	
+clean:
+	rm -rf ./.pdb*
+	rm -rf ./__pycache__

--- a/src/test/py/README
+++ b/src/test/py/README
@@ -1,0 +1,20 @@
+To install the dependencies necessary to run this test suite, run:
+
+sudo pip install -r ./requirements.txt
+
+If you'd prefer to not install these packages system wide, you can
+use virtualenv or install them in a specific directory:
+
+pip install -r ./requirements.txt -t /local/path
+
+Just make sure they're somewhere on your PYTHONPATH. To run the test
+suite after the dependencies have been installed properly, run:
+
+make check
+
+or,
+
+py.test
+
+See http://pytest.org/latest/usage.html for more information on
+how to use py.test for more selective and fancy test running.

--- a/src/test/py/base.py
+++ b/src/test/py/base.py
@@ -1,0 +1,197 @@
+from sqlalchemy import create_engine
+import getpass
+import shutil
+import signal
+import socket
+import time
+import subprocess
+import pytest
+import os
+import base
+
+
+BOOTSTRAPPED_BASE = './.pdbbase'
+ROOT = '../../../'
+INSTALL_FORMAT = './.pdb-%d'
+SERVER = os.path.join(ROOT, 'src', 'backend', 'postgres')
+TEST_DBNAME = 'pipelinedb_test'
+CONNSTR_TEMPLATE = 'postgres://%s@localhost:%d/postgres'
+
+
+class PipelineDB(object):
+    
+    def __init__(self):
+        """
+        Bootstraps the PipelineDB instance. Note that instead of incurring the cost of
+        actually bootstrapping each instance we copy a clean, bootstrapped directory 
+        to our own directory, creating it once for other tests to use if it doesn't
+        already exist.
+        """
+        do_initdb = False
+        if not os.path.exists(BOOTSTRAPPED_BASE):
+            os.mkdir(BOOTSTRAPPED_BASE)
+            make = [
+                'make', '-C', os.path.abspath(ROOT),
+                'DESTDIR=%s' % os.path.abspath(BOOTSTRAPPED_BASE),
+                'install'
+            ]
+            out, err = subprocess.Popen(make).communicate()
+            do_initdb = True
+            
+        # Get the bin dir of our installation 
+        install_bin_dir = None
+        for root, dirs, files in os.walk(BOOTSTRAPPED_BASE):
+            if 'bin' in dirs:
+                install_bin_dir = os.path.join(root, 'bin')
+                    
+        # Install dir is one level above bin
+        install_root, _ = os.path.split(install_bin_dir)
+        install_data_dir = os.path.join(install_root, 'data')
+
+        if do_initdb:
+            initdb = os.path.join(install_bin_dir, 'initdb')
+            out, err = subprocess.Popen([initdb, '-D', install_data_dir]).communicate()
+
+        # Copy the bootstrapped install to our working directory
+        shutil.copytree(install_root, self.tmp_dir)
+        
+        for root, dirs, files in os.walk(self.tmp_dir):
+            if 'data' in dirs:
+                self.data_dir = os.path.join(root, 'data')
+                
+        self.engine = None
+    
+    def run(self):
+        """
+        Runs a test instance of PipelineDB within our temporary directory on a free port
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(('', 0))
+        _, port = sock.getsockname()
+        self.port = port
+        
+        # Let's hope someone doesn't take our port before the server starts up
+        sock.close()
+        self.proc = subprocess.Popen([SERVER, '-D', self.data_dir, '-p', str(self.port)])
+        time.sleep(0.1)
+
+        connstr = CONNSTR_TEMPLATE % (getpass.getuser(), self.port)
+        self.engine = create_engine(connstr)
+        self.conn = self.engine.connect()
+        
+    def destroy(self):
+        """
+        Cleans up resources used by this PipelineDB instance
+        """
+        self.conn.close()
+        if self.proc:
+            os.kill(self.proc.pid, signal.SIGINT)
+        time.sleep(0.05)
+        shutil.rmtree(self.tmp_dir)
+        
+    @property
+    def tmp_dir(self):
+        """
+        Returns the temporary directory that this instance is based within,
+        finding a new one of it hasn't already
+        """
+        if hasattr(self, '_tmp_dir'):
+            return self._tmp_dir
+        
+        # Get all the indexed install dirs so we can created a new one with highest index + 1
+        # Install dirs are of the form: ./.pdb-<n>, so,
+        index = max([int(l.split('-')[1]) for l in os.listdir('.') if '.pdb-' in l] or [-1]) + 1
+        self._tmp_dir = INSTALL_FORMAT % index
+        
+        return self._tmp_dir
+    
+    def create_db(self, name=TEST_DBNAME):
+        """
+        Create a database within this PipelineDB instance
+        """
+        # We can't create a DB in a transaction block
+        self.conn.execute('commit')
+        self.execute('CREATE DATABASE %s' % name)
+    
+    def drop_db(self, name=TEST_DBNAME):
+        """
+        Drop a database within this PipelineDB instance
+        """
+        # We can't drop a DB in a transaction block
+        self.conn.execute('commit')
+        return self.execute('DROP DATABASE %s' % name)
+    
+    def create_cv(self, name, stmt, activate=False):
+        """
+        Create a continuous view
+        """
+        result = self.execute('CREATE CONTINUOUS VIEW %s AS %s' % (name, stmt))
+        if activate:
+            self.activate(name)
+        
+    def drop_cv(self, name):
+        """
+        Drop a continuous view
+        """
+        return self.execute('DROP CONTINUOUS VIEW %s' % name)
+        
+    def activate(self, name=None):
+        """
+        Activate a continuous view, or all of them if no name is given
+        """
+        if name:
+            return self.execute('ACTIVATE %s' % name)
+        else:
+            return self.execute('ACTIVATE')
+        
+    def deactivate(self, name=None):
+        """
+        Deactivate a continuous view, or all of them if no name is given
+        """
+        if name:
+            return self.execute('DEACTIVATE %s' % name)
+        else:
+            return self.execute('DEACTIVATE')
+    
+    def execute(self, stmt):
+        """
+        Execute a raw SQL statement
+        """
+        return self.conn.execute(stmt)
+    
+    def set_sync_insert(self, on):
+        """
+        Sets the flag that makes stream INSERTs synchronous or not
+        """
+        s = on and 'on' or 'off'
+        return self.execute('SET debug_sync_stream_insert = %s' % s)
+
+
+@pytest.fixture
+def clean_db(request):
+    """
+    Called for every test so each test gets a clean db
+    """
+    pdb = request.module.pipeline
+    pdb.create_db()
+    request.addfinalizer(pdb.drop_db)
+    
+    return TEST_DBNAME
+
+
+@pytest.fixture(scope='module')
+def pipeline(request):
+    """
+    Builds and returns a running PipelineDB instance based out of a test
+    directory within the current directory. This is called once per test
+    module, so it's shared between tests even though underlying databases
+    are recreated for each test.
+    """
+    pdb = PipelineDB()
+    request.addfinalizer(pdb.destroy)
+    
+    # Attach it to the module so we can access it with test-scoped fixtures
+    request.module.pipeline = pdb
+    pdb.run()
+    
+    return pdb

--- a/src/test/py/requirements.txt
+++ b/src/test/py/requirements.txt
@@ -1,0 +1,2 @@
+pytest==2.6.3
+SQLAlchemy==0.9.8

--- a/src/test/py/test_sanity.py
+++ b/src/test/py/test_sanity.py
@@ -1,0 +1,65 @@
+from base import pipeline, clean_db
+import pytest
+
+
+def test_create_drop_continuous_view(pipeline, clean_db):
+    """
+    Basic sanity check
+    """
+    pipeline.create_cv('cv0', 'SELECT id::integer FROM stream')
+    pipeline.create_cv('cv1', 'SELECT id::integer FROM stream')
+    pipeline.create_cv('cv2', 'SELECT id::integer FROM stream')
+    
+    result = pipeline.execute('SELECT * FROM pipeline_queries')
+    names = [r['name'] for r in result]
+    
+    assert sorted(names) == ['cv0', 'cv1', 'cv2']
+    
+    pipeline.drop_cv('cv0')
+    pipeline.drop_cv('cv1')
+    pipeline.drop_cv('cv2')
+    
+    result = pipeline.execute('SELECT * FROM pipeline_queries')
+    names = [r['name'] for r in result]
+    
+    assert len(names) == 0
+
+def test_simple_insert(pipeline, clean_db):
+    """
+    Verify that we can insert some rows and count some stuff
+    """
+    pipeline.create_cv('cv', 'SELECT key::integer, COUNT(*) FROM stream GROUP BY key', activate=True)
+    
+    for n in range(1000):
+        pipeline.execute('INSERT INTO stream (key) VALUES (%d)' % (n % 10))
+    
+    pipeline.deactivate('cv')
+    
+    result = list(pipeline.execute('SELECT * FROM cv ORDER BY key'))
+    
+    assert len(result) == 10
+    for i, row in enumerate(result):
+        assert row['key'] == i
+        assert row['count'] == 100
+
+def test_multiple(pipeline, clean_db):
+    """
+    Verify that multiple continuous views work together properly
+    """
+    pipeline.create_cv('cv0', 'SELECT n::numeric FROM stream WHERE n > 10.00001')
+    pipeline.create_cv('cv1', 'SELECT s::text FROM stream WHERE s LIKE \'%%this%%\'')
+    pipeline.activate()
+
+    for n in range(1000):
+        pipeline.execute('INSERT INTO stream (n, s, unused) VALUES (%.6f, \'this\', 100)' % (n + 10))
+
+    for n in range(10):
+        pipeline.execute('INSERT INTO stream (n, s, unused) VALUES (%.6f, \'not a match\', 0)' % (-n))
+
+    pipeline.deactivate()
+
+    result = list(pipeline.execute('SELECT * FROM cv0'))
+    assert len(result) == 999
+
+    result = list(pipeline.execute('SELECT * FROM cv1'))
+    assert len(result) == 1000

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2466,7 +2466,7 @@ regression_main(int argc, char *argv[], init_function ifunc, test_function tfunc
 	 */
 	if (fail_count == 0 && fail_ignore_count == 0)
 		snprintf(buf, sizeof(buf),
-				 _(" All %d tests passed. "),
+				 _(" All %d regression tests passed. "),
 				 success_count);
 	else if (fail_count == 0)	/* fail_count=0, fail_ignore_count>0 */
 		snprintf(buf, sizeof(buf),


### PR DESCRIPTION
This gives us the capability to write tests against Pipeline from Python, which is pretty awesome. Some notes on how this works:
- I decided to use http://pytest.org/ and I really like it so far
- We're using SQLAlchemy as an ORM, although it's easy to just write raw SQL
- There is a new test directory at `src/test/py`. It contains a short README that explains how to set up the Python test suite
- `src/test/py` has its own Makefile and the tests can be run with `make check` or by using pytest directly. Having a Makefile means the tests can easily be recognized by running `make check` from our source root, and it keeps everything consistent
- Currently each test module uses a single PipelineDB instance, but each individual test automatically gets a fresh database
- The tests should be reasonably fast, because we don't have to bootstrap every time we create a new test install. Instead, one untouched install is bootstrapped precisely once and then all other tests copy its directory structure when a test module is loaded
- I included a couple of toy tests in `test_sanity.py` so you guys can get an idea of how everything works
- Things are still fairly minimal, as I figure we'll add library code pretty easily as we require it

It's pretty awesome to actually see how easily we can integrate with ubiquitous and familiar libraries such as SQLAlchemy, basically enabling anyone to immediately have a high-throughput stream processing capability. I'm really excited to grow this test infrastructure and take our code base to the next level.
