### PR TITLE
Fixes #451: show the user how many CVs were activated/deactivated

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -2641,12 +2641,11 @@ copy_generic_opt_arg_list_item:
 
 /*****************************************************************************
  *
- * ( ACTIVATE | DEACTIVATE ) [CONTINUOUS VIEW] [continuous_view_name_list]
+ * ( ACTIVATE | DEACTIVATE ) [continuous_view_name_list]
  *
  * PipelineDB
  *
  * Activates/deactivates continuous view(s)
- * TODO(usmanm): Release should require typing out CONTINUOUS VIEW.
  *
  *****************************************************************************/
 
@@ -2668,14 +2667,6 @@ ActivateContinuousViewStmt: ACTIVATE opt_qualified_name_list opt_reloptions wher
 					s->whereClause = (Node *) $4;
 					$$ = (Node *) s;
 				}
-			| ACTIVATE CONTINUOUS VIEW opt_qualified_name_list opt_reloptions where_clause
-				{
-					ActivateContinuousViewStmt *s = makeNode(ActivateContinuousViewStmt);
-					s->views = (List *) $4;
-					s->withOptions = (List *) $5;
-					s->whereClause = (Node *) $6;
-					$$ = (Node *) s;
-				}
 		;
 
 DeactivateContinuousViewStmt: DEACTIVATE opt_qualified_name_list where_clause
@@ -2683,13 +2674,6 @@ DeactivateContinuousViewStmt: DEACTIVATE opt_qualified_name_list where_clause
 					DeactivateContinuousViewStmt *s = makeNode(DeactivateContinuousViewStmt);
 					s->views = (List *) $2;
 					s->whereClause = (Node *) $3;
-					$$ = (Node *)s;
-				}
-			| DEACTIVATE CONTINUOUS VIEW opt_qualified_name_list where_clause
-				{
-					DeactivateContinuousViewStmt *s = makeNode(DeactivateContinuousViewStmt);
-					s->views = (List *) $4;
-					s->whereClause = (Node *) $5;
 					$$ = (Node *)s;
 				}
 		;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -852,10 +852,6 @@ standard_ProcessUtility(Node *parsetree,
 			}
 			break;
 
-		case T_DeactivateContinuousViewStmt:
-			ExecDeactivateContinuousViewStmt((DeactivateContinuousViewStmt *) parsetree);
-			break;
-
 		default:
 			/* All other statement types have event trigger support */
 			ProcessUtilitySlow(parsetree, queryString,
@@ -2473,10 +2469,10 @@ CreateCommandTag(Node *parsetree)
 			break;
 
 		case T_ActivateContinuousViewStmt:
-			tag = "ACTIVATE CONTINUOUS VIEW";
+			tag = "ACTIVATE";
 			break;
 		case T_DeactivateContinuousViewStmt:
-			tag = "DEACTIVATE CONTINUOUS VIEW";
+			tag = "DEACTIVATE";
 			break;
 		case T_DumpStmt:
 			tag = "DUMP";

--- a/src/include/catalog/pipeline_queries_fn.h
+++ b/src/include/catalog/pipeline_queries_fn.h
@@ -28,7 +28,6 @@ typedef struct ContinuousViewState
 
 void RegisterContinuousView(RangeVar *name, const char *query_string);
 void DeregisterContinuousView(RangeVar *name);
-void ExecActivateContinuousViewStmt(ActivateContinuousViewStmt *stmt);
 bool MarkContinuousViewAsActive(RangeVar *name);
 bool MarkContinuousViewAsInactive(RangeVar *name);
 void SetContinousViewState(RangeVar *name, ContinuousViewState *cv_state);

--- a/src/include/commands/pipelinecmds.h
+++ b/src/include/commands/pipelinecmds.h
@@ -18,7 +18,8 @@ void CreateEncoding(CreateEncodingStmt *stmt);
 void ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *querystring);
 void ExecDropContinuousViewStmt(DropStmt *stmt);
 void ExecDumpStmt(DumpStmt *stmt);
-void ExecDeactivateContinuousViewStmt(DeactivateContinuousViewStmt *stmt);
+int ExecActivateContinuousViewStmt(ActivateContinuousViewStmt *stmt);
+int ExecDeactivateContinuousViewStmt(DeactivateContinuousViewStmt *stmt);
 void ExecTruncateContinuousViewStmt(TruncateStmt *stmt);
 
 #endif   /* PIPELINECMDS_H */

--- a/src/test/regress/expected/cqactivate.out
+++ b/src/test/regress/expected/cqactivate.out
@@ -1,7 +1,7 @@
 CREATE CONTINUOUS VIEW cqactivate1 AS SELECT id::integer FROM stream_sync_cq WHERE id=9099;
-ACTIVATE CONTINUOUS VIEW cqactivate1;
+ACTIVATE cqactivate1;
 CREATE CONTINUOUS VIEW cqactivate2 AS SELECT id::integer FROM stream_sync_cq WHERE id=9099;
-ACTIVATE CONTINUOUS VIEW cqactivate2;
+ACTIVATE cqactivate2;
 SELECT name, query FROM pipeline_queries WHERE state='a' AND name='cqactivate1';
     name     |                                            query                                            
 -------------+---------------------------------------------------------------------------------------------
@@ -14,8 +14,8 @@ SELECT name, query FROM pipeline_queries WHERE state='a' AND name='cqactivate2';
  cqactivate2 | CREATE CONTINUOUS VIEW cqactivate2 AS SELECT id::integer FROM stream_sync_cq WHERE id=9099;
 (1 row)
 
-DEACTIVATE CONTINUOUS VIEW cqactivate1;
-DEACTIVATE CONTINUOUS VIEW cqactivate2;
+DEACTIVATE cqactivate1;
+DEACTIVATE cqactivate2;
 SELECT name, query FROM pipeline_queries WHERE state='i' AND name='cqactivate1';
     name     |                                            query                                            
 -------------+---------------------------------------------------------------------------------------------
@@ -29,3 +29,5 @@ SELECT name, query FROM pipeline_queries WHERE state='i' AND name='cqactivate2';
 (1 row)
 
 DEACTIVATE;
+DROP CONTINUOUS VIEW cqactivate1;
+DROP CONTINUOUS VIEW cqactivate2;

--- a/src/test/regress/expected/cqlatch.out
+++ b/src/test/regress/expected/cqlatch.out
@@ -1,6 +1,6 @@
 set debug_sync_stream_insert = on;
 CREATE CONTINUOUS VIEW cqlatch AS SELECT id::integer FROM stream_latch;
-ACTIVATE CONTINUOUS VIEW cqlatch;
+ACTIVATE cqlatch;
 -- Wait at least 10 seconds till the worker latch is actually blocoed
 SELECT pg_sleep_for('3 seconds');
  pg_sleep_for 
@@ -27,4 +27,5 @@ select query, state FROM pg_stat_activity WHERE NOT query='';
  SELECT id::integer FROM stream_latch;                         | worker latch unblocked
 (2 rows)
 
-DEACTIVATE CONTINUOUS VIEW cqlatch;
+DEACTIVATE cqlatch;
+DROP CONTINUOUS VIEW cqlatch;

--- a/src/test/regress/sql/cqactivate.sql
+++ b/src/test/regress/sql/cqactivate.sql
@@ -1,11 +1,14 @@
 CREATE CONTINUOUS VIEW cqactivate1 AS SELECT id::integer FROM stream_sync_cq WHERE id=9099;
-ACTIVATE CONTINUOUS VIEW cqactivate1;
+ACTIVATE cqactivate1;
 CREATE CONTINUOUS VIEW cqactivate2 AS SELECT id::integer FROM stream_sync_cq WHERE id=9099;
-ACTIVATE CONTINUOUS VIEW cqactivate2;
+ACTIVATE cqactivate2;
 SELECT name, query FROM pipeline_queries WHERE state='a' AND name='cqactivate1';
 SELECT name, query FROM pipeline_queries WHERE state='a' AND name='cqactivate2';
-DEACTIVATE CONTINUOUS VIEW cqactivate1;
-DEACTIVATE CONTINUOUS VIEW cqactivate2;
+DEACTIVATE cqactivate1;
+DEACTIVATE cqactivate2;
 SELECT name, query FROM pipeline_queries WHERE state='i' AND name='cqactivate1';
 SELECT name, query FROM pipeline_queries WHERE state='i' AND name='cqactivate2';
 DEACTIVATE;
+
+DROP CONTINUOUS VIEW cqactivate1;
+DROP CONTINUOUS VIEW cqactivate2;

--- a/src/test/regress/sql/cqlatch.sql
+++ b/src/test/regress/sql/cqlatch.sql
@@ -1,6 +1,6 @@
 set debug_sync_stream_insert = on;
 CREATE CONTINUOUS VIEW cqlatch AS SELECT id::integer FROM stream_latch;
-ACTIVATE CONTINUOUS VIEW cqlatch;
+ACTIVATE cqlatch;
 -- Wait at least 10 seconds till the worker latch is actually blocoed
 SELECT pg_sleep_for('3 seconds');
 -- Query the activity table verify that the worker is waiting on the latch
@@ -10,4 +10,5 @@ INSERT INTO stream_latch (id) VALUES (4);
 INSERT INTO stream_latch (id) VALUES (5);
 -- Query the activity table verify that the worker latch is unblocked
 select query, state FROM pg_stat_activity WHERE NOT query='';
-DEACTIVATE CONTINUOUS VIEW cqlatch;
+DEACTIVATE cqlatch;
+DROP CONTINUOUS VIEW cqlatch;


### PR DESCRIPTION
Instead of rewriting a bare `DE / ACTIVATE` as a bunch of individual statements that operate on a single view, such queries are now rewritten as a single statement that operates on multiple views. This allows us to count how many CVs were affected by the operation more easily.

This also removes the optional `CONTINUOUS VIEW` syntax.
