### PR TITLE
Use ExclusiveLock to avoid deadlocks when bg procs try to rebuild catcac...

### DIFF
--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -416,7 +416,7 @@ ExecActivateContinuousViewStmt(ActivateContinuousViewStmt *stmt)
 	int success = 0;
 	int fail = 0;
 	CVMetadata *entry;
-	Relation pipeline_queries = heap_open(PipelineQueriesRelationId, AccessExclusiveLock);
+	Relation pipeline_queries = heap_open(PipelineQueriesRelationId, ExclusiveLock);
 	int i;
 
 	foreach(lc, stmt->views)
@@ -499,7 +499,7 @@ ExecDeactivateContinuousViewStmt(DeactivateContinuousViewStmt *stmt)
 {
 	int count = 0;
 	ListCell *lc;
-	Relation pipeline_queries = heap_open(PipelineQueriesRelationId, AccessExclusiveLock);
+	Relation pipeline_queries = heap_open(PipelineQueriesRelationId, ExclusiveLock);
 
 	foreach(lc, stmt->views)
 	{

--- a/src/backend/pipeline/stream.c
+++ b/src/backend/pipeline/stream.c
@@ -72,7 +72,7 @@ CreateStreamTargets(void)
 	oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 	targets = hash_create("StreamTargets", 32, &ctl, HASH_ELEM);
 
-	rel = heap_open(PipelineQueriesRelationId, AccessExclusiveLock);
+	rel = heap_open(PipelineQueriesRelationId, AccessShareLock);
 	scandesc = heap_beginscan_catalog(rel, 0, NULL);
 
 	while ((tup = heap_getnext(scandesc, ForwardScanDirection)) != NULL)


### PR DESCRIPTION
...he
