### PR TITLE
161 combine index

### DIFF
--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -44,6 +44,7 @@
 bool DebugSyncStreamInsert;
 
 #define CQ_TABLE_SUFFIX "_pdb"
+#define CQ_MATREL_INDEX_TYPE "btree"
 #define DEFAULT_TYPEMOD -1
 
 /*
@@ -99,6 +100,50 @@ GetCQMatRelationName(char *cvname)
 	 * be CV name suffixed with "_pdb".
 	 */
 	return append_suffix(cvname, CQ_TABLE_SUFFIX);
+}
+
+/*
+ * ExecCreateCQMatViewIndex
+ *
+ * If feasible, create an index on the new materialization table to make
+ * combine retrievals on it as efficient as possible. Sometimes this may be
+ * impossible to do automatically in a smart way, but for some queries,
+ * such as single-column GROUP BYs, it's straightforward.
+ */
+void
+CreateCQMatViewIndex(Oid matreloid, RangeVar *matrelname, SelectStmt *stmt)
+{
+	IndexStmt *index;
+	IndexElem *indexcol;
+	ColumnRef *col;
+
+	if (list_length(stmt->groupClause) != 1)
+		return;
+
+	col = linitial(stmt->groupClause);
+	indexcol = makeNode(IndexElem);
+	indexcol->name = NameListToString(col->fields);
+	indexcol->expr = NULL;
+	indexcol->indexcolname = NULL;
+	indexcol->collation = NULL;
+	indexcol->opclass = NULL;
+	indexcol->ordering = SORTBY_DEFAULT;
+	indexcol->nulls_ordering = SORTBY_NULLS_DEFAULT;
+
+	index = makeNode(IndexStmt);
+	index->idxname = NULL;
+	index->relation = matrelname;
+	index->accessMethod = CQ_MATREL_INDEX_TYPE;
+	index->tableSpace = NULL;
+	index->indexParams = list_make1(indexcol);
+	index->unique = true;
+	index->primary = false;
+	index->isconstraint = false;
+	index->deferrable = false;
+	index->initdeferred = false;
+	index->concurrent = false;
+
+	DefineIndex(matreloid, index, InvalidOid, false, false, false, false);
 }
 
 /*
@@ -169,7 +214,6 @@ ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *queryst
 
 		colname = pstrdup(tle->resname);
 
-
 		/*
 		 * allowSystemTableMods is a global flag that, when true, allows certain column types
 		 * to be created. We need it set to true to create some hidden state columns. In particular,
@@ -213,6 +257,7 @@ ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *queryst
 	allowSystemTableMods = true;
 	reloid = DefineRelation(create_stmt, RELKIND_RELATION, InvalidOid);
 	CommandCounterIncrement();
+	allowSystemTableMods = saveAllowSystemTableMods;
 
 	toast_options = transformRelOptions((Datum) 0, create_stmt->options, "toast",
 			validnsps, true, false);
@@ -246,6 +291,11 @@ ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *queryst
 	 * relation.
 	 */
 	RegisterContinuousView(view, querystring);
+
+	/*
+	 * Index the materialization table smartly if we can
+	 */
+	CreateCQMatViewIndex(reloid, mat_relation, workerselect);
 }
 
 /*

--- a/src/backend/pipeline/Makefile
+++ b/src/backend/pipeline/Makefile
@@ -12,6 +12,7 @@ subdir = src/backend/pipeline
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS = combiner.o combinerReceiver.o cqanalyze.o cqplan.o cqrun.o cqslidingwindow.o decode.o gc.o stream.o streambuf.o worker.o cvmetadata.o
+OBJS = combiner.o combinerReceiver.o cqanalyze.o cqplan.o cqrun.o cqslidingwindow.o \
+			 decode.o gc.o stream.o streambuf.o worker.o cqmatrel.o cvmetadata.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -1,0 +1,126 @@
+/*-------------------------------------------------------------------------
+ *
+ * cqmatrel.c
+ *	  Support for interacting with CV materialization tables and their indexes
+ *
+ * IDENTIFICATION
+ *	  src/backend/pipeline/cqmatrel.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "access/xact.h"
+#include "catalog/index.h"
+#include "executor/executor.h"
+#include "nodes/execnodes.h"
+#include "pipeline/cqmatrel.h"
+#include "utils/rel.h"
+
+/*
+ * CQMatViewOpen
+ *
+ * Open any indexes associated with the given materialization table
+ */
+ResultRelInfo *
+CQMatViewOpen(Relation matrel)
+{
+	ResultRelInfo *resultRelInfo;
+
+	resultRelInfo = makeNode(ResultRelInfo);
+	resultRelInfo->ri_RangeTableIndex = 1; /* dummy */
+	resultRelInfo->ri_RelationDesc = matrel;
+	resultRelInfo->ri_TrigDesc = NULL;
+
+	ExecOpenIndices(resultRelInfo);
+
+	return resultRelInfo;
+}
+
+/*
+ * CQMatViewClose
+ *
+ * Release any resources associated with the given indexes
+ */
+void
+CQMatViewClose(ResultRelInfo *rinfo)
+{
+	ExecCloseIndices(rinfo);
+	pfree(rinfo);
+}
+
+/*
+ * ExecInsertCQMatRelIndexTuples
+ *
+ * This is a trimmed-down version of ExecInsertIndexTuples
+ */
+void
+ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot)
+{
+	int			i;
+	int			numIndexes;
+	RelationPtr relationDescs;
+	Relation	heapRelation;
+	IndexInfo **indexInfoArray;
+	Datum		values[INDEX_MAX_KEYS];
+	bool		isnull[INDEX_MAX_KEYS];
+	HeapTuple tup = ExecMaterializeSlot(slot);
+
+	/* HOT update does not require index inserts */
+	if (HeapTupleIsHeapOnly(tup))
+		return;
+
+	/* bail if there are no indexes to update */
+	numIndexes = indstate->ri_NumIndices;
+	if (numIndexes == 0)
+		return;
+	relationDescs = indstate->ri_IndexRelationDescs;
+	indexInfoArray = indstate->ri_IndexRelationInfo;
+	heapRelation = indstate->ri_RelationDesc;
+
+	/*
+	 * for each index, form and insert the index tuple
+	 */
+	for (i = 0; i < numIndexes; i++)
+	{
+		IndexInfo  *indexInfo;
+
+		indexInfo = indexInfoArray[i];
+
+		/* If the index is marked as read-only, ignore it */
+		if (!indexInfo->ii_ReadyForInserts)
+			continue;
+
+		FormIndexDatum(indexInfo, slot, NULL, values, isnull);
+
+		index_insert(relationDescs[i], values, isnull, &(tup->t_self),
+				heapRelation, relationDescs[i]->rd_index->indisunique ? UNIQUE_CHECK_YES : UNIQUE_CHECK_NO);
+	}
+}
+
+/*
+ * ExecCQMatViewUpdate
+ *
+ * Update an existing row of a CV materialization table.
+ */
+void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot)
+{
+	HeapTuple tup = ExecMaterializeSlot(slot);
+
+	simple_heap_update(ri->ri_RelationDesc, &tup->t_self, tup);
+	ExecInsertCQMatRelIndexTuples(ri, slot);
+}
+
+/*
+ * ExecCQMatViewInsert
+ *
+ * Insert a new row into a CV materialization table
+ */
+void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot)
+{
+	HeapTuple tup = ExecMaterializeSlot(slot);
+
+	heap_insert(ri->ri_RelationDesc, tup, GetCurrentCommandId(true), 0, NULL);
+	ExecInsertCQMatRelIndexTuples(ri, slot);
+}

--- a/src/include/commands/pipelinecmds.h
+++ b/src/include/commands/pipelinecmds.h
@@ -15,6 +15,7 @@
 
 char *GetCQMatRelationName(char *cvname);
 void CreateEncoding(CreateEncodingStmt *stmt);
+void CreateCQMatViewIndex(Oid matreloid, RangeVar *matrelname, SelectStmt *stmt);
 void ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *querystring);
 void ExecDropContinuousViewStmt(DropStmt *stmt);
 void ExecDumpStmt(DumpStmt *stmt);

--- a/src/include/pipeline/cqmatrel.h
+++ b/src/include/pipeline/cqmatrel.h
@@ -1,0 +1,19 @@
+/*-------------------------------------------------------------------------
+ *
+ * cqmatrel.h
+ *	  Interface for modifying continuous view materialization tables
+ *
+ * src/include/catalog/pipeline/cqmatrel.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef CQMATVIEW_H
+#define CQMATVIEW_H
+
+ResultRelInfo *CQMatViewOpen(Relation matrel);
+void CQMatViewClose(ResultRelInfo *rinfo);
+void ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot);
+void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot);
+void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot);
+
+#endif

--- a/src/test/regress/expected/cqcreate.out
+++ b/src/test/regress/expected/cqcreate.out
@@ -97,6 +97,8 @@ View definition:
  count  | bigint  |           | plain    |              | 
  sum    | numeric |           | main     |              | 
  _0     | bytea   |           | extended |              | 
+Indexes:
+    "cqcreate3_pdb_key_idx" UNIQUE, btree (key)
 
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM stream GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_queries WHERE name='cqcreate4';
@@ -124,6 +126,8 @@ View definition:
  sum    | numeric |           | main     |              | 
  _1     | bytea   |           | extended |              | 
  _0     | text(0) |           | extended |              | 
+Indexes:
+    "cqcreate4_pdb__0_idx" UNIQUE, btree (_0)
 
 -- Sliding window queries
 CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second);
@@ -204,6 +208,8 @@ View definition:
  _1           | bigint[]           |           | extended |              | 
  internal_avg | interval           |           | plain    |              | 
  _2           | interval[]         |           | extended |              | 
+Indexes:
+    "cvavg_pdb_key_idx" UNIQUE, btree (key)
 
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM stream;
 \d+ cvjson;
@@ -291,6 +297,8 @@ View definition:
  key        | text(0) |           | extended |              | 
  string_agg | text    |           | extended |              | 
  _0         | bytea   |           | extended |              | 
+Indexes:
+    "cvtext_pdb_key_idx" UNIQUE, btree (key)
 
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM stream;
@@ -330,6 +338,8 @@ View definition:
  _0     | double precision   |           | plain    |              | 
  _2     | double precision[] |           | extended |              | 
  _1     | integer            |           | plain    |              | 
+Indexes:
+    "cqaggexpr2_pdb_key_idx" UNIQUE, btree (key)
 
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key;
 \d+ cqaggexpr3;
@@ -372,4 +382,28 @@ View definition:
  key    | text(0)            |           | extended |              | 
  _0     | double precision   |           | plain    |              | 
  _1     | double precision[] |           | extended |              | 
+Indexes:
+    "cqaggexpr4_pdb_key_idx" UNIQUE, btree (key)
+
+CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM stream GROUP BY k0, k1;
+\d+ cqgroupby
+                View "public.cqgroupby"
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ k0     | text(0) |           | extended | 
+ k1     | integer |           | plain    | 
+ count  | bigint  |           | plain    | 
+View definition:
+ SELECT cqgroupby_pdb.k0,
+    cqgroupby_pdb.k1,
+    cqgroupby_pdb.count
+   FROM cqgroupby_pdb;
+
+\d+ cqgroupby_pdb;
+                     Table "public.cqgroupby_pdb"
+ Column |  Type   | Modifiers | Storage  | Stats target | Description 
+--------+---------+-----------+----------+--------------+-------------
+ k0     | text(0) |           | extended |              | 
+ k1     | integer |           | plain    |              | 
+ count  | bigint  |           | plain    |              | 
 

--- a/src/test/regress/sql/cqcreate.sql
+++ b/src/test/regress/sql/cqcreate.sql
@@ -74,3 +74,8 @@ CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM st
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM stream GROUP BY key;
 \d+ cqaggexpr4;
 \d+ cqaggexpr4_pdb;
+
+CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM stream GROUP BY k0, k1;
+\d+ cqgroupby
+\d+ cqgroupby_pdb;
+


### PR DESCRIPTION
This adds some basic performance improvements to the combine process. Some notes:
- The combiner now makes use of any indexes that exist on the materialization table that it's updating
- Whenever a CV with a single grouping column is created, an index is automatically created on that column
- Intelligently creating indexes on multiple columns is complicated, so for now indexes can just be created manually when necessary since the combiner will see them now
- I modified the way we create the `IN` clause for the retrieval query. Previously we'd create a nested OR statement of the form: `(pred OR (pred OR (pred OR ... )))`, which would cause stack depth issues for large combine inputs when using recursive walkers. Now, the disjunction is flattened: `pred OR pred OR pred ...`.
- After some very basic profiling, using an index on single-column groupings is about 70% faster, but more importantly performance doesn't degrade as much when the materialization table's cardinality grows. Here are a couple of runs with 10M rows sent through the following query with a batch size of 10,000, for input sets with `GROUP BY` cardinalities of 1024 and 2048:

```
CREATE CONTINUOUS VIEW idx_test AS SELECT key::integer, COUNT(*) FROM stream GROUP BY key;
ACTIVATE WITH (batchsize = 10000);
```

With no index:

```
time cat 1024-groups.sql | pipeline
real    1m17.630s
user    0m3.279s
sys 0m0.210s

time cat 2048-groups.sql | pipeline:
real    4m8.536s
user    0m3.124s
sys 0m0.229s 
```

With a btree index:

```
time cat 1024-groups.sql | pipeline
real    0m46.429s
user    0m3.510s
sys 0m0.193s

time cat 2048-groups.sql | pipeline
real    1m18.257s
user    0m3.339s
sys 0m0.228s
```
