### PR TITLE
588 hypothetical set aggs

### DIFF
--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -297,7 +297,7 @@ ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *queryst
 
 	/*
 	 * Create a VIEW over the CQ materialization relation which exposes
-	 * only the columns that users expect. This is needed primarily for two
+	 * only the columns that users expect. This is needed primarily for three
 	 * reasons:
 	 *
 	 * 1. Sliding window queries. For such queries, this VIEW filters events out
@@ -312,8 +312,8 @@ ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *queryst
 	view_stmt = makeNode(ViewStmt);
 	view_stmt->view = view;
 	view_stmt->query = (Node *) viewselect;
-	DefineView(view_stmt, querystring);
 
+	DefineView(view_stmt, querystring);
 	allowSystemTableMods = saveAllowSystemTableMods;
 
 	/*

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -576,16 +576,16 @@ ExecProcNode(PlanState *node)
 			break;
 	}
 
-	if (node->state->es_exec_node_cxt)
-		MemoryContextSwitchTo(oldcontext);
-
 	if (node->instrument)
 		InstrStopNode(node->instrument, TupIsNull(result) ? 0.0 : 1.0);
 
 	if (!TupIsNull(result))
 		node->cq_batch_progress++;
 	else if (IsContinuous(node))
-		return ExecEndBatch(node);
+		result = ExecEndBatch(node);
+
+	if (node->state->es_exec_node_cxt)
+		MemoryContextSwitchTo(oldcontext);
 
 	return result;
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2290,6 +2290,7 @@ ExecEndAggBatch(AggState *node)
 	clear_hash_table(node);
 	node->table_filled = false;
 	node->agg_done = false;
+	ExecClearTuple(node->ss.ss_ScanTupleSlot);
 }
 
 void

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -490,7 +490,13 @@ count_agg_clauses_walker(Node *node, count_agg_clauses_context *context)
 
 		/* count it; note ordered-set aggs always have nonempty aggorder */
 		costs->numAggs++;
-		if (aggref->aggorder != NIL || aggref->aggdistinct != NIL)
+
+		/*
+		 * Continuous queries don't actually do any sorting for ordered-set
+		 * aggs, so only count it if it's not a CQ.
+		 */
+		if (context->root->parse->is_continuous == false &&
+				(aggref->aggorder != NIL || aggref->aggdistinct != NIL))
 			costs->numOrderedAggs++;
 
 		/* add component function execution costs to appropriate totals */

--- a/src/backend/pipeline/cqplan.c
+++ b/src/backend/pipeline/cqplan.c
@@ -186,6 +186,9 @@ SetCQPlanRefs(PlannedStmt *pstmt, char* matrelname)
 			}
 
 			aggref->aggtype = transtype;
+
+			/* CQs have their own way have handling DISTINCT */
+			aggref->aggdistinct = NIL;
 		}
 		else
 		{
@@ -243,7 +246,7 @@ SetCQPlanRefs(PlannedStmt *pstmt, char* matrelname)
 	 * able to work with any ordering of attributes as long as they're all present. Then,
 	 * when combining with on-disk tuples, we could reorder attributes as necessary if
 	 * we detect different orderings. Another option is to have strong guarantees about
-	 * attribute ordering when creating materializtion tables which we can rely on here.
+	 * attribute ordering when creating materialization tables which we can rely on here.
 	 *
 	 * For now, let's just explode if there is an
 	 * inconsistency detected here. This would be a shitty error for a user to get though,

--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -912,6 +912,31 @@ HLLCreate(void)
 }
 
 /*
+ * HLLCreateFromRaw
+ *
+ * Creates a HyperLogLog with the given raw data
+ */
+HyperLogLog *
+HLLCreateFromRaw(uint8 *M, int mlen, uint8 p, char encoding)
+{
+	Size size;
+	HyperLogLog *hll;
+
+	size = sizeof(HyperLogLog) + mlen;
+
+	hll = palloc0(size);
+	hll->p = p;
+	hll->encoding = encoding;
+	hll->mlen = mlen;
+
+	memcpy(hll->M, M, mlen);
+
+	hll->encoding = HLL_IS_SPARSE(hll) ? HLL_SPARSE_DIRTY : HLL_DENSE_DIRTY;
+
+	return hll;
+}
+
+/*
  * HLLAdd
  *
  * Adds an element to the given HLL
@@ -1017,7 +1042,9 @@ HLLSize(HyperLogLog *hll)
    * 1/30 of 2^64 is not needed since it would require a huge set
    * to approach such a value.
    */
-  return (uint64) E;
+  hll->card = (uint64) E;
+
+  return hll->card;
 }
 
 /*

--- a/src/backend/utils/adt/int8.c
+++ b/src/backend/utils/adt/int8.c
@@ -19,6 +19,8 @@
 
 #include "funcapi.h"
 #include "libpq/pqformat.h"
+#include "pipeline/hll.h"
+#include "utils/datum.h"
 #include "utils/int8.h"
 #include "utils/builtins.h"
 
@@ -1536,4 +1538,134 @@ generate_series_step_int8(PG_FUNCTION_ARGS)
 	else
 		/* do when there is no more left */
 		SRF_RETURN_DONE(funcctx);
+}
+
+static HyperLogLog *
+hll_count_distinct_startup(PG_FUNCTION_ARGS)
+{
+	if (fcinfo->flinfo->fn_extra == NULL)
+	{
+		MemoryContext old = MemoryContextSwitchTo(fcinfo->flinfo->fn_mcxt);
+		Aggref *aggref = AggGetAggref(fcinfo);
+		TupleDesc desc = ExecTypeFromTL(aggref->args, false);
+
+		/* count distinct can only have one column in the target list */
+		if (desc->natts != 1)
+			elog(ERROR, "COUNT DISTINCT cannot be used on multiple columns");
+
+		fcinfo->flinfo->fn_extra = (void *) desc->attrs[0];
+
+		MemoryContextSwitchTo(old);
+	}
+
+	return HLLCreate();
+}
+
+/*
+ * COUNT DISTINCT support functions for streaming inputs,
+ * using HyperLogLog to determine input uniqueness
+ */
+Datum
+hll_count_distinct_transition(PG_FUNCTION_ARGS)
+{
+	MemoryContext old;
+	MemoryContext context;
+	HyperLogLog *hll;
+	Datum incoming;
+	StringInfo buf = makeStringInfo();
+	Form_pg_attribute attr;
+	Size size;
+	int result;
+
+	if (!AggCheckCallContext(fcinfo, &context))
+			elog(ERROR, "aggregate function called in non-aggregate context");
+
+	old = MemoryContextSwitchTo(context);
+
+	if (PG_ARGISNULL(0))
+		hll = hll_count_distinct_startup(fcinfo);
+	else
+		hll = (HyperLogLog *) PG_GETARG_POINTER(0);
+
+	attr = (Form_pg_attribute) fcinfo->flinfo->fn_extra;
+
+	incoming = PG_GETARG_DATUM(1);
+	size = datumGetSize(incoming, attr->attbyval, attr->attlen);
+
+	if (attr->attbyval)
+		appendBinaryStringInfo(buf, (char *) &incoming, size);
+	else
+		appendBinaryStringInfo(buf, DatumGetPointer(incoming), size);
+
+	hll = HLLAdd(hll, buf->data, size, &result);
+
+	MemoryContextSwitchTo(old);
+
+	PG_RETURN_POINTER(hll);
+}
+
+/*
+ * Take the union of two HLL transition states
+ */
+Datum
+hll_count_distinct_combine(PG_FUNCTION_ARGS)
+{
+	HyperLogLog *state;
+	HyperLogLog *incoming = (HyperLogLog *) PG_GETARG_POINTER(1);
+
+	if (!AggCheckCallContext(fcinfo, NULL))
+			elog(ERROR, "aggregate function called in non-aggregate context");
+
+	if (PG_ARGISNULL(0))
+	{
+		state = HLLCreateFromRaw(incoming->M, incoming->mlen, incoming->p, incoming->encoding);
+		PG_RETURN_POINTER(state);
+	}
+
+	state = (HyperLogLog *) PG_GETARG_POINTER(0);
+	state = HLLUnion(state, incoming);
+
+	PG_RETURN_POINTER(state);
+}
+
+/*
+ * recv a serialized HyperLogLog and send it to the
+ * combine function
+ */
+Datum
+hll_count_distinct_pcombine(PG_FUNCTION_ARGS)
+{
+	Datum arg0;
+	Datum result;
+
+	if (!AggCheckCallContext(fcinfo, NULL))
+			elog(ERROR, "aggregate function called in non-aggregate context");
+
+	arg0 = PG_ARGISNULL(0) ? (Datum) NULL : (Datum) PG_GETARG_POINTER(0);
+
+	fcinfo->arg[0] = (Datum) PG_GETARG_POINTER(1);
+	fcinfo->nargs = 1;
+	fcinfo->arg[1] = hllrecv(fcinfo);
+	fcinfo->arg[0] = arg0;
+	fcinfo->nargs = 2;
+
+	result = hll_count_distinct_combine(fcinfo);
+
+	PG_RETURN_POINTER(result);
+}
+
+/*
+ * Returns the cardinality of the final HyperLogLog
+ */
+Datum
+hll_count_distinct_final(PG_FUNCTION_ARGS)
+{
+	HyperLogLog *hll;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_INT64(0);
+
+	hll = (HyperLogLog *) PG_GETARG_POINTER(0);
+
+	PG_RETURN_INT64(HLLSize(hll));
 }

--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -3832,8 +3832,6 @@ stringaggstatesend(PG_FUNCTION_ARGS)
 	bytea *result;
 	int nbytes;
 
-	AggCheckCallContext(fcinfo, NULL);
-
 	initStringInfo(&buf);
 
 	pq_sendint(&buf, state->dlen, sizeof(int));
@@ -3843,7 +3841,6 @@ stringaggstatesend(PG_FUNCTION_ARGS)
 	result = (bytea *) palloc(nbytes + VARHDRSZ);
 	SET_VARSIZE(result, nbytes + VARHDRSZ);
 
-	// it's not copying the null byte
 	pq_copymsgbytes(&buf, VARDATA(result), nbytes);
 
 	PG_RETURN_BYTEA_P(result);
@@ -3860,8 +3857,6 @@ stringaggstaterecv(PG_FUNCTION_ARGS)
 	StringAggState *result;
 	StringInfoData buf;
 	int nbytes = VARSIZE(bytesin) - VARHDRSZ;
-
-	AggCheckCallContext(fcinfo, NULL);
 
 	result = (StringAggState *) palloc0(sizeof(StringAggState));
 

--- a/src/include/catalog/pg_aggregate.h
+++ b/src/include/catalog/pg_aggregate.h
@@ -363,6 +363,22 @@ DATA(insert ( 4356	n 0 float8_combine float8_stddev_samp 	-				-				-				f f 0	1
 DATA(insert ( 4357	n 0 numeric_pcombine numeric_stddev_samp 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
 DATA(insert ( 4358	n 0 float8_combine float8_stddev_samp 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
 
+/* PipelineDB streaming hypothetical-set aggregates */
+DATA(insert ( 3999	h 1 cq_hypothetical_set_transition_multi	cq_rank_final	-	-	-	t f 0	1016	0	0	0	_null_ _null_ ));
+DATA(insert ( 5000	n 0 cq_hypothetical_set_pcombine	cq_rank_final	-	-	-	f f 0	1016	0	0	0	_null_ _null_ ));
+
+DATA(insert ( 5002	h 1 cq_hypothetical_set_transition_multi	cq_percent_rank_final	-	-	-	t f 0	1016	0	0	0	_null_ _null_ ));
+DATA(insert ( 5003	n 0 cq_hypothetical_set_pcombine	cq_percent_rank_final	-	-	-	f f 0	1016	0	0	0	_null_ _null_ ));
+
+DATA(insert ( 5005	h 1 cq_hypothetical_set_transition_multi	cq_cume_dist_final	-	-	-	t f 0	1016	0	0	0	_null_ _null_ ));
+DATA(insert ( 5006	n 0 cq_hypothetical_set_pcombine	cq_cume_dist_final	-	-	-	f f 0	1016	0	0	0	_null_ _null_ ));
+
+DATA(insert ( 5011	h 1 hll_hypothetical_set_transition_multi	hll_dense_rank_final	-	-	-	t f 0	2281	0	0	0	_null_ _null_ ));
+DATA(insert ( 5012	n 0 hll_hypothetical_set_pcombine	hll_dense_rank_final	-	-	-	f f 0	2281	0	0	0	_null_ _null_ ));
+
+DATA(insert ( 5014	n 0 hll_count_distinct_transition	hll_count_distinct_final	-	-	-	t f 0	2281	0	0	0	_null_ _null_ ));
+DATA(insert ( 5015	n 0 hll_count_distinct_pcombine	hll_count_distinct_final	-	-	-	f f 0	2281	0	0	0	_null_ _null_ ));
+
 /*
  * prototypes for functions in pg_aggregate.c
  */

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5031,8 +5031,67 @@ DESCR("rank of hypothetical row without gaps");
 DATA(insert OID = 3993 ( dense_rank_final	PGNSP PGUID 12 1 0 2276 0 f f f f f f i 2 0 20 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	hypothetical_dense_rank_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
 
-DATA(insert OID = 4300 (  decode_delimited   PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 1009 "17 25" _null_ _null_ "{$,delimiter}" _null_ text_to_array _null_ _null_ _null_ ));
-DESCR("split a string with a delimiter");
+/* PipelineDB streaming hypothetical-set aggregates */
+DATA(insert OID = 3994 (hllsend PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 17 "2281" _null_ _null_ _null_ _null_ hllsend _null_ _null_ _null_ ));
+DESCR("serializer for HyperLogLog aggregation transition states");
+DATA(insert OID = 3995 (hllrecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2281" _null_ _null_ _null_ _null_ hllrecv _null_ _null_ _null_ ));
+DESCR("deserializer for HyperLogLog aggregation transition states");
+
+DATA(insert OID = 3996 ( cq_hypothetical_set_transition_multi	PGNSP PGUID 12 1 0 2276 0 f f f f f f i 2 0 1016 "1016 2276" "{1016,2276}" "{i,v}" _null_ _null_ cq_hypothetical_set_transition_multi _null_ _null_ _null_ ));
+DESCR("aggregate transition function");
+DATA(insert OID = 3997 ( cq_hypothetical_set_combine_multi	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 1016 "1016 1016" _null_ _null_ _null_ _null_ cq_hypothetical_set_combine_multi _null_ _null_ _null_ ));
+DESCR("aggregate combination function");
+DATA(insert OID = 3998 ( cq_hypothetical_set_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 1016 "1016 1016" _null_ _null_ _null_ _null_ cq_hypothetical_set_pcombine _null_ _null_ _null_ ));
+DESCR("aggregate parse and combine function");
+
+DATA(insert OID = 3999 ( cq_rank				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 20 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5000 ( cq_rank				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 20 "1016 20" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5001 ( cq_rank_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 20 "1016 2276" _null_ _null_ _null_ _null_	cq_hypothetical_rank_final _null_ _null_ _null_ ));
+DESCR("aggregate final function");
+
+DATA(insert OID = 5002 ( cq_percent_rank				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 701 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5003 ( cq_percent_rank				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1016 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5004 ( cq_percent_rank_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 701 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	cq_hypothetical_percent_rank_final _null_ _null_ _null_ ));
+DESCR("aggregate final function");
+
+DATA(insert OID = 5005 ( cq_cume_dist				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 701 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5006 ( cq_cume_dist				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1016 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5007 ( cq_cume_dist_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 701 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	cq_hypothetical_cume_dist_final _null_ _null_ _null_ ));
+DESCR("aggregate final function");
+
+DATA(insert OID = 5008 ( hll_hypothetical_set_transition_multi	PGNSP PGUID 12 1 0 2276 0 f f f f f f i 2 0 2281 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_ hll_hypothetical_set_transition_multi _null_ _null_ _null_ ));
+DESCR("aggregate transition function");
+DATA(insert OID = 5009 ( hll_hypothetical_set_combine_multi	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2281" _null_ _null_ _null_ _null_ hll_hypothetical_set_combine_multi _null_ _null_ _null_ ));
+DESCR("aggregate combination function");
+DATA(insert OID = 5010 ( hll_hypothetical_set_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_ hll_hypothetical_set_pcombine _null_ _null_ _null_ ));
+DESCR("aggregate parse and combine function");
+
+DATA(insert OID = 5011 ( hll_dense_rank				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 20 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5012 ( hll_dense_rank				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 20 "17 20" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("rank of hypothetical row, using hyperloglog");
+DATA(insert OID = 5013 ( hll_dense_rank_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 20 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	hll_hypothetical_dense_rank_final _null_ _null_ _null_ ));
+DESCR("aggregate final function");
+
+/* streaming count distinct using HyperLogLog */
+DATA(insert OID = 5014 ( hll_count_distinct				PGNSP PGUID 12 1 0 0 0 t f f f f f i 1 0 20 "2276" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("distinct count, using hyperloglog");
+DATA(insert OID = 5015 ( hll_count_distinct				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 20 "17 20" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
+DESCR("distinct count, using hyperloglog");
+DATA(insert OID = 5016 ( hll_count_distinct_transition	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_ hll_count_distinct_transition _null_ _null_ _null_ ));
+DESCR("aggregate transition function");
+DATA(insert OID = 5017 ( hll_count_distinct_combine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2281" _null_ _null_ _null_ _null_ hll_count_distinct_combine _null_ _null_ _null_ ));
+DESCR("aggregate combination function");
+DATA(insert OID = 5018 ( hll_count_distinct_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_ hll_count_distinct_pcombine _null_ _null_ _null_ ));
+DESCR("aggregate parse and combine function");
+DATA(insert OID = 5019 ( hll_count_distinct_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 20 "2281" _null_ _null_ _null_ _null_	hll_count_distinct_final _null_ _null_ _null_ ));
+DESCR("aggregate final function");
 
 /* PipelineDB combiner stuff, heavily inspired by Postgres-XC coordinator aggregation */
 DATA(insert OID = 4301 ( float8_combine	PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 1022 "1022 1022" _null_ _null_ _null_ _null_ float8_combine _null_ _null_ _null_ ));

--- a/src/include/catalog/pipeline_combine.h
+++ b/src/include/catalog/pipeline_combine.h
@@ -158,4 +158,13 @@ DATA(insert (numeric_stddev_samp numeric_accum naggstatesend naggstaterecv numer
 DATA(insert (float8_stddev_samp float8_accum 0 0 float8_combine t 1022));
 DATA(insert (float8_stddev_samp float4_accum 0 0 float8_combine t 1022));
 
+/* hypothetical-set rank */
+DATA(insert (cq_rank_final cq_hypothetical_set_transition_multi 0 0 cq_hypothetical_set_combine_multi t 1016));
+DATA(insert (cq_percent_rank_final cq_hypothetical_set_transition_multi 0 0 cq_hypothetical_set_combine_multi t 1016));
+DATA(insert (cq_cume_dist_final cq_hypothetical_set_transition_multi 0 0 cq_hypothetical_set_combine_multi t 1016));
+DATA(insert (hll_dense_rank_final hll_hypothetical_set_transition_multi hllsend hllrecv hll_hypothetical_set_combine_multi t 17));
+
+/* HyperLogLog count distinct */
+DATA(insert (hll_count_distinct_final hll_count_distinct_transition hllsend hllrecv hll_count_distinct_combine t 17));
+
 #endif

--- a/src/include/pipeline/hll.h
+++ b/src/include/pipeline/hll.h
@@ -39,6 +39,7 @@ typedef struct HyperLogLog {
 uint64 MurmurHash64A(const void *key, Size keysize);
 HyperLogLog *HLLCreateWithP(int p);
 HyperLogLog *HLLCreate(void);
+HyperLogLog *HLLCreateFromRaw(uint8 *M, int mlen, uint8 p, char encoding);
 HyperLogLog *HLLAdd(HyperLogLog *hll, void *elem, Size len, int *result);
 uint64 HLLSize(HyperLogLog *hll);
 HyperLogLog *HLLUnion(HyperLogLog *result, HyperLogLog *incoming);

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -534,6 +534,19 @@ extern Datum hypothetical_percent_rank_final(PG_FUNCTION_ARGS);
 extern Datum hypothetical_cume_dist_final(PG_FUNCTION_ARGS);
 extern Datum hypothetical_dense_rank_final(PG_FUNCTION_ARGS);
 
+extern Datum hllsend(PG_FUNCTION_ARGS);
+extern Datum hllrecv(PG_FUNCTION_ARGS);
+extern Datum hll_hypothetical_set_transition_multi(PG_FUNCTION_ARGS);
+extern Datum hll_hypothetical_set_combine_multi(PG_FUNCTION_ARGS);
+extern Datum hll_hypothetical_set_pcombine(PG_FUNCTION_ARGS);
+extern Datum hll_hypothetical_dense_rank_final(PG_FUNCTION_ARGS);
+extern Datum cq_hypothetical_set_transition_multi(PG_FUNCTION_ARGS);
+extern Datum cq_hypothetical_set_combine_multi(PG_FUNCTION_ARGS);
+extern Datum cq_hypothetical_set_pcombine(PG_FUNCTION_ARGS);
+extern Datum cq_hypothetical_rank_final(PG_FUNCTION_ARGS);
+extern Datum cq_hypothetical_percent_rank_final(PG_FUNCTION_ARGS);
+extern Datum cq_hypothetical_cume_dist_final(PG_FUNCTION_ARGS);
+
 /* pseudotypes.c */
 extern Datum cstring_in(PG_FUNCTION_ARGS);
 extern Datum cstring_out(PG_FUNCTION_ARGS);

--- a/src/include/utils/int8.h
+++ b/src/include/utils/int8.h
@@ -126,4 +126,9 @@ extern Datum oidtoi8(PG_FUNCTION_ARGS);
 extern Datum generate_series_int8(PG_FUNCTION_ARGS);
 extern Datum generate_series_step_int8(PG_FUNCTION_ARGS);
 
+extern Datum hll_count_distinct_transition(PG_FUNCTION_ARGS);
+extern Datum hll_count_distinct_combine(PG_FUNCTION_ARGS);
+extern Datum hll_count_distinct_pcombine(PG_FUNCTION_ARGS);
+extern Datum hll_count_distinct_final(PG_FUNCTION_ARGS);
+
 #endif   /* INT8_H */

--- a/src/test/py/test_count_distinct.py
+++ b/src/test/py/test_count_distinct.py
@@ -1,0 +1,26 @@
+from base import pipeline, clean_db
+import random
+
+
+def test_hll_count_distinct(pipeline, clean_db):
+    """
+    Verify that streaming COUNT(DISTINCT) works
+    """
+    q = 'SELECT COUNT(DISTINCT x::integer) FROM stream'
+    pipeline.create_cv('test_count_distinct', q)
+    pipeline.activate()
+    
+    values = [random.randint(1, 1024) for n in range(1000)]
+    for v in values:
+        pipeline.execute('INSERT INTO stream (x) VALUES (%d)' % v)
+        
+    pipeline.deactivate()
+    
+    expected = len(set(values))
+    result = pipeline.execute('SELECT count FROM test_count_distinct').first()
+    
+    # Error rate should be well below %2
+    delta = abs(expected - result['count'])
+    
+    assert delta / float(expected) <= 0.02
+    

--- a/src/test/py/test_hs_aggs.py
+++ b/src/test/py/test_hs_aggs.py
@@ -1,0 +1,77 @@
+from base import pipeline, clean_db
+import random
+
+
+def _rank(n, values):
+    rank = 1
+    peers = 0
+    for v in sorted(values):
+        if v < n:
+            rank += 1
+        if v == n:
+            peers += 1
+            
+    return rank, peers
+
+def _dense_rank(n, values):
+    return _rank(n, set(values))
+
+def _test_hs_agg(pipeline, agg):
+    values = [random.randint(-100, 100) for n in range(1000)] 
+    h = random.choice(values) + random.randint(-10, 10)
+    
+    cq = 'SELECT %s(%d) WITHIN GROUP (ORDER BY x::integer) FROM stream' % (agg, h)
+    pipeline.create_cv('test_%s' % agg, cq)
+    pipeline.activate()
+    
+    for v in values:
+        pipeline.execute('INSERT INTO stream (x) VALUES (%d)' % v)
+
+    pipeline.deactivate()
+    result = pipeline.execute('SELECT %s FROM test_%s' % (agg, agg)).first()
+    
+    rank, peers = _rank(h, values)
+    dense_rank, _ = _dense_rank(h, values)
+
+    return rank, dense_rank, peers, len(values), result[agg]
+
+def test_rank(pipeline, clean_db):
+    """
+    Verify that continuous rank produces the correct result given random input
+    """
+    rank, _, _, _, result = _test_hs_agg(pipeline, 'rank')
+    
+    assert rank == result
+
+def test_dense_rank(pipeline, clean_db):
+    """
+    Verify that continuous dense_rank produces the correct result given random input
+    """
+    _, dense_rank, _, _, result = _test_hs_agg(pipeline, 'dense_rank')
+    
+    # We use HLL for dense_rank, so there may be a small margin of error, 
+    # but it should never be larger than 2% 
+    delta = abs(dense_rank - result)
+    
+    assert delta / float(dense_rank) <= 0.02
+
+def test_percent_rank(pipeline, clean_db):
+    """
+    Verify that continuous percent_rank produces the correct result given random input
+    """
+    rank, _, _, row_count, result = _test_hs_agg(pipeline, 'percent_rank')
+    
+    percent_rank = (rank - 1) / (float(row_count))
+    
+    assert (percent_rank - result) < 0.0000001
+    
+def test_cume_dist(pipeline, clean_db):
+    """
+    Verify that continuous cume_dist produces the correct result given random input
+    """
+    rank, _, peers, row_count, result = _test_hs_agg(pipeline, 'cume_dist')
+    
+    rank += peers
+    cume_dist = rank / (float(row_count + 1))
+    
+    assert abs(cume_dist - result) < 0.0000001

--- a/src/test/regress/expected/cqanalyze.out
+++ b/src/test/regress/expected/cqanalyze.out
@@ -143,6 +143,24 @@ LINE 1: ...OUS VIEW cqanalyze43 AS SELECT date_trunc('hour', ts) AS ts ...
                                                              ^
 HINT:  Explicitly cast to the desired type. For example, ts::integer.
 CREATE CONTINUOUS VIEW cqanalyze44 AS SELECT stream.sid::integer FROM stream;
+-- Hypothetical-set aggregates
+CREATE CONTINUOUS VIEW cqanalyze45 AS SELECT g::integer, percent_rank(1 + 3, 2, substring('xxx', 1, 2)) WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) + rank(4, 5, 'x') WITHIN GROUP (ORDER BY x, y, substring(z, 1, 2))  FROM stream GROUP BY g;
+CREATE CONTINUOUS VIEW cqanalyze46 AS SELECT rank(0, 1) WITHIN GROUP (ORDER BY x::integer, y::integer) + rank(0) WITHIN GROUP (ORDER BY x) FROM stream;
+-- Number of arguments to HS function is inconsistent with the number of GROUP columns
+CREATE CONTINUOUS VIEW error_not_created AS SELECT percent_rank(1) WITHIN GROUP (ORDER BY x::integer, y::integer, z::integer) FROM stream;
+ERROR:  function percent_rank(integer, integer, integer, integer) does not exist
+LINE 1: ...REATE CONTINUOUS VIEW error_not_created AS SELECT percent_ra...
+                                                             ^
+HINT:  To use the hypothetical-set aggregate percent_rank, the number of hypothetical direct arguments (here 1) must match the number of ordering columns (here 3).
+-- Types of arguments to HS function are inconsistent with GROUP column types
+CREATE CONTINUOUS VIEW error_not_created AS SELECT g::integer, dense_rank(2, 3, 4) WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM stream GROUP BY g;
+ERROR:  WITHIN GROUP types text and integer cannot be matched
+LINE 1: ...ot_created AS SELECT g::integer, dense_rank(2, 3, 4) WITHIN ...
+                                                             ^
+CREATE CONTINUOUS VIEW cqanalyze47 AS SELECT g::integer, rank(2, 3, 4) WITHIN GROUP (ORDER BY x::integer, y::integer, z::integer), sum(x + y + z) FROM stream GROUP BY g;
+-- Sliding windows
+CREATE CONTINUOUS VIEW cqanalyze48 AS SELECT cume_dist(2) WITHIN GROUP (ORDER BY x::integer DESC) FROM stream WHERE (arrival_timestamp > clock_timestamp() - interval '5 minutes');
+CREATE CONTINUOUS VIEW cqanalyze49 AS SELECT percent_rank(2) WITHIN GROUP (ORDER BY x::integer DESC), rank(2) WITHIN GROUP (ORDER BY x) FROM stream WHERE (arrival_timestamp > clock_timestamp() - interval '5 minutes');
 DROP CONTINUOUS VIEW cqanalyze0;
 DROP CONTINUOUS VIEW cqanalyze1;
 DROP CONTINUOUS VIEW cqanalyze2;
@@ -203,3 +221,8 @@ ERROR:  continuous view "cqanalyze42" does not exist
 DROP CONTINUOUS VIEW cqanalyze43;
 ERROR:  continuous view "cqanalyze43" does not exist
 DROP CONTINUOUS VIEW cqanalyze44;
+DROP CONTINUOUS VIEW cqanalyze45;
+DROP CONTINUOUS VIEW cqanalyze46;
+DROP CONTINUOUS VIEW cqanalyze47;
+DROP CONTINUOUS VIEW cqanalyze48;
+DROP CONTINUOUS VIEW cqanalyze49;

--- a/src/test/regress/expected/cqdistinct.out
+++ b/src/test/regress/expected/cqdistinct.out
@@ -1,0 +1,87 @@
+SET debug_sync_stream_insert = 'on';
+CREATE CONTINUOUS VIEW test_hll_count AS SELECT COUNT(DISTINCT x::integer) FROM test_hll_count_stream;
+CREATE CONTINUOUS VIEW test_hll_sw_count AS SELECT COUNT(DISTINCT x::integer) FROM test_hll_count_stream WHERE (arrival_timestamp > clock_timestamp() - interval '10 seconds');
+CREATE CONTINUOUS VIEW test_hll_sw_count_small AS SELECT COUNT(DISTINCT x::integer) FROM test_hll_count_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 second');;
+ACTIVATE test_hll_count, test_hll_sw_count, test_hll_sw_count_small;
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (1, 1, '1'), (1, 1, '1'), (4, 4, '4'), (7, 7, '7'), (0, 0, '0'), (2, 2, '2'), (4, 4, '4'), (8, 8, '8'), (8, 8, '8'), (7, 7, '7'), (9, 9, '9'), (6, 6, '6'), (2, 2, '2'), (6, 6, '6'), (5, 5, '5'), (3, 3, '3'), (9, 9, '9'), (0, 0, '0'), (5, 5, '5'), (3, 3, '3');
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('1', 1, 1);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('9', 9, 9);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('9', 9, 9);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('0', 0, 0);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('3', 3, 3);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('4', 4, 4);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('5', 5, 5);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('7', 7, 7);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('0', 0, 0);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('2', 2, 2);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('2', 2, 2);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('3', 3, 3);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('6', 6, 6);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('7', 7, 7);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('6', 6, 6);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('1', 1, 1);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('6', 6, 6);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('7', 7, 7);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('4', 4, 4);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('5', 5, 5);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('4', 4, 4);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('8', 8, 8);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('1', 1, 1);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('8', 8, 8);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('5', 5, 5);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('8', 8, 8);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('3', 3, 3);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('9', 9, 9);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('2', 2, 2);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('0', 0, 0);
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES (null, null, null);
+DEACTIVATE test_hll_count, test_hll_sw_count, test_hll_sw_count_small;
+SELECT * FROM test_hll_count;
+ count 
+-------
+    10
+(1 row)
+
+\d+ test_hll_count_mrel0;
+                 Table "public.test_hll_count_mrel0"
+ Column |  Type  | Modifiers | Storage  | Stats target | Description 
+--------+--------+-----------+----------+--------------+-------------
+ count  | bigint |           | plain    |              | 
+ _0     | bytea  |           | extended |              | 
+
+SELECT * FROM test_hll_sw_count;
+ count 
+-------
+    10
+(1 row)
+
+\d+ test_hll_sw_count_mrel0;
+                        Table "public.test_hll_sw_count_mrel0"
+ Column |           Type           | Modifiers | Storage  | Stats target | Description 
+--------+--------------------------+-----------+----------+--------------+-------------
+ count  | bigint                   |           | plain    |              | 
+ _1     | bytea                    |           | extended |              | 
+ _0     | timestamp with time zone |           | plain    |              | 
+Indexes:
+    "test_hll_sw_count_mrel0__0_idx" UNIQUE, btree (_0)
+
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM test_hll_sw_count_small;
+ count 
+-------
+     0
+(1 row)
+
+DROP CONTINUOUS VIEW test_hll_count;
+DROP CONTINUOUS VIEW test_hll_sw_count;
+DROP CONTINUOUS VIEW test_hll_sw_count_small;

--- a/src/test/regress/expected/cqhsagg.out
+++ b/src/test/regress/expected/cqhsagg.out
@@ -1,0 +1,199 @@
+SET debug_sync_stream_insert = 'on';
+-- rank
+CREATE CONTINUOUS VIEW test_rank0 AS SELECT rank(7, 47, '47') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_rank1 AS SELECT g::integer, rank(5, 5) WITHIN GROUP (ORDER BY g, x::integer) FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_rank2 AS SELECT g::integer, rank(-10, 10) WITHIN GROUP (ORDER BY g, x::integer DESC) FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_rank3 AS SELECT g::integer, rank(2, 1000, 1000, '1000') WITHIN GROUP (ORDER BY g, x::integer, y::integer, z::text) + rank(1000000) WITHIN GROUP (ORDER BY x) AS rank_sum FROM test_hs_stream GROUP BY g;
+ACTIVATE test_rank0, test_rank1, test_rank2, test_rank3;
+-- percent_rank
+CREATE CONTINUOUS VIEW test_percent0 AS SELECT percent_rank(2) WITHIN GROUP (ORDER BY x::integer) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_percent1 AS SELECT g::integer, percent_rank('7') WITHIN GROUP (ORDER BY z::text) AS p0, percent_rank('00') WITHIN GROUP (ORDER BY z) AS p1 FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_percent2 AS SELECT percent_rank(27, -27, '27') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_percent3 AS SELECT percent_rank(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_hs_stream;
+ACTIVATE test_percent0, test_percent1, test_percent2, test_percent3;
+-- cume_dist
+CREATE CONTINUOUS VIEW test_cume_dist0 AS SELECT cume_dist(-2 * 6) WITHIN GROUP (ORDER BY x::integer DESC) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_cume_dist1 AS SELECT g::integer, cume_dist(10, -10) WITHIN GROUP (ORDER BY g, x::integer) AS c0, cume_dist(2, -2) WITHIN GROUP (ORDER BY g, x) AS c1 FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_cume_dist2 AS SELECT cume_dist(50, -50, '50') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_cume_dist3 AS SELECT cume_dist(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_hs_stream;
+ACTIVATE test_cume_dist0, test_cume_dist1, test_cume_dist2, test_cume_dist3;
+-- dense_rank
+CREATE CONTINUOUS VIEW test_dense_rank0 AS SELECT dense_rank(10) WITHIN GROUP (ORDER BY x::integer), rank(10) WITHIN GROUP (ORDER BY x) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_dense_rank1 AS SELECT dense_rank(substring('30', 1, 2)) WITHIN GROUP (ORDER BY z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_dense_rank2 AS SELECT dense_rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text), rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+ACTIVATE test_dense_rank0, test_dense_rank1, test_dense_rank2;
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (7, 27, -27, '27'), (2, 32, -32, '32'), (4, 4, -4, '4'), (6, 26, -26, '26'), (1, 11, -11, '11'), (0, 60, -60, '60'), (2, 82, -82, '82'), (0, 40, -40, '40'), (9, 19, -19, '19'), (7, 77, -77, '77'), (8, 18, -18, '18'), (9, 99, -99, '99'), (5, 85, -85, '85'), (8, 98, -98, '98'), (7, 57, -57, '57'), (5, 65, -65, '65'), (3, 43, -43, '43'), (0, 0, 0, '0'), (8, 38, -38, '38'), (6, 36, -36, '36'), (3, 83, -83, '83'), (7, 97, -97, '97'), (6, 86, -86, '86'), (9, 29, -29, '29'), (9, 79, -79, '79'), (4, 24, -24, '24'), (6, 46, -46, '46'), (1, 51, -51, '51'), (5, 45, -45, '45'), (0, 30, -30, '30'), (1, 61, -61, '61'), (7, 87, -87, '87'), (5, 5, -5, '5'), (4, 54, -54, '54'), (2, 22, -22, '22'), (5, 55, -55, '55'), (3, 13, -13, '13'), (2, 2, -2, '2'), (8, 58, -58, '58'), (2, 72, -72, '72'), (8, 48, -48, '48'), (4, 74, -74, '74'), (6, 16, -16, '16'), (9, 39, -39, '39'), (3, 53, -53, '53'), (8, 78, -78, '78'), (8, 88, -88, '88'), (3, 93, -93, '93'), (0, 50, -50, '50'), (1, 21, -21, '21'), (4, 34, -34, '34'), (1, 71, -71, '71'), (9, 49, -49, '49'), (7, 47, -47, '47'), (6, 56, -56, '56'), (6, 76, -76, '76'), (3, 73, -73, '73'), (0, 10, -10, '10'), (8, 28, -28, '28'), (2, 52, -52, '52'), (8, 8, -8, '8'), (3, 33, -33, '33'), (1, 41, -41, '41'), (0, 90, -90, '90'), (4, 94, -94, '94'), (4, 64, -64, '64'), (3, 23, -23, '23'), (0, 20, -20, '20'), (9, 69, -69, '69'), (6, 66, -66, '66'), (5, 95, -95, '95'), (6, 6, -6, '6'), (7, 37, -37, '37'), (5, 15, -15, '15'), (4, 84, -84, '84'), (3, 63, -63, '63'), (1, 31, -31, '31'), (2, 62, -62, '62'), (0, 80, -80, '80'), (5, 25, -25, '25'), (3, 3, -3, '3'), (9, 89, -89, '89'), (2, 42, -42, '42'), (8, 68, -68, '68'), (2, 12, -12, '12'), (1, 81, -81, '81'), (4, 14, -14, '14'), (0, 70, -70, '70'), (7, 67, -67, '67'), (2, 92, -92, '92'), (5, 75, -75, '75'), (7, 17, -17, '17'), (7, 7, -7, '7'), (1, 91, -91, '91'), (5, 35, -35, '35'), (9, 59, -59, '59'), (9, 9, -9, '9'), (1, 1, -1, '1'), (6, 96, -96, '96'), (4, 44, -44, '44');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+DEACTIVATE test_rank0, test_rank1, test_rank2, test_rank3;
+DEACTIVATE test_percent0, test_percent1, test_percent2, test_percent3;
+DEACTIVATE test_cume_dist0, test_cume_dist1, test_cume_dist2, test_cume_dist3;
+DEACTIVATE test_dense_rank0, test_dense_rank1, test_dense_rank2;
+SELECT * FROM test_rank0 ORDER BY rank;
+ rank 
+------
+   17
+(1 row)
+
+SELECT * FROM test_rank1 ORDER BY g;
+ g | rank 
+---+------
+ 0 |   13
+ 1 |   13
+ 2 |   13
+ 3 |   13
+ 4 |   13
+ 5 |    1
+ 6 |    1
+ 7 |    1
+ 8 |    1
+ 9 |    1
+(10 rows)
+
+SELECT * FROM test_rank2 ORDER BY g;
+ g | rank 
+---+------
+ 0 |    1
+ 1 |    1
+ 2 |    1
+ 3 |    1
+ 4 |    1
+ 5 |    1
+ 6 |    1
+ 7 |    1
+ 8 |    1
+ 9 |    1
+(10 rows)
+
+SELECT * FROM test_rank3 ORDER BY g;
+ g | rank_sum 
+---+----------
+ 0 |       26
+ 1 |       26
+ 2 |       26
+ 3 |       14
+ 4 |       14
+ 5 |       14
+ 6 |       14
+ 7 |       14
+ 8 |       14
+ 9 |       14
+(10 rows)
+
+SELECT * FROM test_percent0 ORDER BY percent_rank;
+    percent_rank    
+--------------------
+ 0.0333333333333333
+(1 row)
+
+SELECT * FROM test_percent1 ORDER BY g;
+ g |        p0         |        p1         
+---+-------------------+-------------------
+ 0 |              0.75 | 0.166666666666667
+ 1 |              0.75 |                 0
+ 2 |              0.75 |                 0
+ 3 |              0.75 |                 0
+ 4 |              0.75 |                 0
+ 5 |              0.75 |                 0
+ 6 |              0.75 |                 0
+ 7 | 0.583333333333333 |                 0
+ 8 | 0.583333333333333 |                 0
+ 9 | 0.583333333333333 |                 0
+(10 rows)
+
+SELECT * FROM test_percent2 ORDER BY percent_rank;
+   percent_rank    
+-------------------
+ 0.391666666666667
+(1 row)
+
+SELECT * FROM test_percent3 ORDER BY percent_rank;
+   percent_rank    
+-------------------
+ 0.183333333333333
+(1 row)
+
+SELECT * FROM test_cume_dist0 ORDER BY cume_dist;
+ cume_dist 
+-----------
+         1
+(1 row)
+
+SELECT * FROM test_cume_dist1 ORDER BY g;
+ g | c0 |         c1         
+---+----+--------------------
+ 0 |  1 |                  1
+ 1 |  1 |                  1
+ 2 |  1 | 0.0769230769230769
+ 3 |  1 | 0.0769230769230769
+ 4 |  1 | 0.0769230769230769
+ 5 |  1 | 0.0769230769230769
+ 6 |  1 | 0.0769230769230769
+ 7 |  1 | 0.0769230769230769
+ 8 |  1 | 0.0769230769230769
+ 9 |  1 | 0.0769230769230769
+(10 rows)
+
+SELECT * FROM test_cume_dist2 ORDER BY cume_dist;
+    cume_dist     
+------------------
+ 0.59504132231405
+(1 row)
+
+SELECT * FROM test_cume_dist3 ORDER BY cume_dist;
+     cume_dist     
+-------------------
+ 0.190082644628099
+(1 row)
+
+SELECT * FROM test_dense_rank0;
+ dense_rank | rank 
+------------+------
+         11 |   21
+(1 row)
+
+SELECT * FROM test_dense_rank1;
+ dense_rank 
+------------
+         25
+(1 row)
+
+SELECT * FROM test_dense_rank2;
+ dense_rank | rank 
+------------+------
+         30 |   51
+(1 row)
+
+DROP CONTINUOUS VIEW test_rank0;
+DROP CONTINUOUS VIEW test_rank1;
+DROP CONTINUOUS VIEW test_rank2;
+DROP CONTINUOUS VIEW test_rank3;
+DROP CONTINUOUS VIEW test_percent0;
+DROP CONTINUOUS VIEW test_percent1;
+DROP CONTINUOUS VIEW test_percent2;
+DROP CONTINUOUS VIEW test_percent3;
+DROP CONTINUOUS VIEW test_cume_dist0;
+DROP CONTINUOUS VIEW test_cume_dist1;
+DROP CONTINUOUS VIEW test_cume_dist2;
+DROP CONTINUOUS VIEW test_cume_dist3;
+DROP CONTINUOUS VIEW test_dense_rank0;
+DROP CONTINUOUS VIEW test_dense_rank1;
+DROP CONTINUOUS VIEW test_dense_rank2;

--- a/src/test/regress/expected/cqswhsagg.out
+++ b/src/test/regress/expected/cqswhsagg.out
@@ -1,0 +1,261 @@
+SET debug_sync_stream_insert = 'on';
+-- First use big windows to verify that we get the same results as identical queries without sliding windows
+-- rank
+CREATE CONTINUOUS VIEW test_sw_rank0 AS SELECT rank(7, 47, '47') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_rank1 AS SELECT g::integer, rank(5, 5) WITHIN GROUP (ORDER BY g, x::integer) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_rank2 AS SELECT g::integer, rank(-10, 10) WITHIN GROUP (ORDER BY g, x::integer DESC) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_rank3 AS SELECT g::integer, rank(2, 1000, 1000, '1000') WITHIN GROUP (ORDER BY g, x::integer, y::integer, z::text) + rank(1000000) WITHIN GROUP (ORDER BY x) AS rank_sum FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+ACTIVATE test_sw_rank0, test_sw_rank1, test_sw_rank2, test_sw_rank3;
+-- percent_rank
+CREATE CONTINUOUS VIEW test_sw_percent0 AS SELECT percent_rank(2) WITHIN GROUP (ORDER BY x::integer) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_percent1 AS SELECT g::integer, percent_rank('7') WITHIN GROUP (ORDER BY z::text) AS p0, percent_rank('00') WITHIN GROUP (ORDER BY z) AS p1 FROM test_sw_hs_stream  WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_percent2 AS SELECT percent_rank(27, -27, '27') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_percent3 AS SELECT percent_rank(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+ACTIVATE test_sw_percent0, test_sw_percent1, test_sw_percent2, test_sw_percent3;
+-- cume_dist
+CREATE CONTINUOUS VIEW test_sw_cume_dist0 AS SELECT cume_dist(-2 * 6) WITHIN GROUP (ORDER BY x::integer DESC) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_cume_dist1 AS SELECT g::integer, cume_dist(10, -10) WITHIN GROUP (ORDER BY g, x::integer) AS c0, cume_dist(2, -2) WITHIN GROUP (ORDER BY g, x) AS c1 FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_cume_dist2 AS SELECT cume_dist(50, -50, '50') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_cume_dist3 AS SELECT cume_dist(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+ACTIVATE test_sw_cume_dist0, test_sw_cume_dist1, test_sw_cume_dist2, test_sw_cume_dist3;
+-- dense_rank
+CREATE CONTINUOUS VIEW test_sw_dense_rank0 AS SELECT dense_rank(10) WITHIN GROUP (ORDER BY x::integer), rank(10) WITHIN GROUP (ORDER BY x) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_dense_rank1 AS SELECT dense_rank(substring('30', 1, 2)) WITHIN GROUP (ORDER BY z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_dense_rank2 AS SELECT dense_rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text), rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+ACTIVATE test_sw_dense_rank0, test_sw_dense_rank1, test_sw_dense_rank2;
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 27, -27, '27'), (2, 32, -32, '32'), (4, 4, -4, '4'), (6, 26, -26, '26'), (1, 11, -11, '11'), (0, 60, -60, '60'), (2, 82, -82, '82'), (0, 40, -40, '40'), (9, 19, -19, '19'), (7, 77, -77, '77'), (8, 18, -18, '18'), (9, 99, -99, '99'), (5, 85, -85, '85'), (8, 98, -98, '98'), (7, 57, -57, '57'), (5, 65, -65, '65'), (3, 43, -43, '43'), (0, 0, 0, '0'), (8, 38, -38, '38'), (6, 36, -36, '36'), (3, 83, -83, '83'), (7, 97, -97, '97'), (6, 86, -86, '86'), (9, 29, -29, '29'), (9, 79, -79, '79'), (4, 24, -24, '24'), (6, 46, -46, '46'), (1, 51, -51, '51'), (5, 45, -45, '45'), (0, 30, -30, '30'), (1, 61, -61, '61'), (7, 87, -87, '87'), (5, 5, -5, '5'), (4, 54, -54, '54'), (2, 22, -22, '22'), (5, 55, -55, '55'), (3, 13, -13, '13'), (2, 2, -2, '2'), (8, 58, -58, '58'), (2, 72, -72, '72'), (8, 48, -48, '48'), (4, 74, -74, '74'), (6, 16, -16, '16'), (9, 39, -39, '39'), (3, 53, -53, '53'), (8, 78, -78, '78'), (8, 88, -88, '88'), (3, 93, -93, '93'), (0, 50, -50, '50'), (1, 21, -21, '21'), (4, 34, -34, '34'), (1, 71, -71, '71'), (9, 49, -49, '49'), (7, 47, -47, '47'), (6, 56, -56, '56'), (6, 76, -76, '76'), (3, 73, -73, '73'), (0, 10, -10, '10'), (8, 28, -28, '28'), (2, 52, -52, '52'), (8, 8, -8, '8'), (3, 33, -33, '33'), (1, 41, -41, '41'), (0, 90, -90, '90'), (4, 94, -94, '94'), (4, 64, -64, '64'), (3, 23, -23, '23'), (0, 20, -20, '20'), (9, 69, -69, '69'), (6, 66, -66, '66'), (5, 95, -95, '95'), (6, 6, -6, '6'), (7, 37, -37, '37'), (5, 15, -15, '15'), (4, 84, -84, '84'), (3, 63, -63, '63'), (1, 31, -31, '31'), (2, 62, -62, '62'), (0, 80, -80, '80'), (5, 25, -25, '25'), (3, 3, -3, '3'), (9, 89, -89, '89'), (2, 42, -42, '42'), (8, 68, -68, '68'), (2, 12, -12, '12'), (1, 81, -81, '81'), (4, 14, -14, '14'), (0, 70, -70, '70'), (7, 67, -67, '67'), (2, 92, -92, '92'), (5, 75, -75, '75'), (7, 17, -17, '17'), (7, 7, -7, '7'), (1, 91, -91, '91'), (5, 35, -35, '35'), (9, 59, -59, '59'), (9, 9, -9, '9'), (1, 1, -1, '1'), (6, 96, -96, '96'), (4, 44, -44, '44');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+DEACTIVATE test_sw_rank0, test_sw_rank1, test_sw_rank2, test_sw_rank3;
+DEACTIVATE test_sw_percent0, test_sw_percent1, test_sw_percent2, test_sw_percent3;
+DEACTIVATE test_sw_cume_dist0, test_sw_cume_dist1, test_sw_cume_dist2, test_sw_cume_dist3;
+DEACTIVATE test_sw_dense_rank0, test_sw_dense_rank1, test_sw_dense_rank2;
+SELECT * FROM test_sw_rank0 ORDER BY rank;
+ rank 
+------
+   17
+(1 row)
+
+SELECT * FROM test_sw_rank1 ORDER BY g;
+ g | rank 
+---+------
+ 0 |   13
+ 1 |   13
+ 2 |   13
+ 3 |   13
+ 4 |   13
+ 5 |    1
+ 6 |    1
+ 7 |    1
+ 8 |    1
+ 9 |    1
+(10 rows)
+
+SELECT * FROM test_sw_rank2 ORDER BY g;
+ g | rank 
+---+------
+ 0 |    1
+ 1 |    1
+ 2 |    1
+ 3 |    1
+ 4 |    1
+ 5 |    1
+ 6 |    1
+ 7 |    1
+ 8 |    1
+ 9 |    1
+(10 rows)
+
+SELECT * FROM test_sw_rank3 ORDER BY g;
+ g | rank_sum 
+---+----------
+ 0 |       26
+ 1 |       26
+ 2 |       26
+ 3 |       14
+ 4 |       14
+ 5 |       14
+ 6 |       14
+ 7 |       14
+ 8 |       14
+ 9 |       14
+(10 rows)
+
+SELECT * FROM test_sw_percent0 ORDER BY percent_rank;
+    percent_rank    
+--------------------
+ 0.0333333333333333
+(1 row)
+
+SELECT * FROM test_sw_percent1 ORDER BY g;
+ g |        p0         |        p1         
+---+-------------------+-------------------
+ 0 |              0.75 | 0.166666666666667
+ 1 |              0.75 |                 0
+ 2 |              0.75 |                 0
+ 3 |              0.75 |                 0
+ 4 |              0.75 |                 0
+ 5 |              0.75 |                 0
+ 6 |              0.75 |                 0
+ 7 | 0.583333333333333 |                 0
+ 8 | 0.583333333333333 |                 0
+ 9 | 0.583333333333333 |                 0
+(10 rows)
+
+SELECT * FROM test_sw_percent2 ORDER BY percent_rank;
+   percent_rank    
+-------------------
+ 0.391666666666667
+(1 row)
+
+SELECT * FROM test_sw_percent3 ORDER BY percent_rank;
+   percent_rank    
+-------------------
+ 0.183333333333333
+(1 row)
+
+SELECT * FROM test_sw_cume_dist0 ORDER BY cume_dist;
+ cume_dist 
+-----------
+         1
+(1 row)
+
+SELECT * FROM test_sw_cume_dist1 ORDER BY g;
+ g | c0 |         c1         
+---+----+--------------------
+ 0 |  1 |                  1
+ 1 |  1 |                  1
+ 2 |  1 | 0.0769230769230769
+ 3 |  1 | 0.0769230769230769
+ 4 |  1 | 0.0769230769230769
+ 5 |  1 | 0.0769230769230769
+ 6 |  1 | 0.0769230769230769
+ 7 |  1 | 0.0769230769230769
+ 8 |  1 | 0.0769230769230769
+ 9 |  1 | 0.0769230769230769
+(10 rows)
+
+SELECT * FROM test_sw_cume_dist2 ORDER BY cume_dist;
+    cume_dist     
+------------------
+ 0.59504132231405
+(1 row)
+
+SELECT * FROM test_sw_cume_dist3 ORDER BY cume_dist;
+     cume_dist     
+-------------------
+ 0.190082644628099
+(1 row)
+
+SELECT * FROM test_sw_dense_rank0;
+ dense_rank | rank 
+------------+------
+         11 |   21
+(1 row)
+
+SELECT * FROM test_sw_dense_rank1;
+ dense_rank 
+------------
+         25
+(1 row)
+
+SELECT * FROM test_sw_dense_rank2;
+ dense_rank | rank 
+------------+------
+         30 |   51
+(1 row)
+
+-- Now use a small windoww to verify that sliding window results change over time
+CREATE CONTINUOUS VIEW test_sw_hs_change AS SELECT 
+rank(5, -5) WITHIN GROUP (ORDER BY x::integer, y::integer),
+dense_rank(5, -5) WITHIN GROUP (ORDER BY x, y),
+percent_rank(10, -10) WITHIN GROUP (ORDER BY x, y),
+cume_dist(15, -15) WITHIN GROUP (ORDER BY x, y) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 second');
+ACTIVATE test_sw_hs_change;
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+DEACTIVATE test_sw_hs_change;
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM test_sw_hs_change ORDER BY rank;
+ rank | dense_rank | percent_rank | cume_dist 
+------+------------+--------------+-----------
+    1 |          1 |            0 |         0
+(1 row)
+
+DROP CONTINUOUS VIEW test_sw_rank0;
+DROP CONTINUOUS VIEW test_sw_rank1;
+DROP CONTINUOUS VIEW test_sw_rank2;
+DROP CONTINUOUS VIEW test_sw_rank3;
+DROP CONTINUOUS VIEW test_sw_percent0;
+DROP CONTINUOUS VIEW test_sw_percent1;
+DROP CONTINUOUS VIEW test_sw_percent2;
+DROP CONTINUOUS VIEW test_sw_percent3;
+DROP CONTINUOUS VIEW test_sw_cume_dist0;
+DROP CONTINUOUS VIEW test_sw_cume_dist1;
+DROP CONTINUOUS VIEW test_sw_cume_dist2;
+DROP CONTINUOUS VIEW test_sw_cume_dist3;
+DROP CONTINUOUS VIEW test_sw_dense_rank0;
+DROP CONTINUOUS VIEW test_sw_dense_rank1;
+DROP CONTINUOUS VIEW test_sw_dense_rank2;
+DROP CONTINUOUS VIEW test_sw_hs_change;

--- a/src/test/regress/expected/opr_sanity.out
+++ b/src/test/regress/expected/opr_sanity.out
@@ -171,13 +171,12 @@ WHERE p1.oid != p2.oid AND
 ORDER BY 1, 2;
  proargtypes | proargtypes 
 -------------+-------------
-          17 |          25
           25 |        1042
           25 |        1043
         1114 |        1184
         1560 |        1562
         2277 |        2283
-(6 rows)
+(5 rows)
 
 SELECT DISTINCT p1.proargtypes[1], p2.proargtypes[1]
 FROM pg_proc AS p1, pg_proc AS p2

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -117,9 +117,14 @@ test: cqanalyze cqcreate cqactivate cqsanity cqsum cqswsum cqavg cqswavg cqcount
 # ----------
 # Another group of parallel tests
 # ----------
-test: cqlatch cqvacuum cqdecode stream_exprs stream_casts
+test: cqvacuum cqdecode stream_exprs stream_casts cqhsagg cqswhsagg cqdistinct
 
 # ----------
 # Another group of parallel tests
 # ----------
 test: pipeline_stream
+
+# ----------
+# Another group of parallel tests
+# ----------
+test: cqlatch

--- a/src/test/regress/sql/cqanalyze.sql
+++ b/src/test/regress/sql/cqanalyze.sql
@@ -116,6 +116,23 @@ CREATE CONTINUOUS VIEW cqanalyze42 AS SELECT COUNT(*) FROM stream WHERE arrival_
 CREATE CONTINUOUS VIEW cqanalyze43 AS SELECT date_trunc('hour', ts) AS ts FROM stream;
 CREATE CONTINUOUS VIEW cqanalyze44 AS SELECT stream.sid::integer FROM stream;
 
+-- Hypothetical-set aggregates
+CREATE CONTINUOUS VIEW cqanalyze45 AS SELECT g::integer, percent_rank(1 + 3, 2, substring('xxx', 1, 2)) WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) + rank(4, 5, 'x') WITHIN GROUP (ORDER BY x, y, substring(z, 1, 2))  FROM stream GROUP BY g;
+
+CREATE CONTINUOUS VIEW cqanalyze46 AS SELECT rank(0, 1) WITHIN GROUP (ORDER BY x::integer, y::integer) + rank(0) WITHIN GROUP (ORDER BY x) FROM stream;
+
+-- Number of arguments to HS function is inconsistent with the number of GROUP columns
+CREATE CONTINUOUS VIEW error_not_created AS SELECT percent_rank(1) WITHIN GROUP (ORDER BY x::integer, y::integer, z::integer) FROM stream;
+
+-- Types of arguments to HS function are inconsistent with GROUP column types
+CREATE CONTINUOUS VIEW error_not_created AS SELECT g::integer, dense_rank(2, 3, 4) WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM stream GROUP BY g;
+
+CREATE CONTINUOUS VIEW cqanalyze47 AS SELECT g::integer, rank(2, 3, 4) WITHIN GROUP (ORDER BY x::integer, y::integer, z::integer), sum(x + y + z) FROM stream GROUP BY g;
+
+-- Sliding windows
+CREATE CONTINUOUS VIEW cqanalyze48 AS SELECT cume_dist(2) WITHIN GROUP (ORDER BY x::integer DESC) FROM stream WHERE (arrival_timestamp > clock_timestamp() - interval '5 minutes');
+CREATE CONTINUOUS VIEW cqanalyze49 AS SELECT percent_rank(2) WITHIN GROUP (ORDER BY x::integer DESC), rank(2) WITHIN GROUP (ORDER BY x) FROM stream WHERE (arrival_timestamp > clock_timestamp() - interval '5 minutes');
+
 DROP CONTINUOUS VIEW cqanalyze0;
 DROP CONTINUOUS VIEW cqanalyze1;
 DROP CONTINUOUS VIEW cqanalyze2;
@@ -161,3 +178,8 @@ DROP CONTINUOUS VIEW cqanalyze41;
 DROP CONTINUOUS VIEW cqanalyze42;
 DROP CONTINUOUS VIEW cqanalyze43;
 DROP CONTINUOUS VIEW cqanalyze44;
+DROP CONTINUOUS VIEW cqanalyze45;
+DROP CONTINUOUS VIEW cqanalyze46;
+DROP CONTINUOUS VIEW cqanalyze47;
+DROP CONTINUOUS VIEW cqanalyze48;
+DROP CONTINUOUS VIEW cqanalyze49;

--- a/src/test/regress/sql/cqdistinct.sql
+++ b/src/test/regress/sql/cqdistinct.sql
@@ -1,0 +1,60 @@
+SET debug_sync_stream_insert = 'on';
+
+CREATE CONTINUOUS VIEW test_hll_count AS SELECT COUNT(DISTINCT x::integer) FROM test_hll_count_stream;
+CREATE CONTINUOUS VIEW test_hll_sw_count AS SELECT COUNT(DISTINCT x::integer) FROM test_hll_count_stream WHERE (arrival_timestamp > clock_timestamp() - interval '10 seconds');
+CREATE CONTINUOUS VIEW test_hll_sw_count_small AS SELECT COUNT(DISTINCT x::integer) FROM test_hll_count_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 second');;
+
+ACTIVATE test_hll_count, test_hll_sw_count, test_hll_sw_count_small;
+
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (1, 1, '1'), (1, 1, '1'), (4, 4, '4'), (7, 7, '7'), (0, 0, '0'), (2, 2, '2'), (4, 4, '4'), (8, 8, '8'), (8, 8, '8'), (7, 7, '7'), (9, 9, '9'), (6, 6, '6'), (2, 2, '2'), (6, 6, '6'), (5, 5, '5'), (3, 3, '3'), (9, 9, '9'), (0, 0, '0'), (5, 5, '5'), (3, 3, '3');
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('1', 1, 1);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('9', 9, 9);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('9', 9, 9);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('0', 0, 0);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('3', 3, 3);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('4', 4, 4);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('5', 5, 5);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('7', 7, 7);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('0', 0, 0);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('2', 2, 2);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('2', 2, 2);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('3', 3, 3);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('6', 6, 6);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('7', 7, 7);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('6', 6, 6);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('1', 1, 1);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('6', 6, 6);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('7', 7, 7);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('4', 4, 4);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('5', 5, 5);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('4', 4, 4);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('8', 8, 8);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('1', 1, 1);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('8', 8, 8);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('5', 5, 5);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('8', 8, 8);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('3', 3, 3);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('9', 9, 9);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('2', 2, 2);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES ('0', 0, 0);
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (x, y, z) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES (null, null, null);
+INSERT INTO test_hll_count_stream (z, y, x) VALUES (null, null, null);
+
+DEACTIVATE test_hll_count, test_hll_sw_count, test_hll_sw_count_small;
+
+SELECT * FROM test_hll_count;
+\d+ test_hll_count_mrel0;
+
+SELECT * FROM test_hll_sw_count;
+\d+ test_hll_sw_count_mrel0;
+
+SELECT pg_sleep(1);
+SELECT * FROM test_hll_sw_count_small;
+
+DROP CONTINUOUS VIEW test_hll_count;
+DROP CONTINUOUS VIEW test_hll_sw_count;
+DROP CONTINUOUS VIEW test_hll_sw_count_small;

--- a/src/test/regress/sql/cqhsagg.sql
+++ b/src/test/regress/sql/cqhsagg.sql
@@ -1,0 +1,94 @@
+SET debug_sync_stream_insert = 'on';
+
+-- rank
+CREATE CONTINUOUS VIEW test_rank0 AS SELECT rank(7, 47, '47') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_rank1 AS SELECT g::integer, rank(5, 5) WITHIN GROUP (ORDER BY g, x::integer) FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_rank2 AS SELECT g::integer, rank(-10, 10) WITHIN GROUP (ORDER BY g, x::integer DESC) FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_rank3 AS SELECT g::integer, rank(2, 1000, 1000, '1000') WITHIN GROUP (ORDER BY g, x::integer, y::integer, z::text) + rank(1000000) WITHIN GROUP (ORDER BY x) AS rank_sum FROM test_hs_stream GROUP BY g;
+
+ACTIVATE test_rank0, test_rank1, test_rank2, test_rank3;
+
+-- percent_rank
+CREATE CONTINUOUS VIEW test_percent0 AS SELECT percent_rank(2) WITHIN GROUP (ORDER BY x::integer) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_percent1 AS SELECT g::integer, percent_rank('7') WITHIN GROUP (ORDER BY z::text) AS p0, percent_rank('00') WITHIN GROUP (ORDER BY z) AS p1 FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_percent2 AS SELECT percent_rank(27, -27, '27') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_percent3 AS SELECT percent_rank(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_hs_stream;
+
+ACTIVATE test_percent0, test_percent1, test_percent2, test_percent3;
+
+-- cume_dist
+CREATE CONTINUOUS VIEW test_cume_dist0 AS SELECT cume_dist(-2 * 6) WITHIN GROUP (ORDER BY x::integer DESC) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_cume_dist1 AS SELECT g::integer, cume_dist(10, -10) WITHIN GROUP (ORDER BY g, x::integer) AS c0, cume_dist(2, -2) WITHIN GROUP (ORDER BY g, x) AS c1 FROM test_hs_stream GROUP BY g;
+CREATE CONTINUOUS VIEW test_cume_dist2 AS SELECT cume_dist(50, -50, '50') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_cume_dist3 AS SELECT cume_dist(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_hs_stream;
+
+ACTIVATE test_cume_dist0, test_cume_dist1, test_cume_dist2, test_cume_dist3;
+
+-- dense_rank
+CREATE CONTINUOUS VIEW test_dense_rank0 AS SELECT dense_rank(10) WITHIN GROUP (ORDER BY x::integer), rank(10) WITHIN GROUP (ORDER BY x) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_dense_rank1 AS SELECT dense_rank(substring('30', 1, 2)) WITHIN GROUP (ORDER BY z::text) FROM test_hs_stream;
+CREATE CONTINUOUS VIEW test_dense_rank2 AS SELECT dense_rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text), rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_hs_stream;
+
+ACTIVATE test_dense_rank0, test_dense_rank1, test_dense_rank2;
+
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (7, 27, -27, '27'), (2, 32, -32, '32'), (4, 4, -4, '4'), (6, 26, -26, '26'), (1, 11, -11, '11'), (0, 60, -60, '60'), (2, 82, -82, '82'), (0, 40, -40, '40'), (9, 19, -19, '19'), (7, 77, -77, '77'), (8, 18, -18, '18'), (9, 99, -99, '99'), (5, 85, -85, '85'), (8, 98, -98, '98'), (7, 57, -57, '57'), (5, 65, -65, '65'), (3, 43, -43, '43'), (0, 0, 0, '0'), (8, 38, -38, '38'), (6, 36, -36, '36'), (3, 83, -83, '83'), (7, 97, -97, '97'), (6, 86, -86, '86'), (9, 29, -29, '29'), (9, 79, -79, '79'), (4, 24, -24, '24'), (6, 46, -46, '46'), (1, 51, -51, '51'), (5, 45, -45, '45'), (0, 30, -30, '30'), (1, 61, -61, '61'), (7, 87, -87, '87'), (5, 5, -5, '5'), (4, 54, -54, '54'), (2, 22, -22, '22'), (5, 55, -55, '55'), (3, 13, -13, '13'), (2, 2, -2, '2'), (8, 58, -58, '58'), (2, 72, -72, '72'), (8, 48, -48, '48'), (4, 74, -74, '74'), (6, 16, -16, '16'), (9, 39, -39, '39'), (3, 53, -53, '53'), (8, 78, -78, '78'), (8, 88, -88, '88'), (3, 93, -93, '93'), (0, 50, -50, '50'), (1, 21, -21, '21'), (4, 34, -34, '34'), (1, 71, -71, '71'), (9, 49, -49, '49'), (7, 47, -47, '47'), (6, 56, -56, '56'), (6, 76, -76, '76'), (3, 73, -73, '73'), (0, 10, -10, '10'), (8, 28, -28, '28'), (2, 52, -52, '52'), (8, 8, -8, '8'), (3, 33, -33, '33'), (1, 41, -41, '41'), (0, 90, -90, '90'), (4, 94, -94, '94'), (4, 64, -64, '64'), (3, 23, -23, '23'), (0, 20, -20, '20'), (9, 69, -69, '69'), (6, 66, -66, '66'), (5, 95, -95, '95'), (6, 6, -6, '6'), (7, 37, -37, '37'), (5, 15, -15, '15'), (4, 84, -84, '84'), (3, 63, -63, '63'), (1, 31, -31, '31'), (2, 62, -62, '62'), (0, 80, -80, '80'), (5, 25, -25, '25'), (3, 3, -3, '3'), (9, 89, -89, '89'), (2, 42, -42, '42'), (8, 68, -68, '68'), (2, 12, -12, '12'), (1, 81, -81, '81'), (4, 14, -14, '14'), (0, 70, -70, '70'), (7, 67, -67, '67'), (2, 92, -92, '92'), (5, 75, -75, '75'), (7, 17, -17, '17'), (7, 7, -7, '7'), (1, 91, -91, '91'), (5, 35, -35, '35'), (9, 59, -59, '59'), (9, 9, -9, '9'), (1, 1, -1, '1'), (6, 96, -96, '96'), (4, 44, -44, '44');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+INSERT INTO test_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+
+DEACTIVATE test_rank0, test_rank1, test_rank2, test_rank3;
+DEACTIVATE test_percent0, test_percent1, test_percent2, test_percent3;
+DEACTIVATE test_cume_dist0, test_cume_dist1, test_cume_dist2, test_cume_dist3;
+DEACTIVATE test_dense_rank0, test_dense_rank1, test_dense_rank2;
+
+SELECT * FROM test_rank0 ORDER BY rank;
+SELECT * FROM test_rank1 ORDER BY g;
+SELECT * FROM test_rank2 ORDER BY g;
+SELECT * FROM test_rank3 ORDER BY g;
+
+SELECT * FROM test_percent0 ORDER BY percent_rank;
+SELECT * FROM test_percent1 ORDER BY g;
+SELECT * FROM test_percent2 ORDER BY percent_rank;
+SELECT * FROM test_percent3 ORDER BY percent_rank;
+
+SELECT * FROM test_cume_dist0 ORDER BY cume_dist;
+SELECT * FROM test_cume_dist1 ORDER BY g;
+SELECT * FROM test_cume_dist2 ORDER BY cume_dist;
+SELECT * FROM test_cume_dist3 ORDER BY cume_dist;
+
+SELECT * FROM test_dense_rank0;
+SELECT * FROM test_dense_rank1;
+SELECT * FROM test_dense_rank2;
+
+DROP CONTINUOUS VIEW test_rank0;
+DROP CONTINUOUS VIEW test_rank1;
+DROP CONTINUOUS VIEW test_rank2;
+DROP CONTINUOUS VIEW test_rank3;
+DROP CONTINUOUS VIEW test_percent0;
+DROP CONTINUOUS VIEW test_percent1;
+DROP CONTINUOUS VIEW test_percent2;
+DROP CONTINUOUS VIEW test_percent3;
+DROP CONTINUOUS VIEW test_cume_dist0;
+DROP CONTINUOUS VIEW test_cume_dist1;
+DROP CONTINUOUS VIEW test_cume_dist2;
+DROP CONTINUOUS VIEW test_cume_dist3;
+DROP CONTINUOUS VIEW test_dense_rank0;
+DROP CONTINUOUS VIEW test_dense_rank1;
+DROP CONTINUOUS VIEW test_dense_rank2;

--- a/src/test/regress/sql/cqswhsagg.sql
+++ b/src/test/regress/sql/cqswhsagg.sql
@@ -1,0 +1,151 @@
+SET debug_sync_stream_insert = 'on';
+
+-- First use big windows to verify that we get the same results as identical queries without sliding windows
+-- rank
+CREATE CONTINUOUS VIEW test_sw_rank0 AS SELECT rank(7, 47, '47') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_rank1 AS SELECT g::integer, rank(5, 5) WITHIN GROUP (ORDER BY g, x::integer) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_rank2 AS SELECT g::integer, rank(-10, 10) WITHIN GROUP (ORDER BY g, x::integer DESC) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_rank3 AS SELECT g::integer, rank(2, 1000, 1000, '1000') WITHIN GROUP (ORDER BY g, x::integer, y::integer, z::text) + rank(1000000) WITHIN GROUP (ORDER BY x) AS rank_sum FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+
+ACTIVATE test_sw_rank0, test_sw_rank1, test_sw_rank2, test_sw_rank3;
+
+-- percent_rank
+CREATE CONTINUOUS VIEW test_sw_percent0 AS SELECT percent_rank(2) WITHIN GROUP (ORDER BY x::integer) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_percent1 AS SELECT g::integer, percent_rank('7') WITHIN GROUP (ORDER BY z::text) AS p0, percent_rank('00') WITHIN GROUP (ORDER BY z) AS p1 FROM test_sw_hs_stream  WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_percent2 AS SELECT percent_rank(27, -27, '27') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_percent3 AS SELECT percent_rank(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+
+ACTIVATE test_sw_percent0, test_sw_percent1, test_sw_percent2, test_sw_percent3;
+
+-- cume_dist
+CREATE CONTINUOUS VIEW test_sw_cume_dist0 AS SELECT cume_dist(-2 * 6) WITHIN GROUP (ORDER BY x::integer DESC) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_cume_dist1 AS SELECT g::integer, cume_dist(10, -10) WITHIN GROUP (ORDER BY g, x::integer) AS c0, cume_dist(2, -2) WITHIN GROUP (ORDER BY g, x) AS c1 FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY g;
+CREATE CONTINUOUS VIEW test_sw_cume_dist2 AS SELECT cume_dist(50, -50, '50') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_cume_dist3 AS SELECT cume_dist(10.1, 10.2) WITHIN GROUP (ORDER BY x::float8, y::float8) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+
+ACTIVATE test_sw_cume_dist0, test_sw_cume_dist1, test_sw_cume_dist2, test_sw_cume_dist3;
+
+-- dense_rank
+CREATE CONTINUOUS VIEW test_sw_dense_rank0 AS SELECT dense_rank(10) WITHIN GROUP (ORDER BY x::integer), rank(10) WITHIN GROUP (ORDER BY x) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_dense_rank1 AS SELECT dense_rank(substring('30', 1, 2)) WITHIN GROUP (ORDER BY z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+CREATE CONTINUOUS VIEW test_sw_dense_rank2 AS SELECT dense_rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text), rank(30, -30, '30') WITHIN GROUP (ORDER BY x::integer, y::integer, z::text) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour');
+
+ACTIVATE test_sw_dense_rank0, test_sw_dense_rank1, test_sw_dense_rank2;
+
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 27, -27, '27'), (2, 32, -32, '32'), (4, 4, -4, '4'), (6, 26, -26, '26'), (1, 11, -11, '11'), (0, 60, -60, '60'), (2, 82, -82, '82'), (0, 40, -40, '40'), (9, 19, -19, '19'), (7, 77, -77, '77'), (8, 18, -18, '18'), (9, 99, -99, '99'), (5, 85, -85, '85'), (8, 98, -98, '98'), (7, 57, -57, '57'), (5, 65, -65, '65'), (3, 43, -43, '43'), (0, 0, 0, '0'), (8, 38, -38, '38'), (6, 36, -36, '36'), (3, 83, -83, '83'), (7, 97, -97, '97'), (6, 86, -86, '86'), (9, 29, -29, '29'), (9, 79, -79, '79'), (4, 24, -24, '24'), (6, 46, -46, '46'), (1, 51, -51, '51'), (5, 45, -45, '45'), (0, 30, -30, '30'), (1, 61, -61, '61'), (7, 87, -87, '87'), (5, 5, -5, '5'), (4, 54, -54, '54'), (2, 22, -22, '22'), (5, 55, -55, '55'), (3, 13, -13, '13'), (2, 2, -2, '2'), (8, 58, -58, '58'), (2, 72, -72, '72'), (8, 48, -48, '48'), (4, 74, -74, '74'), (6, 16, -16, '16'), (9, 39, -39, '39'), (3, 53, -53, '53'), (8, 78, -78, '78'), (8, 88, -88, '88'), (3, 93, -93, '93'), (0, 50, -50, '50'), (1, 21, -21, '21'), (4, 34, -34, '34'), (1, 71, -71, '71'), (9, 49, -49, '49'), (7, 47, -47, '47'), (6, 56, -56, '56'), (6, 76, -76, '76'), (3, 73, -73, '73'), (0, 10, -10, '10'), (8, 28, -28, '28'), (2, 52, -52, '52'), (8, 8, -8, '8'), (3, 33, -33, '33'), (1, 41, -41, '41'), (0, 90, -90, '90'), (4, 94, -94, '94'), (4, 64, -64, '64'), (3, 23, -23, '23'), (0, 20, -20, '20'), (9, 69, -69, '69'), (6, 66, -66, '66'), (5, 95, -95, '95'), (6, 6, -6, '6'), (7, 37, -37, '37'), (5, 15, -15, '15'), (4, 84, -84, '84'), (3, 63, -63, '63'), (1, 31, -31, '31'), (2, 62, -62, '62'), (0, 80, -80, '80'), (5, 25, -25, '25'), (3, 3, -3, '3'), (9, 89, -89, '89'), (2, 42, -42, '42'), (8, 68, -68, '68'), (2, 12, -12, '12'), (1, 81, -81, '81'), (4, 14, -14, '14'), (0, 70, -70, '70'), (7, 67, -67, '67'), (2, 92, -92, '92'), (5, 75, -75, '75'), (7, 17, -17, '17'), (7, 7, -7, '7'), (1, 91, -91, '91'), (5, 35, -35, '35'), (9, 59, -59, '59'), (9, 9, -9, '9'), (1, 1, -1, '1'), (6, 96, -96, '96'), (4, 44, -44, '44');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+
+DEACTIVATE test_sw_rank0, test_sw_rank1, test_sw_rank2, test_sw_rank3;
+DEACTIVATE test_sw_percent0, test_sw_percent1, test_sw_percent2, test_sw_percent3;
+DEACTIVATE test_sw_cume_dist0, test_sw_cume_dist1, test_sw_cume_dist2, test_sw_cume_dist3;
+DEACTIVATE test_sw_dense_rank0, test_sw_dense_rank1, test_sw_dense_rank2;
+
+SELECT * FROM test_sw_rank0 ORDER BY rank;
+SELECT * FROM test_sw_rank1 ORDER BY g;
+SELECT * FROM test_sw_rank2 ORDER BY g;
+SELECT * FROM test_sw_rank3 ORDER BY g;
+
+SELECT * FROM test_sw_percent0 ORDER BY percent_rank;
+SELECT * FROM test_sw_percent1 ORDER BY g;
+SELECT * FROM test_sw_percent2 ORDER BY percent_rank;
+SELECT * FROM test_sw_percent3 ORDER BY percent_rank;
+
+SELECT * FROM test_sw_cume_dist0 ORDER BY cume_dist;
+SELECT * FROM test_sw_cume_dist1 ORDER BY g;
+SELECT * FROM test_sw_cume_dist2 ORDER BY cume_dist;
+SELECT * FROM test_sw_cume_dist3 ORDER BY cume_dist;
+
+SELECT * FROM test_sw_dense_rank0;
+SELECT * FROM test_sw_dense_rank1;
+SELECT * FROM test_sw_dense_rank2;
+
+-- Now use a small windoww to verify that sliding window results change over time
+CREATE CONTINUOUS VIEW test_sw_hs_change AS SELECT 
+rank(5, -5) WITHIN GROUP (ORDER BY x::integer, y::integer),
+dense_rank(5, -5) WITHIN GROUP (ORDER BY x, y),
+percent_rank(10, -10) WITHIN GROUP (ORDER BY x, y),
+cume_dist(15, -15) WITHIN GROUP (ORDER BY x, y) FROM test_sw_hs_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 second');
+
+ACTIVATE test_sw_hs_change;
+
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 0, 0, '0');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 1, -1, '1');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 2, -2, '2');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 3, -3, '3');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 4, -4, '4');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 5, -5, '5');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 6, -6, '6');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 7, -7, '7');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 8, -8, '8');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 9, -9, '9');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (0, 10, -10, '10');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (1, 11, -11, '11');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (2, 12, -12, '12');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (3, 13, -13, '13');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (4, 14, -14, '14');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (5, 15, -15, '15');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (6, 16, -16, '16');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (7, 17, -17, '17');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (8, 18, -18, '18');
+INSERT INTO test_sw_hs_stream (g, x, y, z) VALUES (9, 19, -19, '19');
+
+DEACTIVATE test_sw_hs_change;
+
+SELECT pg_sleep(1);
+SELECT * FROM test_sw_hs_change ORDER BY rank;
+
+DROP CONTINUOUS VIEW test_sw_rank0;
+DROP CONTINUOUS VIEW test_sw_rank1;
+DROP CONTINUOUS VIEW test_sw_rank2;
+DROP CONTINUOUS VIEW test_sw_rank3;
+DROP CONTINUOUS VIEW test_sw_percent0;
+DROP CONTINUOUS VIEW test_sw_percent1;
+DROP CONTINUOUS VIEW test_sw_percent2;
+DROP CONTINUOUS VIEW test_sw_percent3;
+DROP CONTINUOUS VIEW test_sw_cume_dist0;
+DROP CONTINUOUS VIEW test_sw_cume_dist1;
+DROP CONTINUOUS VIEW test_sw_cume_dist2;
+DROP CONTINUOUS VIEW test_sw_cume_dist3;
+DROP CONTINUOUS VIEW test_sw_dense_rank0;
+DROP CONTINUOUS VIEW test_sw_dense_rank1;
+DROP CONTINUOUS VIEW test_sw_dense_rank2;
+DROP CONTINUOUS VIEW test_sw_hs_change;


### PR DESCRIPTION
This adds continuous support for the hypothetical-set aggregates `rank`, `dense_rank`, `percent_rank`, and `cume_dist`. These aggregates take a direct argument tuple, and determine the rank of that tuple if it were included in the set of input tuples that the aggregate function has seen (thus the "hypothetical" nomenclature). The way that the regular versions of these aggregates work is by accumulating all input tuples and sorting them along with the direct argument tuple, and then simply counting up until the input tuple is seen to get the rank.

Obviously we can't sort streams, so these versions simply compare each input tuple to the direct argument tuple, increasing the rank whenever a lower-ranking tuple is seen. To be honest I'm not completely sure why Postgres takes the sorting approach, as it doesn't seem necessary.

However, `dense_rank` is a little more complicated, as it doesn't count peers as increases in rank. For example, given the input `{0, 1, 1, 2}`, `rank(2)` is `4`, whereas `dense_rank(2)` is `3`. Thus `dense_rank` needs to know about every unique lower-ranking tuple that it has seen, because duplicate lower-ranking tuples do not affect the dense rank. For this, HyperLogLog is used.
