### PR TITLE
570 unit tests

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -68,6 +68,7 @@ check check-tests installcheck installcheck-parallel installcheck-tests:
 	$(MAKE) -C src/test/regress $@
 	$(MAKE) -C src/test/isolation $@
 	$(MAKE) -C src/test/py $@
+	$(MAKE) -C src/test/unit $@
 
 $(call recurse,check-world,src/test src/pl src/interfaces/ecpg contrib src/bin,check)
 

--- a/configure
+++ b/configure
@@ -16275,3 +16275,45 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
+# check
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lcheck" >&5
+$as_echo_n "checking for main in -lcheck... " >&6; }
+if ${ac_cv_lib_check_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lcheck  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_check_main=yes
+else
+  ac_cv_lib_check_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_check_main" >&5
+$as_echo "$ac_cv_lib_check_main" >&6; }
+if test "x$ac_cv_lib_check_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBCHECK 1
+_ACEOF
+
+  LIBS="-lcheck $LIBS"
+
+else
+  as_fn_error $? "check library not found (http://check.sourceforge.net/web/install.html)" "$LINENO" 5
+fi
+ac_cv_lib_check=ac_cv_lib_check_main

--- a/configure.in
+++ b/configure.in
@@ -2022,3 +2022,7 @@ AC_CONFIG_HEADERS([src/interfaces/ecpg/include/ecpg_config.h],
                   [echo >src/interfaces/ecpg/include/stamp-h])
 
 AC_OUTPUT
+
+# check
+AC_HAVE_LIBRARY(check, [],
+               [AC_MSG_ERROR([check library not found (http://check.sourceforge.net/web/install.html)])])

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,8 @@ SUBDIRS = \
 	bin \
 	pl \
 	makefiles \
-	test/regress
+	test/regress \
+	test/unit
 
 # There are too many interdependencies between the subdirectories, so
 # don't attempt parallel make here.

--- a/src/backend/main/main.c
+++ b/src/backend/main/main.c
@@ -46,7 +46,6 @@
 #include "utils/ps_status.h"
 
 
-const char *progname;
 
 
 static void startup_hacks(const char *progname);

--- a/src/backend/pipeline/Makefile
+++ b/src/backend/pipeline/Makefile
@@ -13,6 +13,6 @@ top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
 OBJS = combiner.o combinerReceiver.o cqanalyze.o cqplan.o cqproc.o cqwindow.o \
-			 stream.o streambuf.o worker.o cqmatrel.o cqvacuum.o
+			 stream.o streambuf.o worker.o cqmatrel.o cqvacuum.o hll.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -1,0 +1,72 @@
+/*-------------------------------------------------------------------------
+ *
+ * hll.c
+ *	  HyperLogLog implementation
+ *
+ *
+ * src/backend/pipeline/hll.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "pipeline/hll.h"
+#include "utils/palloc.h"
+
+
+/*
+ * MurmurHash - 64-bit version
+ */
+uint64
+MurmurHash64A(const void *key, Size keysize, uint32 seed)
+{
+  const uint64 m = 0xc6a4a7935bd1e995;
+  const int r = 47;
+  const uint64 *data = (const uint64 *) key;
+  const uint64 *end = data + (keysize / 8);
+  const uint8 *data2;
+  uint64 h = seed ^ keysize;
+
+  while(data != end)
+  {
+		uint64 k = *data++;
+
+		k *= m;
+		k ^= k >> r;
+		k *= m;
+
+		h ^= k;
+		h *= m;
+  }
+
+  data2 = (const uint8*) data;
+
+  switch(keysize & 7)
+  {
+		case 7: h ^= (uint64) data2[6] << 48;
+		case 6: h ^= (uint64) data2[5] << 40;
+		case 5: h ^= (uint64) data2[4] << 32;
+		case 4: h ^= (uint64) data2[3] << 24;
+		case 3: h ^= (uint64) data2[2] << 16;
+		case 2: h ^= (uint64) data2[1] << 8;
+		case 1: h ^= (uint64) data2[0];
+						h *= m;
+  };
+
+  h ^= h >> r;
+  h *= m;
+  h ^= h >> r;
+
+  return h;
+
+}
+
+/*
+ * HLLCreate
+ *
+ * Create an empty HyperLogLog structure with the given parameters
+ */
+HyperLogLog *
+HLLCreate(int p, int k)
+{
+
+	return NULL;
+}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -203,6 +203,8 @@ char	   *ListenAddresses;
  */
 int			ReservedBackends;
 
+const char *progname;
+
 /* The socket(s) we're listening to. */
 #define MAXLISTEN	64
 static pgsocket ListenSocket[MAXLISTEN];

--- a/src/include/pipeline/hll.h
+++ b/src/include/pipeline/hll.h
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------
+ *
+ * hll.h
+ *	  Interface for HyperLogLog support
+ *
+ *
+ * src/include/pipeline/hll.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PIPELINE_HLL_H
+#define PIPELINE_HLL_H
+
+#include "c.h"
+
+#define HLL_SPARSE = 's'
+#define HLL_DENSE = 'd'
+
+typedef struct HyperLogLog {
+	/* dense or sparse? */
+  char encoding;
+  /* cached cardinality */
+  uint8 card[8];
+  /* substream registers */
+  uint8_t registers[1];
+} HyperLogLog;
+
+uint64 MurmurHash64A(const void *key, Size keysize, uint32 seed);
+uint64 HLLSize(HyperLogLog *hll);
+bool HLLAdd(HyperLogLog *hll);
+HyperLogLog *HLLCreate(int p, int k);
+
+
+#endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -12,6 +12,6 @@ subdir = src/test
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 
-SUBDIRS = regress isolation py
+SUBDIRS = regress isolation py unit
 
 $(recurse)

--- a/src/test/unit/.gitignore
+++ b/src/test/unit/.gitignore
@@ -1,0 +1,1 @@
+/unit_tests

--- a/src/test/unit/Makefile
+++ b/src/test/unit/Makefile
@@ -1,0 +1,218 @@
+#-------------------------------------------------------------------------
+#
+# Makefile--
+#    Makefile for unit tests
+#
+# IDENTIFICATION
+#    src/test/unit/Makefile
+#
+#-------------------------------------------------------------------------
+
+backend = ../../backend
+subdir = src/test/unit
+top_builddir = ../../..
+include $(top_builddir)/src/Makefile.global
+
+SUBDIRS = $(backend)/access $(backend)/bootstrap \
+$(backend)/catalog $(backend)/parser $(backend)/commands \
+$(backend)/executor $(backend)/foreign $(backend)/lib \
+$(backend)/libpq $(backend)/nodes $(backend)/optimizer \
+$(backend)/pipeline $(backend)/port $(backend)/postmaster \
+$(backend)/regex $(backend)/replication $(backend)/rewrite \
+$(backend)/storage $(backend)/tcop $(backend)/tsearch $(backend)/utils \
+$(top_builddir)/src/timezone
+
+subsysfilename = objfiles.txt
+
+SUBDIROBJS = $(SUBDIRS:%=%/$(subsysfilename))
+
+# top-level backend directory obviously has its own "all" target
+#ifneq ($(subdir), src/backend)
+#all: $(subsysfilename)
+#endif
+
+SUBSYS.o: $(SUBDIROBJS) $(OBJS)
+	$(LD) $(LDREL) $(LDOUT) $@ $^
+
+objfiles.txt: Makefile $(SUBDIROBJS) $(OBJS)
+# Don't rebuild the list if only the OBJS have changed.
+	$(if $(filter-out $(OBJS),$?),( $(if $(SUBDIROBJS),cat $(SUBDIROBJS); )echo $(addprefix $(subdir)/,$(OBJS)) ) >$@,touch $@)
+
+# make function to expand objfiles.txt contents
+expand_subsys = $(foreach file,$(1),$(if $(filter %/objfiles.txt,$(file)),$(patsubst ../../src/backend/%,%,$(addprefix $(top_builddir)/,$(shell cat $(file)))),$(file)))
+
+# Parallel make trickery
+$(SUBDIROBJS): $(SUBDIRS:%=%-recursive) ;
+
+.PHONY: $(SUBDIRS:%=%-recursive)
+$(SUBDIRS:%=%-recursive):
+	$(MAKE) -C $(subst -recursive,,$@) all
+
+# As of 1/2010:
+# The probes.o file is necessary for dtrace support on Solaris, and on recent
+# versions of systemtap.  (Older systemtap releases just produce an empty
+# file, but that's okay.)  However, OS X's dtrace doesn't use it and doesn't
+# even recognize the -G option.  So, build probes.o except on Darwin.
+# This might need adjustment as other platforms add dtrace support.
+ifneq ($(PORTNAME), darwin)
+ifeq ($(enable_dtrace), yes)
+LOCALOBJS += utils/probes.o
+endif
+endif
+
+TEST_OBJS = test_hll.o runner.o
+
+OBJS = $(SUBDIROBJS) $(LOCALOBJS) $(top_builddir)/src/port/libpgport_srv.a \
+       $(top_builddir)/src/common/libpgcommon_srv.a \
+       $(TEST_OBJS)
+
+# We put libpgport and libpgcommon into OBJS, so remove it from LIBS; also add
+# libldap
+LIBS := $(filter-out -lpgport -lpgcommon, $(LIBS)) $(LDAP_LIBS_BE) -lcheck -lpthread
+
+# The backend doesn't need everything that's in LIBS, however
+LIBS := $(filter-out -lz -lreadline -ledit -ltermcap -lncurses -lcurses, $(LIBS))
+
+##########################################################################
+
+all: submake-libpgport submake-schemapg unit_tests $(POSTGRES_IMP)
+
+ifneq ($(PORTNAME), cygwin)
+ifneq ($(PORTNAME), win32)
+ifneq ($(PORTNAME), aix)
+
+unit_tests: $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) $(call expand_subsys,$^) $(LIBS) -o $@
+
+endif
+endif
+endif
+
+ifeq ($(PORTNAME), cygwin)
+
+unit_tests: $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(export_dynamic) -Wl,--stack,$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$^) $(LIBS) -o $@
+
+# There is no correct way to write a rule that generates two files.
+# Rules with two targets don't have that meaning, they are merely
+# shorthand for two otherwise separate rules.  To be safe for parallel
+# make, we must chain the dependencies like this.  The semicolon is
+# important, otherwise make will choose some built-in rule.
+
+libpostgres.a: postgres ;
+
+endif # cygwin
+
+ifeq ($(PORTNAME), win32)
+LIBS += -lsecur32
+
+unit_tests: $(OBJS) $(WIN32RES)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) -Wl,--stack=$(WIN32_STACK_RLIMIT) -Wl,--export-all-symbols -Wl,--out-implib=libpostgres.a $(call expand_subsys,$(OBJS)) $(WIN32RES) $(LIBS) -o $@$(X)
+
+libpostgres.a: postgres ;
+
+endif # win32
+
+ifeq ($(PORTNAME), aix)
+
+unit_tests: $(POSTGRES_IMP)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(LDFLAGS_EX) $(call expand_subsys,$(OBJS)) -Wl,-bE:$(top_builddir)/src/backend/$(POSTGRES_IMP) $(LIBS) -o $@
+
+$(POSTGRES_IMP): $(OBJS)
+	$(LD) $(LDREL) $(LDOUT) SUBSYS.o $(call expand_subsys,$^)
+ifeq ($(host_os), aix3.2.5)
+	$(MKLDEXPORT) SUBSYS.o $(bindir)/postgres > $@
+else
+ifneq (,$(findstring aix4.1, $(host_os)))
+	$(MKLDEXPORT) SUBSYS.o $(bindir)/postgres > $@
+else
+	$(MKLDEXPORT) SUBSYS.o . > $@
+endif
+endif
+	@rm -f SUBSYS.o
+
+endif # aix
+
+# Update the commonly used headers before building the subdirectories
+$(SUBDIRS:%=%-recursive): $(top_builddir)/src/include/parser/gram.h $(top_builddir)/src/include/catalog/schemapg.h $(top_builddir)/src/include/utils/fmgroids.h $(top_builddir)/src/include/utils/errcodes.h $(top_builddir)/src/include/utils/probes.h
+
+# run this unconditionally to avoid needing to know its dependencies here:
+submake-schemapg:
+	$(MAKE) -C $(backend)/catalog schemapg.h
+
+# src/port needs a convenient way to force errcodes.h to get built
+submake-errcodes: $(top_builddir)/src/include/utils/errcodes.h
+
+.PHONY: submake-schemapg submake-errcodes
+
+catalog/schemapg.h: | submake-schemapg
+
+$(top_builddir)/src/port/libpgport_srv.a: | submake-libpgport
+
+
+# The postgres.o target is needed by the rule in Makefile.global that
+# creates the exports file when MAKE_EXPORTS = true.
+postgres.o: $(OBJS)
+	$(CC) $(LDREL) $(LDFLAGS) $(LDFLAGS_EX) $(call expand_subsys,$^) $(LIBS) -o $@
+
+
+# The following targets are specified in make commands that appear in
+# the make files in our subdirectories. Note that it's important we
+# match the dependencies shown in the subdirectory makefiles!
+
+$(backend)/parser/gram.h: parser/gram.y
+	$(MAKE) -C $(backend)/parser gram.h
+
+$(backend)/utils/fmgroids.h: $(backend)/utils/Gen_fmgrtab.pl $(backend)/catalog/Catalog.pm $(top_srcdir)/src/include/catalog/pg_proc.h
+	$(MAKE) -C $(backend)/utils fmgroids.h
+
+$(backend)/utils/errcodes.h: $(backend)/utils/generate-errcodes.pl $(backend)/utils/errcodes.txt
+	$(MAKE) -C $(backend)/utils errcodes.h
+
+$(backend)/utils/probes.h: $(backend)/utils/probes.d
+	$(MAKE) -C $(backend)/utils probes.h
+
+# Make symlinks for these headers in the include directory. That way
+# we can cut down on the -I options. Also, a symlink is automatically
+# up to date when we update the base file.
+#
+# The point of the prereqdir incantation in some of the rules below is to
+# force the symlink to use an absolute path rather than a relative path.
+# For headers which are generated by make distprep, the actual header within
+# src/backend will be in the source tree, while the symlink in src/include
+# will be in the build tree, so a simple ../.. reference won't work.
+# For headers generated during regular builds, we prefer a relative symlink.
+
+$(top_builddir)/src/include/parser/gram.h: $(backend)/parser/gram.h
+	prereqdir=`cd '$(dir $<)' >/dev/null && pwd` && \
+	  cd '$(dir $@)' && rm -f $(notdir $@) && \
+	  $(LN_S) "$$prereqdir/$(notdir $<)" .
+
+$(top_builddir)/src/include/catalog/schemapg.h: $(backend)/catalog/schemapg.h
+	prereqdir=`cd '$(dir $<)' >/dev/null && pwd` && \
+	  cd '$(dir $@)' && rm -f $(notdir $@) && \
+	  $(LN_S) "$$prereqdir/$(notdir $<)" .
+
+$(top_builddir)/src/include/utils/errcodes.h: $(backend)/utils/errcodes.h
+	prereqdir=`cd '$(dir $<)' >/dev/null && pwd` && \
+	  cd '$(dir $@)' && rm -f $(notdir $@) && \
+	  $(LN_S) "$$prereqdir/$(notdir $<)" .
+
+$(top_builddir)/src/include/utils/fmgroids.h: $(backend)/utils/fmgroids.h
+	prereqdir=`cd '$(dir $<)' >/dev/null && pwd` && \
+	  cd '$(dir $@)' && rm -f $(notdir $@) && \
+	  $(LN_S) "$$prereqdir/$(notdir $<)" .
+	  
+$(top_builddir)/src/include/utils/probes.h: $(backend)/utils/probes.h
+	cd '$(dir $@)' && rm -f $(notdir $@) && \
+	    $(LN_S) "$(backend)/utils/probes.h" .
+	  
+utils/probes.o: utils/probes.d $(SUBDIROBJS)
+	$(DTRACE) $(DTRACEFLAGS) -C -G -s $(call expand_subsys,$^) -o $@
+
+check: all
+	$(top_builddir)/$(subdir)/unit_tests
+
+clean:
+	rm -f $(TEST_OBJS) unit_tests
+

--- a/src/test/unit/runner.c
+++ b/src/test/unit/runner.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <check.h>
+
+#include "c.h"
+#include "utils/palloc.h"
+#include "utils/memutils.h"
+
+#include "suites.h"
+
+int main(void)
+{
+	MemoryContext context = AllocSetContextCreate(NULL,
+			"UnitTestContext",
+			ALLOCSET_DEFAULT_MINSIZE,
+			ALLOCSET_DEFAULT_INITSIZE,
+			ALLOCSET_DEFAULT_MAXSIZE);
+
+	int number_failed;
+	SRunner *sr;
+
+	MemoryContextSwitchTo(context);
+
+	sr = srunner_create(suite_create ("main"));
+
+	srunner_add_suite(sr, test_hll_suite());
+
+	srunner_run_all(sr, CK_VERBOSE);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/test/unit/suites.h
+++ b/src/test/unit/suites.h
@@ -1,0 +1,3 @@
+#include <check.h>
+
+Suite *test_hll_suite(void);

--- a/src/test/unit/test_hll.c
+++ b/src/test/unit/test_hll.c
@@ -1,0 +1,81 @@
+#include <check.h>
+
+#include "suites.h"
+#include "pipeline/hll.h"
+
+START_TEST(test_murmurhash64a)
+{
+	char *k = "some_key";
+	uint32 ik;
+	uint64 lk;
+	float8 fk8;
+	uint64 h = MurmurHash64A(k, strlen(k) + 1, 0);
+
+	ck_assert_uint_eq(h, 14613800511125978524U);
+
+	k = "another key";
+	h = MurmurHash64A(k, strlen(k) + 1, 0);
+	ck_assert_uint_eq(h, 14572063269992335582U);
+
+	fk8 = 42.42;
+	h = MurmurHash64A(&fk8, 8, 0);
+	ck_assert_uint_eq(h, 749110323020550257U);
+
+	ik = 42;
+	h = MurmurHash64A(&ik, 4, 0);
+	ck_assert_uint_eq(h, 1957777661270593380U);
+
+	ik = 0;
+	h = MurmurHash64A(&ik, 4, 0);
+	ck_assert_uint_eq(h, 2224014147481998463U);
+
+	ik = 1 << 31;
+	h = MurmurHash64A(&ik, 4, 0);
+	ck_assert_uint_eq(h, 488473488423332433U);
+
+	lk = 1UL << 63;
+	h = MurmurHash64A(&lk, 8, 0);
+	ck_assert_uint_eq(h, 4903226226401862699U);
+}
+END_TEST
+
+START_TEST(test_sparse)
+{
+	ck_assert_int_eq(1, 1);
+}
+END_TEST
+
+START_TEST(test_dense)
+{
+	ck_assert_int_eq(1, 1);
+}
+END_TEST
+
+START_TEST(test_low_cardinality)
+{
+	ck_assert_int_eq(1, 1);
+}
+END_TEST
+
+START_TEST(test_union)
+{
+	ck_assert_int_eq(1, 1);
+}
+END_TEST
+
+Suite *test_hll_suite(void)
+{
+	Suite *s;
+	TCase *tc;
+
+	s = suite_create("test_hll");
+	tc = tcase_create("test_hll");
+	tcase_add_test(tc, test_murmurhash64a);
+	tcase_add_test(tc, test_sparse);
+	tcase_add_test(tc, test_dense);
+	tcase_add_test(tc, test_low_cardinality);
+	tcase_add_test(tc, test_union);
+	suite_add_tcase(s, tc);
+
+	return s;
+}


### PR DESCRIPTION
This adds unit testing infrastructure. I was going to just include it in the HLL PR, but I wanted to get it merged sooner so that you can make use of it for testing T-Digest if you want to. It adds a dependency (libcheck) which you can install with 'sudo apt-get install check'. `./configure` also checks for this dependency now, and should automatically run the next time you build anyways.

This thing works by creating a binary called `unit_tests` that includes all of the same object files as the `postgres` binary, **except** for `main.o` which has Postgres' `main` function. In place of `main.o`,  it links against `src/test/unit/runner.o`, which has a `main` function that runs our unit tests. This gives unit tests access to all of the same functionality that the `postgres` binary uses.

Additionally, it's pretty useful to run the unit tests from CDT and step through them. To do this, create a debug configuration (Run->Debug Configurations) under C/C++ Application. Set the application to `src/test/unit/unit_tests`. Then go to the Environment tab, and set CK_FORK to no. This ensures that the `check` library doesn't fork, which makes it really easy to attach the debugger.
