### PR TITLE
590 user combines

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1182,6 +1182,7 @@ _copyWindowFunc(const WindowFunc *from)
 	COPY_SCALAR_FIELD(winref);
 	COPY_SCALAR_FIELD(winstar);
 	COPY_SCALAR_FIELD(winagg);
+	COPY_SCALAR_FIELD(winaggkind);
 	COPY_LOCATION_FIELD(location);
 
 	return newnode;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -219,6 +219,7 @@ _equalWindowFunc(const WindowFunc *a, const WindowFunc *b)
 	COMPARE_SCALAR_FIELD(winref);
 	COMPARE_SCALAR_FIELD(winstar);
 	COMPARE_SCALAR_FIELD(winagg);
+	COMPARE_SCALAR_FIELD(winaggkind);
 	COMPARE_LOCATION_FIELD(location);
 
 	return true;

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1011,6 +1011,7 @@ _outWindowFunc(StringInfo str, const WindowFunc *node)
 	WRITE_UINT_FIELD(winref);
 	WRITE_BOOL_FIELD(winstar);
 	WRITE_BOOL_FIELD(winagg);
+	WRITE_CHAR_FIELD(winaggkind);
 	WRITE_LOCATION_FIELD(location);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -525,6 +525,7 @@ _readWindowFunc(void)
 	READ_UINT_FIELD(winref);
 	READ_BOOL_FIELD(winstar);
 	READ_BOOL_FIELD(winagg);
+	READ_CHAR_FIELD(winaggkind);
 	READ_LOCATION_FIELD(location);
 
 	READ_DONE();

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2444,6 +2444,7 @@ eval_const_expressions_mutator(Node *node,
 				newexpr->winref = expr->winref;
 				newexpr->winstar = expr->winstar;
 				newexpr->winagg = expr->winagg;
+				newexpr->winaggkind = expr->winaggkind;
 				newexpr->location = expr->location;
 
 				return (Node *) newexpr;

--- a/src/backend/parser/parse_collate.c
+++ b/src/backend/parser/parse_collate.c
@@ -598,6 +598,7 @@ assign_collations_walker(Node *node, assign_collations_context *context)
 							switch (aggref->aggkind)
 							{
 								case AGGKIND_NORMAL:
+								case AGGKIND_USER_COMBINE:
 									assign_aggregate_collations(aggref,
 																&loccontext);
 									break;

--- a/src/backend/pipeline/cqanalyze.c
+++ b/src/backend/pipeline/cqanalyze.c
@@ -11,18 +11,25 @@
  */
 #include "postgres.h"
 
+#include "access/heapam.h"
 #include "access/htup_details.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_aggregate.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pipeline_combine_fn.h"
 #include "catalog/pipeline_query.h"
 #include "catalog/pipeline_query_fn.h"
+#include "funcapi.h"
 #include "lib/stringinfo.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/print.h"
+#include "optimizer/var.h"
+#include "parser/parse_agg.h"
+#include "parser/parse_expr.h"
 #include "parser/parse_func.h"
 #include "parser/parse_node.h"
+#include "parser/parse_relation.h"
 #include "parser/parse_target.h"
 #include "parser/parse_type.h"
 #include "pipeline/cqanalyze.h"
@@ -31,6 +38,8 @@
 #include "storage/lock.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
 #include "utils/syscache.h"
 
 /*
@@ -47,12 +56,30 @@ static char *StreamingVariants[][2] = {
 		{"count", "hll_count_distinct"}
 };
 
-static void replace_hypothetical_set_aggs(SelectStmt *stmt);
 static char *get_streaming_agg(FuncCall *fn);
 static bool associate_types_to_colrefs(Node *node, CQAnalyzeContext *context);
 static bool type_cast_all_column_refs(Node *node, CQAnalyzeContext *context);
 
 #define INTERNAL_COLNAME_PREFIX "_"
+
+/*
+ * GetHiddenAttrNumber
+ *
+ * Returns the hidden attribute associated with the given
+ * visible column, if any
+ */
+AttrNumber
+GetHiddenAttrNumber(char *attname, TupleDesc matrel)
+{
+	int i;
+	for (i=0; i<matrel->natts; i++)
+	{
+		if (strcmp(NameStr(matrel->attrs[i]->attname), attname) == 0)
+			return i + 1 + 1;
+	}
+
+	return InvalidAttrNumber;
+}
 
 /*
  * GetCombineStateColumnType
@@ -61,18 +88,468 @@ static bool type_cast_all_column_refs(Node *node, CQAnalyzeContext *context);
  * required to store transition states for the given target entry
  */
 Oid
-GetCombineStateColumnType(TargetEntry *te)
+GetCombineStateColumnType(Expr *expr)
 {
 	Oid result = InvalidOid;
 
-	if (IsA(te->expr, Aggref))
-	{
-		Aggref *agg = (Aggref *) te->expr;
-
-		result = GetCombineStateType(agg->aggfnoid);
-	}
+	if (IsA(expr, Aggref))
+		result = GetCombineStateType(((Aggref *) expr)->aggfnoid);
+	else if (IsA(expr, WindowFunc))
+		result = GetCombineStateType(((WindowFunc *) expr)->winfnoid);
 
 	return result;
+}
+
+/*
+ * IsUserCombine
+ *
+ * Determines if the given pg_proc entry is the user combine function
+ */
+bool
+IsUserCombine(NameData proname)
+{
+	return strcmp(NameStr(proname), USER_COMBINE) == 0;
+}
+
+/*
+ * locate_aggs
+ *
+ * Given an analyzed targetlist, maps aggregate nodes to their attributes
+ * in a matrel. This is necessary because aggregates can be hoisted out of
+ * CV expressions and given their own columns, so we can't just look at the
+ * aggregate's position in the targetlist to get its matrel attribute position.
+ *
+ * The mapping is encoding within two parallel lists
+ */
+static void
+locate_aggs(List *targetlist, List **aggs, List **atts)
+{
+	ListCell *lc;
+	AttrNumber pos = 1;
+
+	*aggs = NIL;
+	*atts = NIL;
+
+	foreach(lc, targetlist)
+	{
+		TargetEntry *te = (TargetEntry *) lfirst(lc);
+		Expr *expr = te->expr;
+
+		if (IsA(expr, Aggref) || IsA(expr, WindowFunc))
+		{
+			*aggs = lappend(*aggs, expr);
+			*atts = lappend_int(*atts, pos);
+			pos++;
+			if (OidIsValid(GetCombineStateColumnType(expr)))
+				pos++;
+		}
+		else
+		{
+			List *nodes = pull_var_clause((Node *) expr,
+						PVC_INCLUDE_AGGREGATES, PVC_INCLUDE_PLACEHOLDERS);
+			ListCell *nlc;
+			AttrNumber startpos = pos;
+
+			foreach(nlc, nodes)
+			{
+				Expr *e = (Expr *) lfirst(nlc);
+				if (!IsA(e, Aggref) && !IsA(e, WindowFunc))
+					continue;
+
+				*aggs = lappend(*aggs, e);
+				*atts = lappend_int(*atts, pos);
+				pos++;
+				if (OidIsValid(GetCombineStateColumnType(e)))
+					pos++;
+			}
+
+			if (startpos == pos)
+				pos++;
+		}
+	}
+}
+
+/*
+ * agg_to_attr
+ *
+ * Given an aggregate node, returns the matrel attribute that the node belongs to
+ */
+static AttrNumber
+agg_to_attr(Node *agg, List *aggrefs, List *attrs)
+{
+	ListCell *agglc;
+	ListCell *attlc;
+
+	forboth(agglc, aggrefs, attlc, attrs)
+	{
+		if (lfirst(agglc) == agg)
+			return lfirst_int(attlc);
+	}
+
+	elog(ERROR, "aggregate attribute not found for node of type %d", nodeTag(agg));
+
+	return InvalidAttrNumber;
+}
+
+/*
+ * attr_to_agg
+ *
+ * Given a matrel attribute, returns the aggregate node that it corresponds to
+ */
+static Node *
+attr_to_agg(AttrNumber attr, List *aggs, List *atts)
+{
+	ListCell *agglc;
+	ListCell *attlc;
+
+	forboth(agglc, aggs, attlc, atts)
+	{
+		if (lfirst_int(attlc) == attr)
+			return lfirst(agglc);
+	}
+
+	elog(ERROR, "no aggregate node found for attribute %d", attr);
+
+	return NULL;
+}
+
+/*
+ * make_combine_args
+ *
+ * Possibly wraps the target argument in a recv function call to deserialize
+ * hidden state before calling combine()
+ */
+static List *
+make_combine_args(ParseState *pstate, Oid combineinfn, Var *var)
+{
+	List *args;
+
+	if (OidIsValid(combineinfn))
+	{
+		FuncCall *fn = makeNode(FuncCall);
+		fn->funcname = list_make1(makeString(get_func_name(combineinfn)));
+		fn->args = list_make1(var);
+		args = list_make1(transformFuncCall(pstate, fn));
+	}
+	else
+	{
+		/* transition state is stored as a first-class type, no deserialization needed */
+		args = list_make1(var);
+	}
+
+	return args;
+}
+
+/*
+ * make_combine_agg_for_viewdef
+ *
+ * Creates a combine aggregate for a view definition against a matrel
+ */
+static Node *
+make_combine_agg_for_viewdef(ParseState *pstate, RangeVar *cvrv, Var *var,
+		 List *order, WindowDef *over)
+{
+	List *aggs;
+	List *atts;
+	List *args;
+	Node *result;
+	Oid fnoid;
+	Oid combinefn;
+	Oid combineinfn;
+	Oid statetype;
+	Query *q = GetContinuousQuery(cvrv);
+
+	locate_aggs(q->targetList, &aggs, &atts);
+
+	result = attr_to_agg(var->varattno, aggs, atts);
+
+	if (IsA(result, Aggref))
+	{
+		Aggref *agg = (Aggref *) result;
+
+		agg->aggkind = AGGKIND_USER_COMBINE;
+		fnoid = agg->aggfnoid;
+	}
+	else
+	{
+		WindowFunc *w = (WindowFunc *) result;
+
+		w->winaggkind = AGGKIND_USER_COMBINE;
+		fnoid = w->winfnoid;
+	}
+
+	GetCombineInfo(fnoid, &combinefn, &combineinfn, &statetype);
+
+	/* combine state is always adjacent to its visible column */
+	if (OidIsValid(statetype))
+	{
+		var->varattno++;
+		var->vartype = statetype;
+	}
+
+	args = make_combine_args(pstate, combineinfn, var);
+
+	if (IsA(result, Aggref))
+	{
+		transformAggregateCall(pstate, (Aggref *) result, args, order, false);
+	}
+	else
+	{
+		((WindowFunc *) result)->args = args;
+		transformWindowFuncCall(pstate, (WindowFunc *) result, over);
+	}
+
+	return (Node *) result;
+}
+
+/*
+ * combine_target_belongs_to_cv
+ *
+ * Verify that the given combine target actually belongs to a continuous view.
+ * This allows us to run combines on complex range tables such as joins, as long
+ * as the target combine column is from a CV.
+ */
+static bool
+combine_target_belongs_to_cv(Var *target, List *rangetable, RangeVar **cv)
+{
+	RangeTblEntry *targetrte;
+	ListCell *lc;
+	Value *colname;
+
+	if (list_length(rangetable) < target->varno)
+	{
+		elog(ERROR, "range table entry %d not in range table of length %d",
+				target->varno, list_length(rangetable));
+	}
+
+	targetrte = (RangeTblEntry *) list_nth(rangetable, target->varno - 1);
+
+	if (list_length(targetrte->eref->colnames) < target->varattno)
+	{
+		elog(ERROR, "attribute %d not column list of length %d",
+						target->varattno, list_length(targetrte->eref->colnames));
+	}
+
+	colname = (Value *) list_nth(targetrte->eref->colnames, target->varattno - 1);
+
+	foreach(lc, rangetable)
+	{
+		ListCell *clc;
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+
+		if (rte->relkind != RELKIND_VIEW)
+			continue;
+
+		foreach(clc, rte->eref->colnames)
+		{
+			Value *c = (Value *) lfirst(clc);
+			Relation rel;
+			RangeVar *rv;
+			char *cvname;
+
+			if (!equal(colname, c))
+				continue;
+
+			/*
+			 * The view contains a column name that matches the target column,
+			 * so we just need to verify that it's actually a continuous view.
+			 */
+			rel = heap_open(rte->relid, NoLock);
+			cvname = RelationGetRelationName(rel);
+			relation_close(rel, NoLock);
+			rv = makeRangeVar(NULL, cvname, -1);
+
+			if (IsAContinuousView(rv))
+			{
+				*cv = rv;
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/*
+ * find_attr_from_joinlist
+ *
+ * Given a join list and a variable within it, finds the attribute position of that variable
+ * in its matrel's descriptor.
+ *
+ * This also sets the given Var's varno to the varno of the continuous view RTE in the range
+ * table, because it simplifies things if we're not selecting directly from the messy join RTE.
+ */
+static AttrNumber
+find_attr_from_joinlist(ParseState *pstate, RangeVar *cvrv, RangeTblEntry *joinrte, Var *var)
+{
+	RangeTblEntry *cvrte;
+	ListCell *lc;
+	Value *colname = (Value *) list_nth(joinrte->eref->colnames, var->varattno - 1);
+	Oid relid = RangeVarGetRelid(cvrv, NoLock, false);
+	int i = 0;
+	int varno = 0;
+
+	foreach(lc, pstate->p_rtable)
+	{
+		varno++;
+		cvrte = (RangeTblEntry *) lfirst(lc);
+		if (cvrte->relid == relid)
+			break;
+	}
+
+	foreach(lc, cvrte->eref->colnames)
+	{
+		Value *c = (Value *) lfirst(lc);
+		i++;
+		if (equal(colname, c))
+		{
+			var->varno = varno;
+			return i;
+		}
+	}
+
+	elog(ERROR, "could not find column \"%s\" in continuous view range table entry", strVal(colname));
+
+	return InvalidAttrNumber;
+}
+
+/*
+ * ParseCombineFuncCall
+ *
+ * Builds an expression for a combine() call on an aggregate CV column.
+ * This may involve deserializing the column transition state.
+ */
+Node *
+ParseCombineFuncCall(ParseState *pstate, List *fargs,
+		List *order, Expr *filter, WindowDef *over, int location)
+{
+	Node *arg;
+	ListCell *lc;
+	Var *var;
+	List *args;
+	Oid combinefn;
+	Oid combineinfn;
+	Oid statetype;
+	RangeVar *rv;
+	bool ismatrel;
+	Query *q;
+	TargetEntry *target;
+	List *nodes;
+	List *aggs;
+	List *atts;
+	RangeTblEntry *rte;
+	AttrNumber cvatt = InvalidAttrNumber;
+
+	if (list_length(fargs) != 1)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+				 errmsg("combine called with %d arguments", list_length(fargs)),
+				 errhint("combine must be called with a single column reference as its argument.")));
+	}
+
+	arg = linitial(fargs);
+
+	if (!IsA(arg, Var))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+				 errmsg("combine called with an invalid expression"),
+				 errhint("combine must be called with a single column reference as its argument.")));
+	}
+
+	var = (Var *) arg;
+
+	if (!combine_target_belongs_to_cv(var, pstate->p_rtable, &rv))
+	{
+		RangeVar *matrelrv;
+		RangeVar *cvrv;
+		Relation rel;
+		RangeTblEntry *rte = list_nth(pstate->p_rtable, var->varno - 1);
+
+		rel = heap_open(rte->relid, NoLock);
+		matrelrv = makeRangeVar(NULL, RelationGetRelationName(rel), -1);
+		relation_close(rel, NoLock);
+
+		/*
+		 * Sliding-window CQ's use combine aggregates in their
+		 * view definition, so when they're created we can also
+		 * end up here. We do this check second because it's slow.
+		 */
+		ismatrel = IsAMatRel(matrelrv, &cvrv);
+		if (!ismatrel)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+					 errmsg("\"%s\" is not a continuous view", matrelrv->relname),
+					 errhint("Only aggregate continuous view columns can be combined.")));
+		}
+
+		return make_combine_agg_for_viewdef(pstate, cvrv, var, order, over);
+	}
+
+	/* ok, it's a user combine query against an existing continuous view */
+	q = GetContinuousQuery(rv);
+	locate_aggs(q->targetList, &aggs, &atts);
+
+	rte = (RangeTblEntry *) list_nth(pstate->p_rtable, var->varno - 1);
+	cvatt = var->varattno;
+	/*
+	 * If this is a join, our varattno will point to the position of the target
+	 * combine column within the joined target list, so we need to pull out the
+	 * table-level var that will point us to the CQ's target list
+	 */
+	if (rte->rtekind == RTE_JOIN)
+		cvatt = find_attr_from_joinlist(pstate, rv, rte, var);
+
+	/*
+	 * Find the aggregate node in the CQ that corresponds
+	 * to the target combine column
+	 */
+	target = (TargetEntry *) list_nth(q->targetList, cvatt - 1);
+	nodes = pull_var_clause((Node *) target->expr,
+			PVC_INCLUDE_AGGREGATES, PVC_INCLUDE_PLACEHOLDERS);
+
+	foreach(lc, nodes)
+	{
+		Node *n = (Node *) lfirst(lc);
+		Var *v;
+		AttrNumber att;
+		Oid fnoid;
+
+		if (IsA(n, Aggref))
+			fnoid = ((Aggref *) n)->aggfnoid;
+		else if (IsA(n, WindowFunc))
+			fnoid = ((WindowFunc *) n)->winfnoid;
+		else
+			continue;
+
+		GetCombineInfo(fnoid, &combinefn, &combineinfn, &statetype);
+
+		/* combine state is always adjacent to its visible column */
+		att = agg_to_attr(n, aggs, atts);
+		if (OidIsValid(statetype))
+			att++;
+
+		v = makeVar(var->varno, att, statetype, InvalidOid, InvalidOid, InvalidOid);
+		args = make_combine_args(pstate, combineinfn, v);
+
+		if (IsA(n, Aggref))
+		{
+			Aggref *agg = (Aggref *) n;
+			agg->aggkind = AGGKIND_USER_COMBINE;
+			transformAggregateCall(pstate, agg, args, order, false);
+		}
+		else if (IsA(n, WindowFunc))
+		{
+			WindowFunc *w = (WindowFunc *) n;
+			w->args = args;
+			w->winaggkind = AGGKIND_USER_COMBINE;
+			transformWindowFuncCall(pstate, w, over);
+		}
+	}
+
+	return copyObject((Node *) target->expr);
 }
 
 /*
@@ -155,7 +632,7 @@ GetUniqueInternalColname(CQAnalyzeContext *context)
 }
 
 /*
- * is_column_ref
+ * IsAColumnRef
  */
 bool
 IsAColumnRef(Node *node)
@@ -187,6 +664,7 @@ FindColumnRefsWithTypeCasts(Node *node, CQAnalyzeContext *context)
 	}
 	else if (IsA(node, ColumnRef))
 	{
+
 		context->cols = lappend(context->cols, node);
 	}
 
@@ -510,14 +988,14 @@ get_streaming_agg(FuncCall *fn)
 }
 
 /*
- * replace_hypothetical_set_aggs
+ * RewriteStreamingAggs
  *
  * Replaces hypothetical set aggregate functions with their streaming
  * variants if possible, since we can't use the sorting approach that
  * the standard functions use.
  */
-static void
-replace_hypothetical_set_aggs(SelectStmt *stmt)
+void
+RewriteStreamingAggs(SelectStmt *stmt)
 {
 	ListCell *lc;
 
@@ -584,6 +1062,9 @@ GetSelectStmtForCQWorker(SelectStmt *stmt, SelectStmt **viewstmtptr)
 	int origNumGroups;
 	int i;
 	ListCell *lc;
+	ResTarget *timeRes;
+	AttrNumber timeAttr;
+	AttrNumber curAttr;
 
 	InitializeCQAnalyzeContext(stmt, NULL, &context);
 	associate_types_to_colrefs((Node *) stmt, &context);
@@ -605,14 +1086,14 @@ GetSelectStmtForCQWorker(SelectStmt *stmt, SelectStmt **viewstmtptr)
 	 * so that we can perform the necessary windowing functionality.
 	 */
 	if (isSlidingWindow || doesViewAggregate)
-		AddProjectionsAndGroupBysForWindows(workerstmt, viewstmt, doesViewAggregate, &context);
+		timeRes = AddProjectionsAndGroupBysForWindows(workerstmt, viewstmt, doesViewAggregate, &context, &timeAttr);
 
 	/*
 	 * We can't use the standard hypothetical set aggregate functions because
 	 * they require sorting the input set, so replace them with their
 	 * streaming variants if possible.
 	 */
-	replace_hypothetical_set_aggs(workerstmt);
+	RewriteStreamingAggs(workerstmt);
 
 	/*
 	 * Rewrite the groupClause and project any group expressions that
@@ -704,6 +1185,7 @@ GetSelectStmtForCQWorker(SelectStmt *stmt, SelectStmt **viewstmtptr)
 	 * Any WINDOWing cruft should be removed from the worker statement
 	 * and only left in the view stmt.
 	 */
+	curAttr = 1;
 	workerstmt->targetList = NIL;
 	foreach(lc, workerTargetList)
 	{
@@ -715,8 +1197,25 @@ GetSelectStmtForCQWorker(SelectStmt *stmt, SelectStmt **viewstmtptr)
 			fcall->over = NULL;
 		}
 
+		/*
+		 * If applicable, put the time-based ResTarget where it
+		 * originated in the original target list to maintain order
+		 * between the input target list and the columns of the matrel
+		 * we'll ultimately create.
+		 */
+		if (curAttr == timeAttr)
+		{
+			workerstmt->targetList = lappend(workerstmt->targetList, timeRes);
+			curAttr++;
+		}
+
 		workerstmt->targetList = lappend(workerstmt->targetList, res);
+		curAttr++;
 	}
+
+	/* time ResTarget wasn't in the target list, so just add it on to the end */
+	if (!AttributeNumberIsValid(timeAttr))
+		workerstmt->targetList = lappend(workerstmt->targetList, timeRes);
 
 	viewstmt->windowClause = workerstmt->windowClause;
 	workerstmt->windowClause = NIL;
@@ -1071,6 +1570,21 @@ CollectFuncs(Node *node, CQAnalyzeContext *context)
 }
 
 /*
+ * CollectAggrefs
+ */
+bool
+CollectAggrefs(Node *node, CQAnalyzeContext *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Aggref))
+		context->funcCalls = lappend(context->funcCalls, node);
+
+	return raw_expression_tree_walker(node, CollectAggrefs, (void *) context);
+}
+
+/*
  * AnalyzeAndValidateContinuousSelectStmt
  *
  * This is mainly to prepare a CV SELECT's FROM clause, which may involve streams
@@ -1332,4 +1846,84 @@ pipeline_rewrite(List *raw_parsetree_list)
 	}
 
 	return raw_parsetree_list;
+}
+
+/*
+ * RewriteContinuousViewSelect
+ *
+ * Possibly modify a continuous view's SELECT rule before it's applied.
+ * This is mainly used for including hidden columns in the view's subselect
+ * query when they are needed by functions in the target list.
+ */
+Query *
+RewriteContinuousViewSelect(Query *query, Query *rule, Relation cv)
+{
+	RangeVar *rv = makeRangeVar(NULL, RelationGetRelationName(cv), -1);
+	ListCell *lc;
+	List *targets = NIL;
+	List *targetlist = NIL;
+	AttrNumber matrelvarno = InvalidAttrNumber;
+	TupleDesc matreldesc;
+	bool needshidden = false;
+	char *matrelname;
+	int i;
+
+	/* try to bail early because this gets called from a hot path */
+	if (!IsAContinuousView(rv))
+		return rule;
+
+	matrelname = GetMatRelationName(RelationGetRelationName(cv));
+	matreldesc = RelationNameGetTupleDesc(matrelname);
+
+	targets = pull_var_clause((Node *) rule->targetList,
+			PVC_RECURSE_AGGREGATES, PVC_INCLUDE_PLACEHOLDERS);
+
+	foreach(lc, targets)
+	{
+		Node *n = (Node *) lfirst(lc);
+		if (IsA(n, Var))
+		{
+			matrelvarno = ((Var *) n)->varno;
+			break;
+		}
+	}
+
+	/* is there anything to do? */
+	if (!AttributeNumberIsValid(matrelvarno))
+		return rule;
+
+	targets = pull_var_clause((Node *) query->targetList,
+			PVC_INCLUDE_AGGREGATES, PVC_INCLUDE_PLACEHOLDERS);
+
+	/* pull out all the user combine aggregates */
+	foreach(lc, targets)
+	{
+		Node *n = (Node *) lfirst(lc);
+		if (IsA(n, Aggref) && AGGKIND_IS_USER_COMBINE(((Aggref *) n)->aggkind))
+		{
+			needshidden = true;
+			break;
+		}
+	}
+
+	if (!needshidden)
+		return rule;
+
+	/* we have user combines, so expose hidden columns */
+	for (i=0; i<matreldesc->natts; i++)
+	{
+		Var *tev;
+		TargetEntry *te;
+		Form_pg_attribute attr = matreldesc->attrs[i];
+
+		tev = makeVar(matrelvarno, attr->attnum, attr->atttypid,
+				attr->atttypmod, attr->attcollation, 0);
+
+		te = makeTargetEntry((Expr *) tev, tev->varattno, NULL, false);
+		targetlist = lappend(targetlist, te);
+	}
+
+	rule->targetList = targetlist;
+
+	return rule;
 }

--- a/src/backend/pipeline/cqplan.c
+++ b/src/backend/pipeline/cqplan.c
@@ -148,7 +148,7 @@ SetCQPlanRefs(PlannedStmt *pstmt, char* matrelname)
 		if (IsA(expr, Aggref))
 		{
 			Aggref *aggref = (Aggref *) expr;
-			Oid hiddentype = GetCombineStateColumnType(te);
+			Oid hiddentype = GetCombineStateColumnType(te->expr);
 			AttrNumber hidden = 0;
 			Oid transtype;
 

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -22,6 +22,7 @@
 #include "parser/analyze.h"
 #include "parser/parse_coerce.h"
 #include "parser/parsetree.h"
+#include "pipeline/cqanalyze.h"
 #include "pipeline/stream.h"
 #include "rewrite/rewriteDefine.h"
 #include "rewrite/rewriteHandler.h"
@@ -1443,6 +1444,13 @@ ApplyRetrieveRule(Query *parsetree,
 	 * Recursively expand any view references inside the view.
 	 */
 	rule_action = fireRIRrules(rule_action, activeRIRs, forUpdatePushedDown);
+
+	/*
+	 * If we're selecting from a continuous view, some functions in the
+	 * target list may need access to columns that aren't in the view's
+	 * target list.
+	 */
+	RewriteContinuousViewSelect(parsetree, rule_action, relation);
 
 	/*
 	 * Now, plug the view query in as a subselect, replacing the relation's

--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -1511,8 +1511,17 @@ Datum
 arrayaggstaterecv(PG_FUNCTION_ARGS)
 {
 	ArrayType *vals = (ArrayType *) PG_GETARG_ARRAYTYPE_P(0);
-	ArrayBuildState *result = (ArrayBuildState *) palloc0(sizeof(ArrayBuildState));
+	ArrayBuildState *result;
 
+	MemoryContext old;
+	MemoryContext context;
+
+	if (!AggCheckCallContext(fcinfo, &context))
+		context = fcinfo->flinfo->fn_mcxt;
+
+	old = MemoryContextSwitchTo(context);
+
+	result = (ArrayBuildState *) palloc0(sizeof(ArrayBuildState));
 	result->mcontext = CurrentMemoryContext;
 	result->element_type = ARR_ELEMTYPE(vals);
 
@@ -1526,6 +1535,8 @@ arrayaggstaterecv(PG_FUNCTION_ARGS)
 			&result->dvalues, &result->dnulls, &result->nelems);
 
 	result->alen = result->nelems;
+
+	MemoryContextSwitchTo(old);
 
 	PG_RETURN_POINTER(result);
 }

--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -2067,58 +2067,6 @@ json_object_agg_combine(PG_FUNCTION_ARGS)
 }
 
 /*
- * json_agg parse and combine function
- */
-Datum
-json_agg_pcombine(PG_FUNCTION_ARGS)
-{
-	MemoryContext aggcontext;
-	Datum arg0;
-	Datum result;
-
-	if (!AggCheckCallContext(fcinfo, &aggcontext))
-		elog(ERROR, "json_agg_pcombine called in non-aggregate context");
-
-	arg0 = PG_ARGISNULL(0) ? (Datum) makeStringInfo() :(Datum) PG_GETARG_POINTER(0);
-
-	fcinfo->arg[0] = (Datum) PG_GETARG_POINTER(1);
-	fcinfo->nargs = 1;
-	fcinfo->arg[1] = byteatostringinfo(fcinfo);
-	fcinfo->arg[0] = arg0;
-	fcinfo->nargs = 2;
-
-	result = json_agg_combine(fcinfo);
-
-	PG_RETURN_POINTER(result);
-}
-
-/*
- * json_object_agg parse and combine function
- */
-Datum
-json_object_agg_pcombine(PG_FUNCTION_ARGS)
-{
-	MemoryContext aggcontext;
-	Datum arg0;
-	Datum result;
-
-	if (!AggCheckCallContext(fcinfo, &aggcontext))
-		elog(ERROR, "json_agg_pcombine called in non-aggregate context");
-
-	arg0 = PG_ARGISNULL(0) ? (Datum) makeStringInfo() :(Datum) PG_GETARG_POINTER(0);
-
-	fcinfo->arg[0] = (Datum) PG_GETARG_POINTER(1);
-	fcinfo->nargs = 1;
-	fcinfo->arg[1] = byteatostringinfo(fcinfo);
-	fcinfo->arg[0] = arg0;
-	fcinfo->nargs = 2;
-
-	result = json_object_agg_combine(fcinfo);
-
-	PG_RETURN_POINTER(result);
-}
-
-/*
  * SQL function json_build_object(variadic "any")
  */
 Datum

--- a/src/backend/utils/adt/varlena.c
+++ b/src/backend/utils/adt/varlena.c
@@ -3769,10 +3769,7 @@ makeStringAggState(FunctionCallInfo fcinfo)
 	MemoryContext oldcontext;
 
 	if (!AggCheckCallContext(fcinfo, &aggcontext))
-	{
-		/* cannot be called directly because of internal-type argument */
-		elog(ERROR, "string_agg_transfn called in non-aggregate context");
-	}
+		aggcontext = fcinfo->flinfo->fn_mcxt;
 
 	/*
 	 * Create state in aggregate context.  It'll stay there across subsequent
@@ -3889,31 +3886,6 @@ string_agg_combine(PG_FUNCTION_ARGS)
 		appendStringInfoString(state->buf, incoming->buf->data);
 
 	PG_RETURN_POINTER(state);
-}
-
-/*
- * Parse and concatenate two delimited strings
- */
-Datum
-string_agg_pcombine(PG_FUNCTION_ARGS)
-{
-	Datum arg0;
-	Datum result;
-
-	if (!AggCheckCallContext(fcinfo, NULL))
-			elog(ERROR, "aggregate function called in non-aggregate context");
-
-	arg0 = PG_ARGISNULL(0) ? (Datum) makeStringAggState(fcinfo) : (Datum) PG_GETARG_POINTER(0);
-
-	fcinfo->arg[0] = (Datum) PG_GETARG_POINTER(1);
-	fcinfo->nargs = 1;
-	fcinfo->arg[1] = stringaggstaterecv(fcinfo);
-	fcinfo->arg[0] = arg0;
-	fcinfo->nargs = 2;
-
-	result = string_agg_combine(fcinfo);
-
-	PG_RETURN_POINTER(result);
 }
 
 Datum

--- a/src/include/catalog/pg_aggregate.h
+++ b/src/include/catalog/pg_aggregate.h
@@ -123,11 +123,13 @@ typedef FormData_pg_aggregate *Form_pg_aggregate;
  * aggregation overhead.
  */
 #define AGGKIND_STORE 's'
+#define AGGKIND_USER_COMBINE 'c'
 
 #define AGGKIND_IS_STORE(kind) ((kind) == AGGKIND_STORE)
+#define AGGKIND_IS_USER_COMBINE(kind) ((kind) == AGGKIND_USER_COMBINE)
 
 /* Use this macro to test for "ordered-set agg including hypothetical case" */
-#define AGGKIND_IS_ORDERED_SET(kind)  ((kind) != AGGKIND_NORMAL)
+#define AGGKIND_IS_ORDERED_SET(kind)  ((kind) != AGGKIND_NORMAL && (kind) != AGGKIND_USER_COMBINE)
 
 
 /* ----------------
@@ -308,76 +310,12 @@ DATA(insert ( 3988	h 1 ordered_set_transition_multi	percent_rank_final						-		-
 DATA(insert ( 3990	h 1 ordered_set_transition_multi	cume_dist_final							-		-		-		t f 0	2281	0	0		0	_null_ _null_ ));
 DATA(insert ( 3992	h 1 ordered_set_transition_multi	dense_rank_final						-		-		-		t f 0	2281	0	0		0	_null_ _null_ ));
 
-/* PipelineDB Sliding Window Aggregates */
-
-/* avg */
-DATA(insert ( 4322	n 0 numeric_pcombine numeric_avg 	-				-				-				f f 0	2281	128 0		0	_null_ _null_ ));
-DATA(insert ( 4323	n 0 int_avg_combine int8_avg	 	-				-				-				f f 0	1016	128 0		0	"{0,0}" _null_ ));
-DATA(insert ( 4324	n 0 float8_combine  float8_avg	 	-				-				-				f f 0	1022	128 0		0	"{0,0,0}" _null_ ));
-DATA(insert ( 4325	n 0 interval_combine interval_avg 	-				-				-				f f 0	1187	128 0		0	"{0 second,0 second}" _null_ ));
-
-/* sum */
-DATA(insert ( 4326	n 0 numeric_pcombine numeric_sum 	-				-				-				f f 0	2281	128 0		0	_null_ _null_ ));
-
-/* array */
-DATA(insert ( 4328	n 0 array_agg_pcombine array_agg_finalfn 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-
-/* text */
-DATA(insert ( 4330	n 0 string_agg_pcombine string_agg_finalfn 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4331	n 0 string_agg_pcombine bytea_string_agg_finalfn 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-
-/* json */
-DATA(insert ( 4332	n 0 json_agg_pcombine json_agg_finalfn 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4333	n 0 json_object_agg_pcombine json_object_agg_finalfn 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-
-/* binary regression aggregates */
-DATA(insert ( 4336	n 0 float8_regr_combine float8_regr_sxx 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4337	n 0 float8_regr_combine float8_regr_syy 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4338	n 0 float8_regr_combine float8_regr_sxy 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4339	n 0 float8_regr_combine float8_regr_avgx 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4340	n 0 float8_regr_combine float8_regr_avgy 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4341	n 0 float8_regr_combine float8_regr_r2 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4342	n 0 float8_regr_combine float8_regr_slope 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4343	n 0 float8_regr_combine float8_regr_intercept 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4344	n 0 float8_regr_combine float8_covar_pop 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4345	n 0 float8_regr_combine float8_covar_samp 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4346	n 0 float8_regr_combine float8_corr 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-
-/* var_pop */
-DATA(insert ( 4347	n 0 numeric_pcombine numeric_var_pop 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4348	n 0 float8_combine float8_var_pop 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-
-/* var_samp / variance (same thing) */
-DATA(insert ( 4349	n 0 numeric_pcombine numeric_var_samp 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4350	n 0 float8_combine float8_var_samp 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4351	n 0 numeric_pcombine numeric_var_samp 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4352	n 0 float8_combine float8_var_samp 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-
-/* stddev_pop */
-DATA(insert ( 4353	n 0 numeric_pcombine numeric_stddev_pop 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4354	n 0 float8_combine float8_stddev_pop 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-
-/* stddev_samp / stddev (same thing) */
-DATA(insert ( 4355	n 0 numeric_pcombine numeric_stddev_samp 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4356	n 0 float8_combine float8_stddev_samp 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-DATA(insert ( 4357	n 0 numeric_pcombine numeric_stddev_samp 	-				-				-				f f 0	2281	0 0		0	_null_ _null_ ));
-DATA(insert ( 4358	n 0 float8_combine float8_stddev_samp 	-				-				-				f f 0	1022	0 0		0	_null_ _null_ ));
-
 /* PipelineDB streaming hypothetical-set aggregates */
 DATA(insert ( 3999	h 1 cq_hypothetical_set_transition_multi	cq_rank_final	-	-	-	t f 0	1016	0	0	0	_null_ _null_ ));
-DATA(insert ( 5000	n 0 cq_hypothetical_set_pcombine	cq_rank_final	-	-	-	f f 0	1016	0	0	0	_null_ _null_ ));
-
 DATA(insert ( 5002	h 1 cq_hypothetical_set_transition_multi	cq_percent_rank_final	-	-	-	t f 0	1016	0	0	0	_null_ _null_ ));
-DATA(insert ( 5003	n 0 cq_hypothetical_set_pcombine	cq_percent_rank_final	-	-	-	f f 0	1016	0	0	0	_null_ _null_ ));
-
 DATA(insert ( 5005	h 1 cq_hypothetical_set_transition_multi	cq_cume_dist_final	-	-	-	t f 0	1016	0	0	0	_null_ _null_ ));
-DATA(insert ( 5006	n 0 cq_hypothetical_set_pcombine	cq_cume_dist_final	-	-	-	f f 0	1016	0	0	0	_null_ _null_ ));
-
 DATA(insert ( 5011	h 1 hll_hypothetical_set_transition_multi	hll_dense_rank_final	-	-	-	t f 0	2281	0	0	0	_null_ _null_ ));
-DATA(insert ( 5012	n 0 hll_hypothetical_set_pcombine	hll_dense_rank_final	-	-	-	f f 0	2281	0	0	0	_null_ _null_ ));
-
 DATA(insert ( 5014	n 0 hll_count_distinct_transition	hll_count_distinct_final	-	-	-	t f 0	2281	0	0	0	_null_ _null_ ));
-DATA(insert ( 5015	n 0 hll_count_distinct_pcombine	hll_count_distinct_final	-	-	-	f f 0	2281	0	0	0	_null_ _null_ ));
 
 /*
  * prototypes for functions in pg_aggregate.c

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5034,33 +5034,25 @@ DESCR("aggregate final function");
 /* PipelineDB streaming hypothetical-set aggregates */
 DATA(insert OID = 3994 (hllsend PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 17 "2281" _null_ _null_ _null_ _null_ hllsend _null_ _null_ _null_ ));
 DESCR("serializer for HyperLogLog aggregation transition states");
-DATA(insert OID = 3995 (hllrecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2281" _null_ _null_ _null_ _null_ hllrecv _null_ _null_ _null_ ));
+DATA(insert OID = 3995 (hllrecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "17" _null_ _null_ _null_ _null_ hllrecv _null_ _null_ _null_ ));
 DESCR("deserializer for HyperLogLog aggregation transition states");
 
 DATA(insert OID = 3996 ( cq_hypothetical_set_transition_multi	PGNSP PGUID 12 1 0 2276 0 f f f f f f i 2 0 1016 "1016 2276" "{1016,2276}" "{i,v}" _null_ _null_ cq_hypothetical_set_transition_multi _null_ _null_ _null_ ));
 DESCR("aggregate transition function");
 DATA(insert OID = 3997 ( cq_hypothetical_set_combine_multi	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 1016 "1016 1016" _null_ _null_ _null_ _null_ cq_hypothetical_set_combine_multi _null_ _null_ _null_ ));
 DESCR("aggregate combination function");
-DATA(insert OID = 3998 ( cq_hypothetical_set_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 1016 "1016 1016" _null_ _null_ _null_ _null_ cq_hypothetical_set_pcombine _null_ _null_ _null_ ));
-DESCR("aggregate parse and combine function");
 
 DATA(insert OID = 3999 ( cq_rank				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 20 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("rank of hypothetical row, using hyperloglog");
-DATA(insert OID = 5000 ( cq_rank				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 20 "1016 20" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
 DESCR("rank of hypothetical row, using hyperloglog");
 DATA(insert OID = 5001 ( cq_rank_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 20 "1016 2276" _null_ _null_ _null_ _null_	cq_hypothetical_rank_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
 
 DATA(insert OID = 5002 ( cq_percent_rank				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 701 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
 DESCR("rank of hypothetical row, using hyperloglog");
-DATA(insert OID = 5003 ( cq_percent_rank				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1016 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("rank of hypothetical row, using hyperloglog");
 DATA(insert OID = 5004 ( cq_percent_rank_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 701 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	cq_hypothetical_percent_rank_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
 
 DATA(insert OID = 5005 ( cq_cume_dist				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 701 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("rank of hypothetical row, using hyperloglog");
-DATA(insert OID = 5006 ( cq_cume_dist				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1016 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
 DESCR("rank of hypothetical row, using hyperloglog");
 DATA(insert OID = 5007 ( cq_cume_dist_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 701 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	cq_hypothetical_cume_dist_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
@@ -5069,12 +5061,8 @@ DATA(insert OID = 5008 ( hll_hypothetical_set_transition_multi	PGNSP PGUID 12 1 
 DESCR("aggregate transition function");
 DATA(insert OID = 5009 ( hll_hypothetical_set_combine_multi	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2281" _null_ _null_ _null_ _null_ hll_hypothetical_set_combine_multi _null_ _null_ _null_ ));
 DESCR("aggregate combination function");
-DATA(insert OID = 5010 ( hll_hypothetical_set_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_ hll_hypothetical_set_pcombine _null_ _null_ _null_ ));
-DESCR("aggregate parse and combine function");
 
 DATA(insert OID = 5011 ( hll_dense_rank				PGNSP PGUID 12 1 0 2276 0 t f f f f f i 1 0 20 "2276" "{2276}" "{v}" _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("rank of hypothetical row, using hyperloglog");
-DATA(insert OID = 5012 ( hll_dense_rank				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 20 "17 20" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
 DESCR("rank of hypothetical row, using hyperloglog");
 DATA(insert OID = 5013 ( hll_dense_rank_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 20 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_	hll_hypothetical_dense_rank_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
@@ -5082,14 +5070,10 @@ DESCR("aggregate final function");
 /* streaming count distinct using HyperLogLog */
 DATA(insert OID = 5014 ( hll_count_distinct				PGNSP PGUID 12 1 0 0 0 t f f f f f i 1 0 20 "2276" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
 DESCR("distinct count, using hyperloglog");
-DATA(insert OID = 5015 ( hll_count_distinct				PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 20 "17 20" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("distinct count, using hyperloglog");
 DATA(insert OID = 5016 ( hll_count_distinct_transition	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2276" "{2281,2276}" "{i,v}" _null_ _null_ hll_count_distinct_transition _null_ _null_ _null_ ));
 DESCR("aggregate transition function");
 DATA(insert OID = 5017 ( hll_count_distinct_combine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2281" _null_ _null_ _null_ _null_ hll_count_distinct_combine _null_ _null_ _null_ ));
 DESCR("aggregate combination function");
-DATA(insert OID = 5018 ( hll_count_distinct_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_ hll_count_distinct_pcombine _null_ _null_ _null_ ));
-DESCR("aggregate parse and combine function");
 DATA(insert OID = 5019 ( hll_count_distinct_final			PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 20 "2281" _null_ _null_ _null_ _null_	hll_count_distinct_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
 
@@ -5108,12 +5092,12 @@ DATA(insert OID = 4307 ( float8_regr_combine	PGNSP PGUID 12 1 0 0 0 f f f f t f 
 DESCR("REGR_...(double, double) combination function");
 
 /* Transition result serialization/deserialization functions */
-DATA(insert OID = 4308 (naggstaterecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2281" _null_ _null_ _null_ _null_ naggstaterecv _null_ _null_ _null_ ));
+DATA(insert OID = 4308 (naggstaterecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "17" _null_ _null_ _null_ _null_ naggstaterecv _null_ _null_ _null_ ));
 DESCR("deserializer for numeric aggregation transition states");
 DATA(insert OID = 4309 (naggstatesend PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 17 "2281" _null_ _null_ _null_ _null_ naggstatesend _null_ _null_ _null_ ));
 DESCR("serializer for numeric aggregation transition states");
 
-DATA(insert OID = 4310 (arrayaggstaterecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2281" _null_ _null_ _null_ _null_ arrayaggstaterecv _null_ _null_ _null_ ));
+DATA(insert OID = 4310 (arrayaggstaterecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2277" _null_ _null_ _null_ _null_ arrayaggstaterecv _null_ _null_ _null_ ));
 DESCR("deserializer for array aggregation transition states");
 DATA(insert OID = 4311 (arrayaggstatesend PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 17 "2281" _null_ _null_ _null_ _null_ arrayaggstatesend _null_ _null_ _null_ ));
 DESCR("serializer for array aggregation transition states");
@@ -5121,7 +5105,7 @@ DESCR("serializer for array aggregation transition states");
 DATA(insert OID = 4312 ( array_agg_combine	PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 2281 "2281 2281" _null_ _null_ _null_ _null_ array_agg_combine _null_ _null_ _null_ ));
 DESCR("array aggregation combination function");
 
-DATA(insert OID = 4313 (byteatostringinfo PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2281" _null_ _null_ _null_ _null_ byteatostringinfo _null_ _null_ _null_ ));
+DATA(insert OID = 4313 (byteatostringinfo PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "17" _null_ _null_ _null_ _null_ byteatostringinfo _null_ _null_ _null_ ));
 DESCR("deserializer for string aggregation transition states");
 
 DATA(insert OID = 4314 (json_agg_combine PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2281" _null_ _null_ _null_ _null_ json_agg_combine _null_ _null_ _null_ ));
@@ -5135,119 +5119,12 @@ DESCR("string aggregation combination function");
 
 DATA(insert OID = 4319 (stringaggstatesend PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 17 "2281" _null_ _null_ _null_ _null_ stringaggstatesend _null_ _null_ _null_ ));
 DESCR("deserializer for string aggregation transition states");
-DATA(insert OID = 4320 (stringaggstaterecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "2281" _null_ _null_ _null_ _null_ stringaggstaterecv _null_ _null_ _null_ ));
+DATA(insert OID = 4320 (stringaggstaterecv PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2281 "17" _null_ _null_ _null_ _null_ stringaggstaterecv _null_ _null_ _null_ ));
 DESCR("serializer for string aggregation transition states");
 
-DATA(insert OID = 4321 ( numeric_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_ numeric_pcombine _null_ _null_ _null_ ));
-DESCR("aggregate parse and combine function");
-
-DATA(insert OID = 4322 ( avg PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("the average (arithmetic mean) as numeric of all serialized numeric values");
-DATA(insert OID = 4323 ( avg PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "1016 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("the average (arithmetic mean) as numeric of all numeric[] values");
-DATA(insert OID = 4324 ( avg PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701  "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("the average (arithmetic mean) as numeric of all double precision[] values");
-DATA(insert OID = 4325 ( avg PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1186 "1187 1186" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("the average (arithmetic mean) as numeric of all interval[] values");
-
-DATA(insert OID = 4326 ( sum PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("sum as numeric across all serialized numeric input values");
-
-DATA(insert OID = 4327 ( array_agg_pcombine	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 2277" _null_ _null_ _null_ _null_ array_agg_pcombine _null_ _null_ _null_ ));
-DESCR("aggregate parse and combine function");
-
-DATA(insert OID = 4328 ( array_agg PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 2277 "2277 2277" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("array aggregate of multiple input arrays");
-
-DATA(insert OID = 4329 ( string_agg_pcombine PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_	string_agg_pcombine _null_ _null_ _null_ ));
-DESCR("string aggregate parse and combine function");
-
-DATA(insert OID = 4330 ( string_agg PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 25 "17 25 25" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("aggregate of multiple string aggregates");
-
-DATA(insert OID = 4331 ( string_agg PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 17 "17 17 17" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("aggregate of multiple bytea aggregates");
-
-DATA(insert OID = 4332 ( json_agg PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 114 "17 114" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("aggregate of multiple json aggregates");
-
-DATA(insert OID = 4333 ( json_object_agg PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 114 "17 114 2276" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("aggregate of multiple json object aggregates");
-
-DATA(insert OID = 4334 ( json_agg_pcombine PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_	json_agg_pcombine _null_ _null_ _null_ ));
-DESCR("json aggregate parse and combine function");
-
-DATA(insert OID = 4335 ( json_object_agg_pcombine PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 2281 "2281 17" _null_ _null_ _null_ _null_	json_object_agg_pcombine _null_ _null_ _null_ ));
-DESCR("json object aggregate parse and combine function");
-
-DATA(insert OID = 4336 ( regr_sxx PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4337 ( regr_syy PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4338 ( regr_sxy PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4339 ( regr_avgx PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4340 ( regr_avgy PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4341 ( regr_r2 PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4342 ( regr_slope PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4343 ( regr_intercept PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4344 ( covar_pop PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4345 ( covar_samp PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4346 ( corr PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 701 "1022 701 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4347 ( var_pop PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4348 ( var_pop PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4349 ( var_samp PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4350 ( var_samp PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4351 ( variance PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4352 ( variance PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4353 ( stddev_pop PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4354 ( stddev_pop PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4355 ( stddev_samp PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4356 ( stddev_samp PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4357 ( stddev PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 1700 "17 1700" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
-
-DATA(insert OID = 4358 ( stddev PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 701 "1022 701" _null_ _null_ _null_ _null_	aggregate_dummy _null_ _null_ _null_ ));
-DESCR("combine aggregate");
+/* generic combine function */
+DATA(insert OID = 4300 ( combine	PGNSP PGUID 12 1 0 2283 0 t f f f t f i 1 0 2283 "2283" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ ));
+DESCR("generic user combine function");
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/catalog/pipeline_combine.h
+++ b/src/include/catalog/pipeline_combine.h
@@ -75,6 +75,9 @@ CATALOG(pipeline_combine,4247) BKI_WITHOUT_OIDS
 
 typedef FormData_pipeline_combine *Form_pipeline_combine;
 
+#define COMBINE_OID 4300
+#define IS_COMBINE_AGG(oid) (oid == COMBINE_OID)
+
 #define Natts_pipeline_combine							7
 #define Anum_pipeline_combine_aggfinalfn		1
 #define Anum_pipeline_combine_transfn 			2

--- a/src/include/catalog/pipeline_combine_fn.h
+++ b/src/include/catalog/pipeline_combine_fn.h
@@ -14,5 +14,6 @@
 #include "catalog/pipeline_combine.h"
 
 Oid GetCombineStateType(Oid aggfnoid);
+void GetCombineInfo(Oid aggfnoid, Oid *combinefn, Oid *combineinfn, Oid *statetype);
 
 #endif

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -38,9 +38,12 @@ bool IsContinuousViewActive(RangeVar *name);
 char *GetQueryStringOrNull(const char *cvname, bool selectonly);
 char *GetQueryString(const char *cvname, bool selectonly);
 bool IsAContinuousView(RangeVar *name);
+bool IsAMatRel(RangeVar *name, RangeVar **cvname);
 bool GetGCFlag(RangeVar *name);
 void MarkAllContinuousViewsAsInactive(void);
 char *GetMatRelationName(char *cvname);
 char *GetCVNameForMatRelationName(char *matrelname);
+Query *GetContinuousQuery(RangeVar *rv);
+void InvalidateContinuousQuery(RangeVar *rv);
 
 #endif

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -298,6 +298,7 @@ typedef struct WindowFunc
 	bool		winstar;		/* TRUE if argument list was really '*' */
 	bool		winagg;			/* is function a simple aggregate? */
 	int			location;		/* token location, or -1 if unknown */
+	char 		winaggkind; /* aggregate kind (see pg_aggregate.h) */
 } WindowFunc;
 
 /* ----------------

--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -38,7 +38,8 @@ typedef enum
 	FUNCDETAIL_NORMAL,			/* found a matching regular function */
 	FUNCDETAIL_AGGREGATE,		/* found a matching aggregate function */
 	FUNCDETAIL_WINDOWFUNC,		/* found a matching window function */
-	FUNCDETAIL_COERCION			/* it's a type coercion request */
+	FUNCDETAIL_COERCION,			/* it's a type coercion request */
+	FUNCDETAIL_COMBINE			/* the function is a combine request */
 } FuncDetailCode;
 
 

--- a/src/include/pipeline/cqanalyze.h
+++ b/src/include/pipeline/cqanalyze.h
@@ -32,14 +32,20 @@ typedef struct CQAnalyzeContext
 	char *stepSize;
 } CQAnalyzeContext;
 
+#define USER_COMBINE "combine"
+
 TupleDesc InferStreamScanTupleDescriptor(ParseState *pstate, RangeTblEntry *rte);
 void AnalyzeAndValidateContinuousSelectStmt(ParseState *pstate, SelectStmt **stmt);
 RangeTblEntry *TransformStreamEntry(ParseState *pstate, StreamDesc *stream);
 
+void RewriteStreamingAggs(SelectStmt *stmt);
 SelectStmt *GetSelectStmtForCQWorker(SelectStmt *stmt, SelectStmt **viewstmtptr);
 SelectStmt *GetSelectStmtForCQCombiner(SelectStmt *stmt);
 
-Oid GetCombineStateColumnType(TargetEntry *te);
+AttrNumber GetHiddenAttrNumber(char *attname, TupleDesc matrel);
+Oid GetCombineStateColumnType(Expr *expr);
+bool IsUserCombine(NameData proname);
+Node *ParseCombineFuncCall(ParseState *pstate, List *args, List *order, Expr *filter, WindowDef *over, int location);
 
 void InitializeCQAnalyzeContext(SelectStmt *stmt, ParseState *pstate, CQAnalyzeContext *context);
 char *GetUniqueInternalColname(CQAnalyzeContext *context);
@@ -51,6 +57,7 @@ bool IsAColumnRef(Node *node);
 bool AreColumnRefsEqual(Node *cr1, Node *cr2);
 Node *HoistNode(SelectStmt *stmt, Node *node, CQAnalyzeContext *context);
 bool CollectFuncs(Node *node, CQAnalyzeContext *context);
+bool CollectAggrefs(Node *node, CQAnalyzeContext *context);
 bool CollectAggFuncs(Node *node, CQAnalyzeContext *context);
 ResTarget *CreateResTargetForNode(Node *node);
 ResTarget *CreateUniqueResTargetForNode(Node *node, CQAnalyzeContext *context);
@@ -58,5 +65,6 @@ ColumnRef *CreateColumnRefFromResTarget(ResTarget *res);
 bool HasAggOrGroupBy(SelectStmt *stmt);
 bool AddStreams(Node *node, CQAnalyzeContext *context);
 List *pipeline_rewrite(List *raw_parsetree_list);
+Query *RewriteContinuousViewSelect(Query *query, Query *rule, Relation cv);
 
 #endif

--- a/src/include/pipeline/cqwindow.h
+++ b/src/include/pipeline/cqwindow.h
@@ -23,9 +23,9 @@ Node *GetSlidingWindowExpr(SelectStmt *stmt, CQAnalyzeContext *context);
 
 bool DoesViewAggregate(SelectStmt *stmt, CQAnalyzeContext *context);
 
-void AddProjectionsAndGroupBysForWindows(SelectStmt *stmt, SelectStmt *viewselect, bool hasAggOrGroupBy, CQAnalyzeContext *context);
+ResTarget *AddProjectionsAndGroupBysForWindows(SelectStmt *workerstmt, SelectStmt *viewstmt,
+		bool doesViewAggregate, CQAnalyzeContext *context, AttrNumber *timeAttr);
 void TransformAggNodeForCQView(SelectStmt *viewselect, Node *agg, ResTarget *aggres, bool doesViewAggregate);
-void FixAggArgForCQView(SelectStmt *viewselect, SelectStmt *workerselect, RangeVar *matrelation);
 Node* GetCQVacuumExpr(char *cvname);
 
 #endif

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -538,11 +538,9 @@ extern Datum hllsend(PG_FUNCTION_ARGS);
 extern Datum hllrecv(PG_FUNCTION_ARGS);
 extern Datum hll_hypothetical_set_transition_multi(PG_FUNCTION_ARGS);
 extern Datum hll_hypothetical_set_combine_multi(PG_FUNCTION_ARGS);
-extern Datum hll_hypothetical_set_pcombine(PG_FUNCTION_ARGS);
 extern Datum hll_hypothetical_dense_rank_final(PG_FUNCTION_ARGS);
 extern Datum cq_hypothetical_set_transition_multi(PG_FUNCTION_ARGS);
 extern Datum cq_hypothetical_set_combine_multi(PG_FUNCTION_ARGS);
-extern Datum cq_hypothetical_set_pcombine(PG_FUNCTION_ARGS);
 extern Datum cq_hypothetical_rank_final(PG_FUNCTION_ARGS);
 extern Datum cq_hypothetical_percent_rank_final(PG_FUNCTION_ARGS);
 extern Datum cq_hypothetical_cume_dist_final(PG_FUNCTION_ARGS);
@@ -843,7 +841,6 @@ extern Datum string_agg_finalfn(PG_FUNCTION_ARGS);
 extern Datum stringaggstatesend(PG_FUNCTION_ARGS);
 extern Datum stringaggstaterecv(PG_FUNCTION_ARGS);
 extern Datum string_agg_combine(PG_FUNCTION_ARGS);
-extern Datum string_agg_pcombine(PG_FUNCTION_ARGS);
 
 extern Datum text_concat(PG_FUNCTION_ARGS);
 extern Datum text_concat_ws(PG_FUNCTION_ARGS);
@@ -1238,10 +1235,6 @@ extern Datum numeric_combine(PG_FUNCTION_ARGS);
 extern Datum numeric_avg_combine(PG_FUNCTION_ARGS);
 extern Datum array_agg_combine(PG_FUNCTION_ARGS);
 extern Datum json_agg_combine(PG_FUNCTION_ARGS);
-extern Datum json_agg_pcombine(PG_FUNCTION_ARGS);
-extern Datum json_object_agg_pcombine(PG_FUNCTION_ARGS);
 extern Datum json_object_agg_combine(PG_FUNCTION_ARGS);
-extern Datum array_agg_pcombine(PG_FUNCTION_ARGS);
-extern Datum numeric_pcombine(PG_FUNCTION_ARGS);
 
 #endif   /* BUILTINS_H */

--- a/src/include/utils/int8.h
+++ b/src/include/utils/int8.h
@@ -128,7 +128,6 @@ extern Datum generate_series_step_int8(PG_FUNCTION_ARGS);
 
 extern Datum hll_count_distinct_transition(PG_FUNCTION_ARGS);
 extern Datum hll_count_distinct_combine(PG_FUNCTION_ARGS);
-extern Datum hll_count_distinct_pcombine(PG_FUNCTION_ARGS);
 extern Datum hll_count_distinct_final(PG_FUNCTION_ARGS);
 
 #endif   /* INT8_H */

--- a/src/test/py/base.py
+++ b/src/test/py/base.py
@@ -183,6 +183,15 @@ class PipelineDB(object):
         """
         return self.conn.execute(stmt)
 
+    def insert(self, target, desc, rows):
+        """
+        Insert a batch of rows
+        """
+        header = ', '.join(desc)
+        values = ', '.join([str(r) for r in rows])
+
+        return self.execute('INSERT INTO %s (%s) VALUES %s' % (target, header, values))
+
     def set_sync_insert(self, on):
         """
         Sets the flag that makes stream INSERTs synchronous or not

--- a/src/test/py/test_user_combines.py
+++ b/src/test/py/test_user_combines.py
@@ -1,0 +1,249 @@
+from base import pipeline, clean_db
+import random
+import json
+
+
+def test_simple_aggs(pipeline, clean_db):
+    """
+    Verify that combines work properly on simple aggs
+    """
+    q = """
+    SELECT x::integer %% 10 AS k,
+    avg(x), sum(y::float8), count(*) FROM stream GROUP BY k;
+    """
+    desc = ('x', 'y')
+    pipeline.create_cv('test_simple_aggs', q)
+    pipeline.create_table('test_simple_aggs_t', x='integer', y='float8')
+    
+    rows = []
+    for n in range(10000):
+        row = (random.randint(0, 1000), random.random())
+        rows.append(row)
+        
+    pipeline.activate()
+    
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_simple_aggs_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    table_result = list(pipeline.execute('SELECT avg(x), sum(y::float8), count(*) FROM test_simple_aggs_t'))
+    cv_result = list(pipeline.execute('SELECT combine(avg), combine(sum), combine(count) FROM test_simple_aggs'))
+    
+    assert len(table_result) == len(cv_result)
+    
+    for tr, cr in zip(table_result, cv_result):
+        assert abs(tr[0] - cr[0]) < 0.00001
+        assert abs(tr[1] - cr[1]) < 0.00001
+        assert abs(tr[2] - cr[2]) < 0.00001
+
+def test_object_aggs(pipeline, clean_db):
+    """
+    Verify that combines work properly on object aggs
+    """
+    q = """
+    SELECT x::integer %% 10 AS k,
+    json_agg(x), json_object_agg(x, y::float8), string_agg(s::text, \' :: \')FROM stream GROUP BY k;
+    """
+    desc = ('x', 'y', 's')
+    pipeline.create_cv('test_object_aggs', q)
+    pipeline.create_table('test_object_aggs_t', x='integer', y='float8', s='text')
+    
+    rows = []
+    for n in range(10000):
+        row = (random.randint(0, 1000), random.random(), str(n) * random.randint(1, 8))
+        rows.append(row)
+        
+    pipeline.activate()
+    
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_object_aggs_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    tq = """
+    SELECT json_agg(x), json_object_agg(x, y::float8), string_agg(s::text, \' :: \') FROM test_object_aggs_t
+    """
+    table_result = list(pipeline.execute(tq))
+    
+    cq = """
+    SELECT combine(json_agg), combine(json_object_agg), combine(string_agg) FROM test_object_aggs
+    """
+    cv_result = list(pipeline.execute(cq))
+    
+    assert len(table_result) == len(cv_result)
+    
+    for tr, cr in zip(table_result, cv_result):
+        assert sorted(tr[0]) == sorted(cr[0])
+        assert sorted(tr[1]) == sorted(cr[1])
+        assert sorted(tr[2]) == sorted(cr[2])
+    
+def test_stats_aggs(pipeline, clean_db):
+    """
+    Verify that combines work on stats aggs
+    """
+    q = """
+    SELECT x::integer %% 10 AS k,
+    regr_sxx(x, y::float8), stddev(x) FROM stream GROUP BY k;
+    """
+    desc = ('x', 'y')
+    pipeline.create_cv('test_stats_aggs', q)
+    pipeline.create_table('test_stats_aggs_t', x='integer', y='float8')
+    
+    rows = []
+    for n in range(10000):
+        row = (random.randint(0, 1000), random.random())
+        rows.append(row)
+        
+    pipeline.activate()
+    
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_stats_aggs_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    tq = """
+    SELECT regr_sxx(x, y::float8), stddev(x) FROM test_stats_aggs_t
+    """
+    table_result = list(pipeline.execute(tq))
+    
+    cq = """
+    SELECT combine(regr_sxx), combine(stddev) FROM test_stats_aggs
+    """
+    cv_result = list(pipeline.execute(cq))
+    
+    assert len(table_result) == len(cv_result)
+    
+    for tr, cr in zip(table_result, cv_result):
+        assert abs(tr[0] - cr[0]) < 0.00001
+        assert abs(tr[1] - cr[1]) < 0.00001
+
+def test_hypothetical_set_aggs(pipeline, clean_db):
+    """
+    Verify that combines work properly on HS aggs
+    """
+    q = """
+    SELECT x::integer %% 10 AS k,
+    rank(256) WITHIN GROUP (ORDER BY x),
+    dense_rank(256) WITHIN GROUP (ORDER BY x)
+    FROM stream GROUP BY k
+    """
+    desc = ('x', 'y')
+    pipeline.create_cv('test_hs_aggs', q)
+    pipeline.create_table('test_hs_aggs_t', x='integer', y='float8')
+    
+    rows = []
+    for n in range(10000):
+        row = (random.randint(0, 1000), random.random())
+        rows.append(row)
+        
+    pipeline.activate()
+    
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_hs_aggs_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    # Note that the CQ will use the HLL variant of dense_rank, 
+    # so use hll_dense_rank on the table too
+    tq = """
+    SELECT rank(256) WITHIN GROUP (ORDER BY x), hll_dense_rank(256) WITHIN GROUP (ORDER BY x) 
+    FROM test_hs_aggs_t
+    """
+    table_result = list(pipeline.execute(tq))
+    
+    cq = """
+    SELECT combine(rank), combine(dense_rank) FROM test_hs_aggs
+    """
+    cv_result = list(pipeline.execute(cq))
+    
+    assert len(table_result) == len(cv_result)
+    
+    for tr, cr in zip(table_result, cv_result):
+        assert tr == cr
+        
+def test_nested_expressions(pipeline, clean_db):
+    """
+    Verify that combines work properly on arbitrarily nested expressions
+    """
+    q = """
+    SELECT x::integer %% 10 AS k,
+    (rank(256) WITHIN GROUP (ORDER BY x) + dense_rank(256) WITHIN GROUP (ORDER BY x)) * 
+        (avg(x + y::float8) - (sum(x) * avg(y))) AS whoa
+    FROM stream GROUP BY k
+    """
+    desc = ('x', 'y')
+    pipeline.create_cv('test_nested', q)
+    pipeline.create_table('test_nested_t', x='integer', y='float8')
+    
+    rows = []
+    for n in range(10000):
+        row = (random.randint(0, 1000), random.random())
+        rows.append(row)
+        
+    pipeline.activate()
+    
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_nested_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    # Note that the CQ will use the HLL variant of dense_rank, 
+    # so use hll_dense_rank on the table too
+    tq = """
+    SELECT
+    (rank(256) WITHIN GROUP (ORDER BY x) + hll_dense_rank(256) WITHIN GROUP (ORDER BY x)) * 
+        (avg(x + y::float8) - (sum(x) * avg(y))) AS whoa
+    FROM test_nested_t
+    """
+    table_result = list(pipeline.execute(tq))
+    
+    cq = """
+    SELECT combine(whoa) FROM test_nested
+    """
+    cv_result = list(pipeline.execute(cq))
+    
+    assert len(table_result) == len(cv_result)
+    
+    for tr, cr in zip(table_result, cv_result):
+        assert abs(tr[0] - cr[0]) < 0.0001
+        
+def test_hll_distinct(pipeline, clean_db):
+    """
+    Verify that combines work on HLL COUNT DISTINCT queries
+    """
+    q = """
+    SELECT x::integer %% 10 AS k, COUNT(DISTINCT x) AS count FROM stream GROUP BY k
+    """
+    desc = ('x', 'y')
+    pipeline.create_cv('test_hll_distinct', q)
+    pipeline.create_table('test_hll_distinct_t', x='integer', y='float8')
+    
+    rows = []
+    for n in range(10000):
+        row = (random.randint(0, 1000), random.random())
+        rows.append(row)
+
+    pipeline.activate()
+    
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_hll_distinct_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    # Note that the CQ will use the HLL variant of COUNT DISTINCT, 
+    # so use hll_count_distinct on the table too
+    tq = """
+    SELECT hll_count_distinct(x) FROM test_hll_distinct_t
+    """
+    table_result = list(pipeline.execute(tq))
+    
+    cq = """
+    SELECT combine(count) FROM test_hll_distinct
+    """
+    cv_result = list(pipeline.execute(cq))
+    
+    assert len(table_result) == len(cv_result)
+    
+    for tr, cr in zip(table_result, cv_result):
+        assert tr == cr

--- a/src/test/regress/expected/cqcreate.out
+++ b/src/test/regress/expected/cqcreate.out
@@ -183,11 +183,11 @@ SELECT gc FROM pipeline_query WHERE name='cqcreate5';
 
 \d+ cqcreate6;
                View "public.cqcreate6"
- Column |  Type   | Modifiers | Storage | Description 
---------+---------+-----------+---------+-------------
- count  | numeric |           | main    | 
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
 View definition:
- SELECT sum(cqcreate6_mrel0.count) AS count
+ SELECT combine(cqcreate6_mrel0.count) AS count
    FROM cqcreate6_mrel0
   WHERE cqcreate6_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second)
   GROUP BY cqcreate6_mrel0._1;
@@ -197,8 +197,8 @@ View definition:
  Column |           Type           | Modifiers | Storage  | Stats target | Description 
 --------+--------------------------+-----------+----------+--------------+-------------
  count  | bigint                   |           | plain    |              | 
- _0     | timestamp with time zone |           | plain    |              | 
  _1     | text(0)                  |           | extended |              | 
+ _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqcreate6_mrel0__0_idx" btree (_0)
 
@@ -369,10 +369,10 @@ CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM st
  Column |  Type   | Modifiers | Storage  | Description 
 --------+---------+-----------+----------+-------------
  key    | text(0) |           | extended | 
- value  | numeric |           | main     | 
+ value  | bigint  |           | plain    | 
 View definition:
  SELECT cqaggexpr3_mrel0.key,
-    sum(cqaggexpr3_mrel0.value) AS value
+    combine(cqaggexpr3_mrel0.value) AS value
    FROM cqaggexpr3_mrel0
   WHERE cqaggexpr3_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second)
   GROUP BY cqaggexpr3_mrel0.key;

--- a/src/test/regress/expected/cqwindow.out
+++ b/src/test/regress/expected/cqwindow.out
@@ -17,7 +17,7 @@ CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PART
  sum    | numeric |           | main     | 
 View definition:
  SELECT cqwindow0_mrel0.key,
-    sum(cqwindow0_mrel0._1, NULL::numeric(65535,65532)) OVER (PARTITION BY cqwindow0_mrel0.key ORDER BY cqwindow0_mrel0._0 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS sum
+    pg_catalog.sum(naggstaterecv(cqwindow0_mrel0._1)) OVER (PARTITION BY cqwindow0_mrel0.key ORDER BY cqwindow0_mrel0._0 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS sum
    FROM cqwindow0_mrel0;
 
 ACTIVATE cqwindow0;
@@ -75,7 +75,7 @@ CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITIO
  avg    | numeric |           | main     | 
 View definition:
  SELECT cqwindow1_mrel0.key,
-    avg(cqwindow1_mrel0._1, NULL::numeric(65535,65532)) OVER (PARTITION BY cqwindow1_mrel0.key ORDER BY cqwindow1_mrel0._0 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg
+    pg_catalog.avg(cqwindow1_mrel0._1) OVER (PARTITION BY cqwindow1_mrel0.key ORDER BY cqwindow1_mrel0._0 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg
    FROM cqwindow1_mrel0;
 
 ACTIVATE cqwindow1;

--- a/src/test/regress/expected/opr_sanity.out
+++ b/src/test/regress/expected/opr_sanity.out
@@ -277,7 +277,8 @@ ORDER BY 1, 2;
 SELECT p1.oid, p1.proname
 FROM pg_proc as p1
 WHERE p1.prorettype = 'internal'::regtype AND NOT
-    'internal'::regtype = ANY (p1.proargtypes);
+    'internal'::regtype = ANY (p1.proargtypes) AND
+	p1.oid NOT IN (SELECT combineinfn FROM pipeline_combine);
  oid  |   proname   
 ------+-------------
  2304 | internal_in
@@ -1084,7 +1085,8 @@ WHERE a.aggfnoid = p.oid AND
 SELECT oid, proname
 FROM pg_proc as p
 WHERE p.proisagg AND
-    NOT EXISTS (SELECT 1 FROM pg_aggregate a WHERE a.aggfnoid = p.oid);
+    NOT EXISTS (SELECT 1 FROM pg_aggregate a WHERE a.aggfnoid = p.oid)
+	AND p.proname != 'combine';
  oid | proname 
 -----+---------
 (0 rows)
@@ -1355,7 +1357,7 @@ WHERE proisagg AND proargdefaults IS NOT NULL;
 -- that is not subject to the misplaced ORDER BY issue).
 SELECT p.oid, proname
 FROM pg_proc AS p JOIN pg_aggregate AS a ON a.aggfnoid = p.oid
-WHERE proisagg AND provariadic != 0 AND a.aggkind = 'n';
+WHERE proisagg AND provariadic != 0 AND a.aggkind = 'n' AND p.proname != 'combine';
  oid | proname 
 -----+---------
 (0 rows)

--- a/src/test/regress/expected/user_combine.out
+++ b/src/test/regress/expected/user_combine.out
@@ -1,0 +1,886 @@
+SET debug_sync_stream_insert = 'on';
+-- Verify some validation
+CREATE CONTINUOUS VIEW test_uc_validation AS SELECT k::text, avg(x::integer) FROM test_uc_stream GROUP BY k;
+CREATE TABLE test_uc_table (v numeric);
+INSERT INTO test_uc_table (v) VALUES (0), (1), (2);
+-- combine only accepts a single colref as an argument
+SELECT combine(avg + 1) FROM test_uc_validation;
+ERROR:  combine called with an invalid expression
+HINT:  combine must be called with a single column reference as its argument.
+SELECT combine(avg, avg) FROM test_uc_validation;
+ERROR:  combine called with 2 arguments
+HINT:  combine must be called with a single column reference as its argument.
+-- combine isn't allowed on tables
+SELECT combine(v) FROM test_uc_table;
+ERROR:  "test_uc_table" is not a continuous view
+HINT:  Only aggregate continuous view columns can be combined.
+-- combine is only allowed on aggregate columns
+SELECT combine(k) FROM test_uc_validation;
+ combine 
+---------
+(0 rows)
+
+-- Column doesn't exist
+SELECT combine(nothere) FROM test_uc_validation; 
+ERROR:  column "nothere" does not exist
+LINE 1: SELECT combine(nothere) FROM test_uc_validation;
+                       ^
+DROP TABLE test_uc_table;
+DROP CONTINUOUS VIEW test_uc_validation;
+CREATE CONTINUOUS VIEW test_uc0 AS SELECT 
+s::text,
+avg(x::integer) + avg(y::integer) AS avg_sum,
+sum(x) + (count(*) + (avg(x) * sum(y))) AS expr,
+json_object_agg(x, y),
+array_agg(x),
+max(x),
+min(y),
+string_agg(substring(s, 1, 1), ' :: ')
+FROM test_uc_stream GROUP BY s;
+CREATE CONTINUOUS VIEW test_uc1 AS SELECT
+s::text,
+dense_rank('20') WITHIN GROUP (ORDER BY s) + rank('20') WITHIN GROUP (ORDER BY s) AS expr0,
+stddev(x::integer) + (regr_r2(x, y::integer) * rank(10) WITHIN GROUP (ORDER BY y)) AS expr1
+FROM test_uc_stream GROUP BY s;
+ACTIVATE test_uc0, test_uc1;
+INSERT INTO test_uc_stream (x, y, s) VALUES (0, 0, '0');
+INSERT INTO test_uc_stream (x, y, s) VALUES (1, 100, '1');
+INSERT INTO test_uc_stream (x, y, s) VALUES (2, 200, '2');
+INSERT INTO test_uc_stream (x, y, s) VALUES (3, 300, '3');
+INSERT INTO test_uc_stream (x, y, s) VALUES (4, 400, '4');
+INSERT INTO test_uc_stream (x, y, s) VALUES (5, 500, '5');
+INSERT INTO test_uc_stream (x, y, s) VALUES (6, 600, '6');
+INSERT INTO test_uc_stream (x, y, s) VALUES (7, 700, '7');
+INSERT INTO test_uc_stream (x, y, s) VALUES (8, 800, '8');
+INSERT INTO test_uc_stream (x, y, s) VALUES (9, 900, '9');
+INSERT INTO test_uc_stream (x, y, s) VALUES (10, 1000, '10');
+INSERT INTO test_uc_stream (x, y, s) VALUES (11, 1100, '11');
+INSERT INTO test_uc_stream (x, y, s) VALUES (12, 1200, '12');
+INSERT INTO test_uc_stream (x, y, s) VALUES (13, 1300, '13');
+INSERT INTO test_uc_stream (x, y, s) VALUES (14, 1400, '14');
+INSERT INTO test_uc_stream (x, y, s) VALUES (15, 1500, '15');
+INSERT INTO test_uc_stream (x, y, s) VALUES (16, 1600, '16');
+INSERT INTO test_uc_stream (x, y, s) VALUES (17, 1700, '17');
+INSERT INTO test_uc_stream (x, y, s) VALUES (18, 1800, '18');
+INSERT INTO test_uc_stream (x, y, s) VALUES (19, 1900, '19');
+INSERT INTO test_uc_stream (x, y, s) VALUES (20, 2000, '20');
+INSERT INTO test_uc_stream (x, y, s) VALUES (21, 2100, '21');
+INSERT INTO test_uc_stream (x, y, s) VALUES (22, 2200, '22');
+INSERT INTO test_uc_stream (x, y, s) VALUES (23, 2300, '23');
+INSERT INTO test_uc_stream (x, y, s) VALUES (24, 2400, '24');
+INSERT INTO test_uc_stream (x, y, s) VALUES (25, 2500, '25');
+INSERT INTO test_uc_stream (x, y, s) VALUES (26, 2600, '26');
+INSERT INTO test_uc_stream (x, y, s) VALUES (27, 2700, '27');
+INSERT INTO test_uc_stream (x, y, s) VALUES (28, 2800, '28');
+INSERT INTO test_uc_stream (x, y, s) VALUES (29, 2900, '29');
+INSERT INTO test_uc_stream (x, y, s) VALUES (30, 3000, '30');
+INSERT INTO test_uc_stream (x, y, s) VALUES (31, 3100, '31');
+INSERT INTO test_uc_stream (x, y, s) VALUES (32, 3200, '32');
+INSERT INTO test_uc_stream (x, y, s) VALUES (33, 3300, '33');
+INSERT INTO test_uc_stream (x, y, s) VALUES (34, 3400, '34');
+INSERT INTO test_uc_stream (x, y, s) VALUES (35, 3500, '35');
+INSERT INTO test_uc_stream (x, y, s) VALUES (36, 3600, '36');
+INSERT INTO test_uc_stream (x, y, s) VALUES (37, 3700, '37');
+INSERT INTO test_uc_stream (x, y, s) VALUES (38, 3800, '38');
+INSERT INTO test_uc_stream (x, y, s) VALUES (39, 3900, '39');
+INSERT INTO test_uc_stream (x, y, s) VALUES (40, 4000, '40');
+INSERT INTO test_uc_stream (x, y, s) VALUES (41, 4100, '41');
+INSERT INTO test_uc_stream (x, y, s) VALUES (42, 4200, '42');
+INSERT INTO test_uc_stream (x, y, s) VALUES (43, 4300, '43');
+INSERT INTO test_uc_stream (x, y, s) VALUES (44, 4400, '44');
+INSERT INTO test_uc_stream (x, y, s) VALUES (45, 4500, '45');
+INSERT INTO test_uc_stream (x, y, s) VALUES (46, 4600, '46');
+INSERT INTO test_uc_stream (x, y, s) VALUES (47, 4700, '47');
+INSERT INTO test_uc_stream (x, y, s) VALUES (48, 4800, '48');
+INSERT INTO test_uc_stream (x, y, s) VALUES (49, 4900, '49');
+INSERT INTO test_uc_stream (x, y, s) VALUES (50, 5000, '0');
+INSERT INTO test_uc_stream (x, y, s) VALUES (51, 5100, '1');
+INSERT INTO test_uc_stream (x, y, s) VALUES (52, 5200, '2');
+INSERT INTO test_uc_stream (x, y, s) VALUES (53, 5300, '3');
+INSERT INTO test_uc_stream (x, y, s) VALUES (54, 5400, '4');
+INSERT INTO test_uc_stream (x, y, s) VALUES (55, 5500, '5');
+INSERT INTO test_uc_stream (x, y, s) VALUES (56, 5600, '6');
+INSERT INTO test_uc_stream (x, y, s) VALUES (57, 5700, '7');
+INSERT INTO test_uc_stream (x, y, s) VALUES (58, 5800, '8');
+INSERT INTO test_uc_stream (x, y, s) VALUES (59, 5900, '9');
+INSERT INTO test_uc_stream (x, y, s) VALUES (60, 6000, '10');
+INSERT INTO test_uc_stream (x, y, s) VALUES (61, 6100, '11');
+INSERT INTO test_uc_stream (x, y, s) VALUES (62, 6200, '12');
+INSERT INTO test_uc_stream (x, y, s) VALUES (63, 6300, '13');
+INSERT INTO test_uc_stream (x, y, s) VALUES (64, 6400, '14');
+INSERT INTO test_uc_stream (x, y, s) VALUES (65, 6500, '15');
+INSERT INTO test_uc_stream (x, y, s) VALUES (66, 6600, '16');
+INSERT INTO test_uc_stream (x, y, s) VALUES (67, 6700, '17');
+INSERT INTO test_uc_stream (x, y, s) VALUES (68, 6800, '18');
+INSERT INTO test_uc_stream (x, y, s) VALUES (69, 6900, '19');
+INSERT INTO test_uc_stream (x, y, s) VALUES (70, 7000, '20');
+INSERT INTO test_uc_stream (x, y, s) VALUES (71, 7100, '21');
+INSERT INTO test_uc_stream (x, y, s) VALUES (72, 7200, '22');
+INSERT INTO test_uc_stream (x, y, s) VALUES (73, 7300, '23');
+INSERT INTO test_uc_stream (x, y, s) VALUES (74, 7400, '24');
+INSERT INTO test_uc_stream (x, y, s) VALUES (75, 7500, '25');
+INSERT INTO test_uc_stream (x, y, s) VALUES (76, 7600, '26');
+INSERT INTO test_uc_stream (x, y, s) VALUES (77, 7700, '27');
+INSERT INTO test_uc_stream (x, y, s) VALUES (78, 7800, '28');
+INSERT INTO test_uc_stream (x, y, s) VALUES (79, 7900, '29');
+INSERT INTO test_uc_stream (x, y, s) VALUES (80, 8000, '30');
+INSERT INTO test_uc_stream (x, y, s) VALUES (81, 8100, '31');
+INSERT INTO test_uc_stream (x, y, s) VALUES (82, 8200, '32');
+INSERT INTO test_uc_stream (x, y, s) VALUES (83, 8300, '33');
+INSERT INTO test_uc_stream (x, y, s) VALUES (84, 8400, '34');
+INSERT INTO test_uc_stream (x, y, s) VALUES (85, 8500, '35');
+INSERT INTO test_uc_stream (x, y, s) VALUES (86, 8600, '36');
+INSERT INTO test_uc_stream (x, y, s) VALUES (87, 8700, '37');
+INSERT INTO test_uc_stream (x, y, s) VALUES (88, 8800, '38');
+INSERT INTO test_uc_stream (x, y, s) VALUES (89, 8900, '39');
+INSERT INTO test_uc_stream (x, y, s) VALUES (90, 9000, '40');
+INSERT INTO test_uc_stream (x, y, s) VALUES (91, 9100, '41');
+INSERT INTO test_uc_stream (x, y, s) VALUES (92, 9200, '42');
+INSERT INTO test_uc_stream (x, y, s) VALUES (93, 9300, '43');
+INSERT INTO test_uc_stream (x, y, s) VALUES (94, 9400, '44');
+INSERT INTO test_uc_stream (x, y, s) VALUES (95, 9500, '45');
+INSERT INTO test_uc_stream (x, y, s) VALUES (96, 9600, '46');
+INSERT INTO test_uc_stream (x, y, s) VALUES (97, 9700, '47');
+INSERT INTO test_uc_stream (x, y, s) VALUES (98, 9800, '48');
+INSERT INTO test_uc_stream (x, y, s) VALUES (99, 9900, '49');
+INSERT INTO test_uc_stream (x, y, s) VALUES (100, 1000, '0'), (101, 1010, '1'), (102, 1020, '2'), (103, 1030, '3'), (104, 1040, '4'), (105, 1050, '5'), (106, 1060, '6'), (107, 1070, '7'), (108, 1080, '8'), (109, 1090, '9'), (110, 1100, '10'), (111, 1110, '11'), (112, 1120, '12'), (113, 1130, '13'), (114, 1140, '14'), (115, 1150, '15'), (116, 1160, '16'), (117, 1170, '17'), (118, 1180, '18'), (119, 1190, '19'), (120, 1200, '20'), (121, 1210, '21'), (122, 1220, '22'), (123, 1230, '23'), (124, 1240, '24'), (125, 1250, '25'), (126, 1260, '26'), (127, 1270, '27'), (128, 1280, '28'), (129, 1290, '29'), (130, 1300, '30'), (131, 1310, '31'), (132, 1320, '32'), (133, 1330, '33'), (134, 1340, '34'), (135, 1350, '35'), (136, 1360, '36'), (137, 1370, '37'), (138, 1380, '38'), (139, 1390, '39'), (140, 1400, '40'), (141, 1410, '41'), (142, 1420, '42'), (143, 1430, '43'), (144, 1440, '44'), (145, 1450, '45'), (146, 1460, '46'), (147, 1470, '47'), (148, 1480, '48'), (149, 1490, '49'), (150, 1500, '0'), (151, 1510, '1'), (152, 1520, '2'), (153, 1530, '3'), (154, 1540, '4'), (155, 1550, '5'), (156, 1560, '6'), (157, 1570, '7'), (158, 1580, '8'), (159, 1590, '9'), (160, 1600, '10'), (161, 1610, '11'), (162, 1620, '12'), (163, 1630, '13'), (164, 1640, '14'), (165, 1650, '15'), (166, 1660, '16'), (167, 1670, '17'), (168, 1680, '18'), (169, 1690, '19'), (170, 1700, '20'), (171, 1710, '21'), (172, 1720, '22'), (173, 1730, '23'), (174, 1740, '24'), (175, 1750, '25'), (176, 1760, '26'), (177, 1770, '27'), (178, 1780, '28'), (179, 1790, '29'), (180, 1800, '30'), (181, 1810, '31'), (182, 1820, '32'), (183, 1830, '33'), (184, 1840, '34'), (185, 1850, '35'), (186, 1860, '36'), (187, 1870, '37'), (188, 1880, '38'), (189, 1890, '39'), (190, 1900, '40'), (191, 1910, '41'), (192, 1920, '42'), (193, 1930, '43'), (194, 1940, '44'), (195, 1950, '45'), (196, 1960, '46'), (197, 1970, '47'), (198, 1980, '48'), (199, 1990, '49');
+DEACTIVATE test_uc0, test_uc1;
+CREATE TABLE test_uc_table1 (x integer, y integer, s text);
+INSERT INTO test_uc_table1 (x, y, s) VALUES (100, 1000, '0'), (101, 1010, '1'), (102, 1020, '2'), (103, 1030, '3'), (104, 1040, '4'), (105, 1050, '5'), (106, 1060, '6'), (107, 1070, '7'), (108, 1080, '8'), (109, 1090, '9'), (110, 1100, '10'), (111, 1110, '11'), (112, 1120, '12'), (113, 1130, '13'), (114, 1140, '14'), (115, 1150, '15'), (116, 1160, '16'), (117, 1170, '17'), (118, 1180, '18'), (119, 1190, '19'), (120, 1200, '20'), (121, 1210, '21'), (122, 1220, '22'), (123, 1230, '23'), (124, 1240, '24'), (125, 1250, '25'), (126, 1260, '26'), (127, 1270, '27'), (128, 1280, '28'), (129, 1290, '29'), (130, 1300, '30'), (131, 1310, '31'), (132, 1320, '32'), (133, 1330, '33'), (134, 1340, '34'), (135, 1350, '35'), (136, 1360, '36'), (137, 1370, '37'), (138, 1380, '38'), (139, 1390, '39'), (140, 1400, '40'), (141, 1410, '41'), (142, 1420, '42'), (143, 1430, '43'), (144, 1440, '44'), (145, 1450, '45'), (146, 1460, '46'), (147, 1470, '47'), (148, 1480, '48'), (149, 1490, '49');
+-- Verify that table-wide combines work
+SELECT combine(avg_sum) FROM test_uc0;
+        combine        
+-----------------------
+ 3322.0000000000000000
+(1 row)
+
+SELECT combine(expr) FROM test_uc0;
+          combine          
+---------------------------
+ 64147850.0000000000000000
+(1 row)
+
+SELECT combine(max) FROM test_uc0;
+ combine 
+---------
+     199
+(1 row)
+
+SELECT combine(min) FROM test_uc0;
+ combine 
+---------
+       0
+(1 row)
+
+-- Verify the lengths for these since the ordering is nondeterministic and they're really long
+SELECT json_object_keys(combine(json_object_agg)) AS k FROM test_uc0 ORDER BY k;
+  k  
+-----
+ 0
+ 1
+ 10
+ 100
+ 101
+ 102
+ 103
+ 104
+ 105
+ 106
+ 107
+ 108
+ 109
+ 11
+ 110
+ 111
+ 112
+ 113
+ 114
+ 115
+ 116
+ 117
+ 118
+ 119
+ 12
+ 120
+ 121
+ 122
+ 123
+ 124
+ 125
+ 126
+ 127
+ 128
+ 129
+ 13
+ 130
+ 131
+ 132
+ 133
+ 134
+ 135
+ 136
+ 137
+ 138
+ 139
+ 14
+ 140
+ 141
+ 142
+ 143
+ 144
+ 145
+ 146
+ 147
+ 148
+ 149
+ 15
+ 150
+ 151
+ 152
+ 153
+ 154
+ 155
+ 156
+ 157
+ 158
+ 159
+ 16
+ 160
+ 161
+ 162
+ 163
+ 164
+ 165
+ 166
+ 167
+ 168
+ 169
+ 17
+ 170
+ 171
+ 172
+ 173
+ 174
+ 175
+ 176
+ 177
+ 178
+ 179
+ 18
+ 180
+ 181
+ 182
+ 183
+ 184
+ 185
+ 186
+ 187
+ 188
+ 189
+ 19
+ 190
+ 191
+ 192
+ 193
+ 194
+ 195
+ 196
+ 197
+ 198
+ 199
+ 2
+ 20
+ 21
+ 22
+ 23
+ 24
+ 25
+ 26
+ 27
+ 28
+ 29
+ 3
+ 30
+ 31
+ 32
+ 33
+ 34
+ 35
+ 36
+ 37
+ 38
+ 39
+ 4
+ 40
+ 41
+ 42
+ 43
+ 44
+ 45
+ 46
+ 47
+ 48
+ 49
+ 5
+ 50
+ 51
+ 52
+ 53
+ 54
+ 55
+ 56
+ 57
+ 58
+ 59
+ 6
+ 60
+ 61
+ 62
+ 63
+ 64
+ 65
+ 66
+ 67
+ 68
+ 69
+ 7
+ 70
+ 71
+ 72
+ 73
+ 74
+ 75
+ 76
+ 77
+ 78
+ 79
+ 8
+ 80
+ 81
+ 82
+ 83
+ 84
+ 85
+ 86
+ 87
+ 88
+ 89
+ 9
+ 90
+ 91
+ 92
+ 93
+ 94
+ 95
+ 96
+ 97
+ 98
+ 99
+(200 rows)
+
+SELECT array_length(combine(array_agg), 1) FROM test_uc0;
+ array_length 
+--------------
+          200
+(1 row)
+
+SELECT length(combine(string_agg)) FROM test_uc0;
+ length 
+--------
+    996
+(1 row)
+
+-- Verify that subsets of rows are combined properly
+SELECT s, combine(avg_sum) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ s  |        combine        
+----+-----------------------
+ 26 | 3406.0000000000000000
+ 27 | 3462.0000000000000000
+ 28 | 3518.0000000000000000
+ 29 | 3574.0000000000000000
+ 3  | 2118.0000000000000000
+ 30 | 3630.0000000000000000
+ 31 | 3686.0000000000000000
+ 32 | 3742.0000000000000000
+ 33 | 3798.0000000000000000
+ 34 | 3854.0000000000000000
+ 35 | 3910.0000000000000000
+ 36 | 3966.0000000000000000
+ 37 | 4022.0000000000000000
+ 38 | 4078.0000000000000000
+ 39 | 4134.0000000000000000
+ 4  | 2174.0000000000000000
+ 40 | 4190.0000000000000000
+ 41 | 4246.0000000000000000
+ 42 | 4302.0000000000000000
+ 43 | 4358.0000000000000000
+ 44 | 4414.0000000000000000
+ 45 | 4470.0000000000000000
+ 46 | 4526.0000000000000000
+ 47 | 4582.0000000000000000
+ 48 | 4638.0000000000000000
+ 49 | 4694.0000000000000000
+ 5  | 2230.0000000000000000
+ 6  | 2286.0000000000000000
+ 7  | 2342.0000000000000000
+ 8  | 2398.0000000000000000
+ 9  | 2454.0000000000000000
+(31 rows)
+
+SELECT s, combine(expr) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ s  |         combine          
+----+--------------------------
+ 26 | 1335628.0000000000000000
+ 27 | 1371292.0000000000000000
+ 28 | 1407396.0000000000000000
+ 29 | 1443940.0000000000000000
+ 3  |  636796.0000000000000000
+ 30 | 1480924.0000000000000000
+ 31 | 1518348.0000000000000000
+ 32 | 1556212.0000000000000000
+ 33 | 1594516.0000000000000000
+ 34 | 1633260.0000000000000000
+ 35 | 1672444.0000000000000000
+ 36 | 1712068.0000000000000000
+ 37 | 1752132.0000000000000000
+ 38 | 1792636.0000000000000000
+ 39 | 1833580.0000000000000000
+ 4  |  662340.0000000000000000
+ 40 | 1874964.0000000000000000
+ 41 | 1916788.0000000000000000
+ 42 | 1959052.0000000000000000
+ 43 | 2001756.0000000000000000
+ 44 | 2044900.0000000000000000
+ 45 | 2088484.0000000000000000
+ 46 | 2132508.0000000000000000
+ 47 | 2176972.0000000000000000
+ 48 | 2221876.0000000000000000
+ 49 | 2267220.0000000000000000
+ 5  |  688324.0000000000000000
+ 6  |  714748.0000000000000000
+ 7  |  741612.0000000000000000
+ 8  |  768916.0000000000000000
+ 9  |  796660.0000000000000000
+(31 rows)
+
+SELECT s, combine(max) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ s  | combine 
+----+---------
+ 26 |     176
+ 27 |     177
+ 28 |     178
+ 29 |     179
+ 3  |     153
+ 30 |     180
+ 31 |     181
+ 32 |     182
+ 33 |     183
+ 34 |     184
+ 35 |     185
+ 36 |     186
+ 37 |     187
+ 38 |     188
+ 39 |     189
+ 4  |     154
+ 40 |     190
+ 41 |     191
+ 42 |     192
+ 43 |     193
+ 44 |     194
+ 45 |     195
+ 46 |     196
+ 47 |     197
+ 48 |     198
+ 49 |     199
+ 5  |     155
+ 6  |     156
+ 7  |     157
+ 8  |     158
+ 9  |     159
+(31 rows)
+
+SELECT s, combine(min) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ s  | combine 
+----+---------
+ 26 |    1260
+ 27 |    1270
+ 28 |    1280
+ 29 |    1290
+ 3  |     300
+ 30 |    1300
+ 31 |    1310
+ 32 |    1320
+ 33 |    1330
+ 34 |    1340
+ 35 |    1350
+ 36 |    1360
+ 37 |    1370
+ 38 |    1380
+ 39 |    1390
+ 4  |     400
+ 40 |    1400
+ 41 |    1410
+ 42 |    1420
+ 43 |    1430
+ 44 |    1440
+ 45 |    1450
+ 46 |    1460
+ 47 |    1470
+ 48 |    1480
+ 49 |    1490
+ 5  |     500
+ 6  |     600
+ 7  |     700
+ 8  |     800
+ 9  |     900
+(31 rows)
+
+-- Verify the lengths for these since the ordering is nondeterministic and they're really long
+SELECT s, json_object_keys(combine(json_object_agg)) AS k FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ s  |  k  
+----+-----
+ 26 | 26
+ 26 | 76
+ 26 | 126
+ 26 | 176
+ 27 | 27
+ 27 | 77
+ 27 | 127
+ 27 | 177
+ 28 | 28
+ 28 | 78
+ 28 | 128
+ 28 | 178
+ 29 | 29
+ 29 | 79
+ 29 | 129
+ 29 | 179
+ 3  | 3
+ 3  | 53
+ 3  | 103
+ 3  | 153
+ 30 | 30
+ 30 | 80
+ 30 | 130
+ 30 | 180
+ 31 | 31
+ 31 | 81
+ 31 | 131
+ 31 | 181
+ 32 | 32
+ 32 | 82
+ 32 | 132
+ 32 | 182
+ 33 | 33
+ 33 | 83
+ 33 | 133
+ 33 | 183
+ 34 | 34
+ 34 | 84
+ 34 | 134
+ 34 | 184
+ 35 | 35
+ 35 | 85
+ 35 | 135
+ 35 | 185
+ 36 | 36
+ 36 | 86
+ 36 | 136
+ 36 | 186
+ 37 | 37
+ 37 | 87
+ 37 | 137
+ 37 | 187
+ 38 | 38
+ 38 | 88
+ 38 | 138
+ 38 | 188
+ 39 | 39
+ 39 | 89
+ 39 | 139
+ 39 | 189
+ 4  | 4
+ 4  | 54
+ 4  | 104
+ 4  | 154
+ 40 | 40
+ 40 | 90
+ 40 | 140
+ 40 | 190
+ 41 | 41
+ 41 | 91
+ 41 | 141
+ 41 | 191
+ 42 | 42
+ 42 | 92
+ 42 | 142
+ 42 | 192
+ 43 | 43
+ 43 | 93
+ 43 | 143
+ 43 | 193
+ 44 | 44
+ 44 | 94
+ 44 | 144
+ 44 | 194
+ 45 | 45
+ 45 | 95
+ 45 | 145
+ 45 | 195
+ 46 | 46
+ 46 | 96
+ 46 | 146
+ 46 | 196
+ 47 | 47
+ 47 | 97
+ 47 | 147
+ 47 | 197
+ 48 | 48
+ 48 | 98
+ 48 | 148
+ 48 | 198
+ 49 | 49
+ 49 | 99
+ 49 | 149
+ 49 | 199
+ 5  | 5
+ 5  | 55
+ 5  | 105
+ 5  | 155
+ 6  | 6
+ 6  | 56
+ 6  | 106
+ 6  | 156
+ 7  | 7
+ 7  | 57
+ 7  | 107
+ 7  | 157
+ 8  | 8
+ 8  | 58
+ 8  | 108
+ 8  | 158
+ 9  | 9
+ 9  | 59
+ 9  | 109
+ 9  | 159
+(124 rows)
+
+SELECT array_length(combine(array_agg), 1) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ array_length 
+--------------
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+            4
+(31 rows)
+
+SELECT length(combine(string_agg)) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+ length 
+--------
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+     16
+(31 rows)
+
+-- Verify that table-wide combines work
+SELECT combine(expr0) FROM test_uc1;
+ combine 
+---------
+      67
+(1 row)
+
+SELECT combine(expr1) FROM test_uc1;
+     combine      
+------------------
+ 58.0163369819087
+(1 row)
+
+-- Verify that subsets of rows are combined properly
+SELECT s, combine(expr0) FROM test_uc1 WHERE s < '25' GROUP BY s ORDER BY s;
+ s  | combine 
+----+---------
+ 0  |       7
+ 1  |       7
+ 10 |       7
+ 11 |       7
+ 12 |       7
+ 13 |       7
+ 14 |       7
+ 15 |       7
+ 16 |       7
+ 17 |       7
+ 18 |       7
+ 19 |       7
+ 2  |       7
+ 20 |       2
+ 21 |       2
+ 22 |       2
+ 23 |       2
+ 24 |       2
+(18 rows)
+
+SELECT s, combine(expr1) FROM test_uc1 WHERE s < '25' GROUP BY s ORDER BY s;
+ s  |     combine      
+----+------------------
+ 0  | 64.5514845513277
+ 1  | 64.5497903951277
+ 10 | 64.5775815468062
+ 11 |  64.583650542625
+ 12 | 64.5901358654677
+ 13 | 64.5969926652362
+ 14 | 64.6041781596134
+ 15 | 64.6116517635894
+ 16 | 64.6193751750575
+ 17 | 64.6273124217559
+ 18 | 64.6354298747513
+ 19 | 64.6436962334667
+ 2  | 64.5498874004233
+ 20 | 64.6520824869556
+ 21 | 64.6605618557704
+ 22 | 64.6691097183727
+ 23 | 64.6777035256203
+ 24 | 64.6863227064465
+(18 rows)
+
+-- Verify that combines work with CV-CV joins
+SELECT combine(avg_sum), 
+combine(expr),
+combine(max),
+combine(min),
+combine(expr0),
+combine(expr1)
+FROM test_uc0 v0 JOIN test_uc1 v1 ON v0.s = v1.s;
+        combine        |          combine          | combine | combine | combine |     combine      
+-----------------------+---------------------------+---------+---------+---------+------------------
+ 3322.0000000000000000 | 64147850.0000000000000000 |     199 |       0 |      67 | 58.0163369819087
+(1 row)
+
+-- Verify that combines work with subsets of CV-CV joins
+SELECT v0.s,
+combine(avg_sum), 
+combine(expr),
+combine(max),
+combine(min),
+combine(expr0),
+combine(expr1)
+FROM test_uc0 v0 JOIN test_uc1 v1 ON v0.s = v1.s WHERE v0.s IN ('0', '1', '2') AND v1.s IN ('0', '1', '2')
+GROUP BY v0.s;
+ s |        combine        |         combine         | combine | combine | combine |     combine      
+---+-----------------------+-------------------------+---------+---------+---------+------------------
+ 0 | 1950.0000000000000000 | 562804.0000000000000000 |     150 |       0 |       7 | 64.5514845513277
+ 1 | 2006.0000000000000000 | 587028.0000000000000000 |     151 |     100 |       7 | 64.5497903951277
+ 2 | 2062.0000000000000000 | 611692.0000000000000000 |     152 |     200 |       7 | 64.5498874004233
+(3 rows)
+
+-- Verify that combines work on CV-table joins
+SELECT combine(avg_sum), 
+combine(expr),
+combine(max),
+combine(min),
+combine(expr0),
+combine(expr1),
+sum(x),
+sum(y)
+FROM test_uc0 v0 JOIN test_uc1 v1 ON v0.s = v1.s JOIN test_uc_table1 t0 ON v0.s = t0.s;
+        combine        |          combine          | combine | combine | combine |     combine      | sum  |  sum  
+-----------------------+---------------------------+---------+---------+---------+------------------+------+-------
+ 3322.0000000000000000 | 64147850.0000000000000000 |     199 |       0 |      67 | 58.0163369819087 | 6225 | 62250
+(1 row)
+
+-- Verify that combines work on subsets of CV-table joins
+SELECT v0.s, combine(expr0), combine(avg_sum) FROM test_uc0 v0 
+JOIN test_uc1 v1 ON v0.s = v1.s JOIN test_uc_table1 t0 ON v0.s = t0.s
+WHERE v0.s > '25' GROUP BY v0.s;
+ s  | combine |        combine        
+----+---------+-----------------------
+ 8  |       2 | 2398.0000000000000000
+ 9  |       2 | 2454.0000000000000000
+ 46 |       2 | 4526.0000000000000000
+ 48 |       2 | 4638.0000000000000000
+ 4  |       2 | 2174.0000000000000000
+ 38 |       2 | 4078.0000000000000000
+ 34 |       2 | 3854.0000000000000000
+ 28 |       2 | 3518.0000000000000000
+ 26 |       2 | 3406.0000000000000000
+ 5  |       2 | 2230.0000000000000000
+ 43 |       2 | 4358.0000000000000000
+ 47 |       2 | 4582.0000000000000000
+ 3  |       2 | 2118.0000000000000000
+ 32 |       2 | 3742.0000000000000000
+ 31 |       2 | 3686.0000000000000000
+ 30 |       2 | 3630.0000000000000000
+ 35 |       2 | 3910.0000000000000000
+ 41 |       2 | 4246.0000000000000000
+ 33 |       2 | 3798.0000000000000000
+ 40 |       2 | 4190.0000000000000000
+ 37 |       2 | 4022.0000000000000000
+ 6  |       2 | 2286.0000000000000000
+ 45 |       2 | 4470.0000000000000000
+ 49 |       2 | 4694.0000000000000000
+ 36 |       2 | 3966.0000000000000000
+ 27 |       2 | 3462.0000000000000000
+ 44 |       2 | 4414.0000000000000000
+ 29 |       2 | 3574.0000000000000000
+ 39 |       2 | 4134.0000000000000000
+ 7  |       2 | 2342.0000000000000000
+ 42 |       2 | 4302.0000000000000000
+(31 rows)
+
+DROP CONTINUOUS VIEW test_uc0;
+DROP CONTINUOUS VIEW test_uc1;
+DROP TABLE test_uc_table1;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -117,7 +117,7 @@ test: cqanalyze cqcreate cqactivate cqsanity cqsum cqswsum cqavg cqswavg cqcount
 # ----------
 # Another group of parallel tests
 # ----------
-test: cqvacuum cqdecode stream_exprs stream_casts cqhsagg cqswhsagg cqdistinct stream_table_join
+test: cqvacuum cqdecode stream_exprs stream_casts cqhsagg cqswhsagg cqdistinct stream_table_join user_combine
 
 # ----------
 # Another group of parallel tests

--- a/src/test/regress/sql/opr_sanity.sql
+++ b/src/test/regress/sql/opr_sanity.sql
@@ -224,7 +224,8 @@ ORDER BY 1, 2;
 SELECT p1.oid, p1.proname
 FROM pg_proc as p1
 WHERE p1.prorettype = 'internal'::regtype AND NOT
-    'internal'::regtype = ANY (p1.proargtypes);
+    'internal'::regtype = ANY (p1.proargtypes) AND
+	p1.oid NOT IN (SELECT combineinfn FROM pipeline_combine);
 
 -- Look for functions that return a polymorphic type and do not have any
 -- polymorphic argument.  Calls of such functions would be unresolvable
@@ -676,7 +677,8 @@ WHERE a.aggfnoid = p.oid AND
 SELECT oid, proname
 FROM pg_proc as p
 WHERE p.proisagg AND
-    NOT EXISTS (SELECT 1 FROM pg_aggregate a WHERE a.aggfnoid = p.oid);
+    NOT EXISTS (SELECT 1 FROM pg_aggregate a WHERE a.aggfnoid = p.oid)
+	AND p.proname != 'combine';
 
 -- If there is no finalfn then the output type must be the transtype.
 
@@ -912,7 +914,7 @@ WHERE proisagg AND proargdefaults IS NOT NULL;
 
 SELECT p.oid, proname
 FROM pg_proc AS p JOIN pg_aggregate AS a ON a.aggfnoid = p.oid
-WHERE proisagg AND provariadic != 0 AND a.aggkind = 'n';
+WHERE proisagg AND provariadic != 0 AND a.aggkind = 'n' AND p.proname != 'combine';
 
 -- **************** pg_opfamily ****************
 

--- a/src/test/regress/sql/user_combine.sql
+++ b/src/test/regress/sql/user_combine.sql
@@ -1,0 +1,220 @@
+SET debug_sync_stream_insert = 'on';
+
+-- Verify some validation
+CREATE CONTINUOUS VIEW test_uc_validation AS SELECT k::text, avg(x::integer) FROM test_uc_stream GROUP BY k;
+CREATE TABLE test_uc_table (v numeric);
+INSERT INTO test_uc_table (v) VALUES (0), (1), (2);
+
+-- combine only accepts a single colref as an argument
+SELECT combine(avg + 1) FROM test_uc_validation;
+SELECT combine(avg, avg) FROM test_uc_validation;
+
+-- combine isn't allowed on tables
+SELECT combine(v) FROM test_uc_table;
+
+-- combine is only allowed on aggregate columns
+SELECT combine(k) FROM test_uc_validation;
+
+-- Column doesn't exist
+SELECT combine(nothere) FROM test_uc_validation; 
+
+DROP TABLE test_uc_table;
+DROP CONTINUOUS VIEW test_uc_validation;
+
+CREATE CONTINUOUS VIEW test_uc0 AS SELECT 
+s::text,
+avg(x::integer) + avg(y::integer) AS avg_sum,
+sum(x) + (count(*) + (avg(x) * sum(y))) AS expr,
+json_object_agg(x, y),
+array_agg(x),
+max(x),
+min(y),
+string_agg(substring(s, 1, 1), ' :: ')
+FROM test_uc_stream GROUP BY s;
+
+CREATE CONTINUOUS VIEW test_uc1 AS SELECT
+s::text,
+dense_rank('20') WITHIN GROUP (ORDER BY s) + rank('20') WITHIN GROUP (ORDER BY s) AS expr0,
+stddev(x::integer) + (regr_r2(x, y::integer) * rank(10) WITHIN GROUP (ORDER BY y)) AS expr1
+FROM test_uc_stream GROUP BY s;
+
+ACTIVATE test_uc0, test_uc1;
+
+INSERT INTO test_uc_stream (x, y, s) VALUES (0, 0, '0');
+INSERT INTO test_uc_stream (x, y, s) VALUES (1, 100, '1');
+INSERT INTO test_uc_stream (x, y, s) VALUES (2, 200, '2');
+INSERT INTO test_uc_stream (x, y, s) VALUES (3, 300, '3');
+INSERT INTO test_uc_stream (x, y, s) VALUES (4, 400, '4');
+INSERT INTO test_uc_stream (x, y, s) VALUES (5, 500, '5');
+INSERT INTO test_uc_stream (x, y, s) VALUES (6, 600, '6');
+INSERT INTO test_uc_stream (x, y, s) VALUES (7, 700, '7');
+INSERT INTO test_uc_stream (x, y, s) VALUES (8, 800, '8');
+INSERT INTO test_uc_stream (x, y, s) VALUES (9, 900, '9');
+INSERT INTO test_uc_stream (x, y, s) VALUES (10, 1000, '10');
+INSERT INTO test_uc_stream (x, y, s) VALUES (11, 1100, '11');
+INSERT INTO test_uc_stream (x, y, s) VALUES (12, 1200, '12');
+INSERT INTO test_uc_stream (x, y, s) VALUES (13, 1300, '13');
+INSERT INTO test_uc_stream (x, y, s) VALUES (14, 1400, '14');
+INSERT INTO test_uc_stream (x, y, s) VALUES (15, 1500, '15');
+INSERT INTO test_uc_stream (x, y, s) VALUES (16, 1600, '16');
+INSERT INTO test_uc_stream (x, y, s) VALUES (17, 1700, '17');
+INSERT INTO test_uc_stream (x, y, s) VALUES (18, 1800, '18');
+INSERT INTO test_uc_stream (x, y, s) VALUES (19, 1900, '19');
+INSERT INTO test_uc_stream (x, y, s) VALUES (20, 2000, '20');
+INSERT INTO test_uc_stream (x, y, s) VALUES (21, 2100, '21');
+INSERT INTO test_uc_stream (x, y, s) VALUES (22, 2200, '22');
+INSERT INTO test_uc_stream (x, y, s) VALUES (23, 2300, '23');
+INSERT INTO test_uc_stream (x, y, s) VALUES (24, 2400, '24');
+INSERT INTO test_uc_stream (x, y, s) VALUES (25, 2500, '25');
+INSERT INTO test_uc_stream (x, y, s) VALUES (26, 2600, '26');
+INSERT INTO test_uc_stream (x, y, s) VALUES (27, 2700, '27');
+INSERT INTO test_uc_stream (x, y, s) VALUES (28, 2800, '28');
+INSERT INTO test_uc_stream (x, y, s) VALUES (29, 2900, '29');
+INSERT INTO test_uc_stream (x, y, s) VALUES (30, 3000, '30');
+INSERT INTO test_uc_stream (x, y, s) VALUES (31, 3100, '31');
+INSERT INTO test_uc_stream (x, y, s) VALUES (32, 3200, '32');
+INSERT INTO test_uc_stream (x, y, s) VALUES (33, 3300, '33');
+INSERT INTO test_uc_stream (x, y, s) VALUES (34, 3400, '34');
+INSERT INTO test_uc_stream (x, y, s) VALUES (35, 3500, '35');
+INSERT INTO test_uc_stream (x, y, s) VALUES (36, 3600, '36');
+INSERT INTO test_uc_stream (x, y, s) VALUES (37, 3700, '37');
+INSERT INTO test_uc_stream (x, y, s) VALUES (38, 3800, '38');
+INSERT INTO test_uc_stream (x, y, s) VALUES (39, 3900, '39');
+INSERT INTO test_uc_stream (x, y, s) VALUES (40, 4000, '40');
+INSERT INTO test_uc_stream (x, y, s) VALUES (41, 4100, '41');
+INSERT INTO test_uc_stream (x, y, s) VALUES (42, 4200, '42');
+INSERT INTO test_uc_stream (x, y, s) VALUES (43, 4300, '43');
+INSERT INTO test_uc_stream (x, y, s) VALUES (44, 4400, '44');
+INSERT INTO test_uc_stream (x, y, s) VALUES (45, 4500, '45');
+INSERT INTO test_uc_stream (x, y, s) VALUES (46, 4600, '46');
+INSERT INTO test_uc_stream (x, y, s) VALUES (47, 4700, '47');
+INSERT INTO test_uc_stream (x, y, s) VALUES (48, 4800, '48');
+INSERT INTO test_uc_stream (x, y, s) VALUES (49, 4900, '49');
+INSERT INTO test_uc_stream (x, y, s) VALUES (50, 5000, '0');
+INSERT INTO test_uc_stream (x, y, s) VALUES (51, 5100, '1');
+INSERT INTO test_uc_stream (x, y, s) VALUES (52, 5200, '2');
+INSERT INTO test_uc_stream (x, y, s) VALUES (53, 5300, '3');
+INSERT INTO test_uc_stream (x, y, s) VALUES (54, 5400, '4');
+INSERT INTO test_uc_stream (x, y, s) VALUES (55, 5500, '5');
+INSERT INTO test_uc_stream (x, y, s) VALUES (56, 5600, '6');
+INSERT INTO test_uc_stream (x, y, s) VALUES (57, 5700, '7');
+INSERT INTO test_uc_stream (x, y, s) VALUES (58, 5800, '8');
+INSERT INTO test_uc_stream (x, y, s) VALUES (59, 5900, '9');
+INSERT INTO test_uc_stream (x, y, s) VALUES (60, 6000, '10');
+INSERT INTO test_uc_stream (x, y, s) VALUES (61, 6100, '11');
+INSERT INTO test_uc_stream (x, y, s) VALUES (62, 6200, '12');
+INSERT INTO test_uc_stream (x, y, s) VALUES (63, 6300, '13');
+INSERT INTO test_uc_stream (x, y, s) VALUES (64, 6400, '14');
+INSERT INTO test_uc_stream (x, y, s) VALUES (65, 6500, '15');
+INSERT INTO test_uc_stream (x, y, s) VALUES (66, 6600, '16');
+INSERT INTO test_uc_stream (x, y, s) VALUES (67, 6700, '17');
+INSERT INTO test_uc_stream (x, y, s) VALUES (68, 6800, '18');
+INSERT INTO test_uc_stream (x, y, s) VALUES (69, 6900, '19');
+INSERT INTO test_uc_stream (x, y, s) VALUES (70, 7000, '20');
+INSERT INTO test_uc_stream (x, y, s) VALUES (71, 7100, '21');
+INSERT INTO test_uc_stream (x, y, s) VALUES (72, 7200, '22');
+INSERT INTO test_uc_stream (x, y, s) VALUES (73, 7300, '23');
+INSERT INTO test_uc_stream (x, y, s) VALUES (74, 7400, '24');
+INSERT INTO test_uc_stream (x, y, s) VALUES (75, 7500, '25');
+INSERT INTO test_uc_stream (x, y, s) VALUES (76, 7600, '26');
+INSERT INTO test_uc_stream (x, y, s) VALUES (77, 7700, '27');
+INSERT INTO test_uc_stream (x, y, s) VALUES (78, 7800, '28');
+INSERT INTO test_uc_stream (x, y, s) VALUES (79, 7900, '29');
+INSERT INTO test_uc_stream (x, y, s) VALUES (80, 8000, '30');
+INSERT INTO test_uc_stream (x, y, s) VALUES (81, 8100, '31');
+INSERT INTO test_uc_stream (x, y, s) VALUES (82, 8200, '32');
+INSERT INTO test_uc_stream (x, y, s) VALUES (83, 8300, '33');
+INSERT INTO test_uc_stream (x, y, s) VALUES (84, 8400, '34');
+INSERT INTO test_uc_stream (x, y, s) VALUES (85, 8500, '35');
+INSERT INTO test_uc_stream (x, y, s) VALUES (86, 8600, '36');
+INSERT INTO test_uc_stream (x, y, s) VALUES (87, 8700, '37');
+INSERT INTO test_uc_stream (x, y, s) VALUES (88, 8800, '38');
+INSERT INTO test_uc_stream (x, y, s) VALUES (89, 8900, '39');
+INSERT INTO test_uc_stream (x, y, s) VALUES (90, 9000, '40');
+INSERT INTO test_uc_stream (x, y, s) VALUES (91, 9100, '41');
+INSERT INTO test_uc_stream (x, y, s) VALUES (92, 9200, '42');
+INSERT INTO test_uc_stream (x, y, s) VALUES (93, 9300, '43');
+INSERT INTO test_uc_stream (x, y, s) VALUES (94, 9400, '44');
+INSERT INTO test_uc_stream (x, y, s) VALUES (95, 9500, '45');
+INSERT INTO test_uc_stream (x, y, s) VALUES (96, 9600, '46');
+INSERT INTO test_uc_stream (x, y, s) VALUES (97, 9700, '47');
+INSERT INTO test_uc_stream (x, y, s) VALUES (98, 9800, '48');
+INSERT INTO test_uc_stream (x, y, s) VALUES (99, 9900, '49');
+
+INSERT INTO test_uc_stream (x, y, s) VALUES (100, 1000, '0'), (101, 1010, '1'), (102, 1020, '2'), (103, 1030, '3'), (104, 1040, '4'), (105, 1050, '5'), (106, 1060, '6'), (107, 1070, '7'), (108, 1080, '8'), (109, 1090, '9'), (110, 1100, '10'), (111, 1110, '11'), (112, 1120, '12'), (113, 1130, '13'), (114, 1140, '14'), (115, 1150, '15'), (116, 1160, '16'), (117, 1170, '17'), (118, 1180, '18'), (119, 1190, '19'), (120, 1200, '20'), (121, 1210, '21'), (122, 1220, '22'), (123, 1230, '23'), (124, 1240, '24'), (125, 1250, '25'), (126, 1260, '26'), (127, 1270, '27'), (128, 1280, '28'), (129, 1290, '29'), (130, 1300, '30'), (131, 1310, '31'), (132, 1320, '32'), (133, 1330, '33'), (134, 1340, '34'), (135, 1350, '35'), (136, 1360, '36'), (137, 1370, '37'), (138, 1380, '38'), (139, 1390, '39'), (140, 1400, '40'), (141, 1410, '41'), (142, 1420, '42'), (143, 1430, '43'), (144, 1440, '44'), (145, 1450, '45'), (146, 1460, '46'), (147, 1470, '47'), (148, 1480, '48'), (149, 1490, '49'), (150, 1500, '0'), (151, 1510, '1'), (152, 1520, '2'), (153, 1530, '3'), (154, 1540, '4'), (155, 1550, '5'), (156, 1560, '6'), (157, 1570, '7'), (158, 1580, '8'), (159, 1590, '9'), (160, 1600, '10'), (161, 1610, '11'), (162, 1620, '12'), (163, 1630, '13'), (164, 1640, '14'), (165, 1650, '15'), (166, 1660, '16'), (167, 1670, '17'), (168, 1680, '18'), (169, 1690, '19'), (170, 1700, '20'), (171, 1710, '21'), (172, 1720, '22'), (173, 1730, '23'), (174, 1740, '24'), (175, 1750, '25'), (176, 1760, '26'), (177, 1770, '27'), (178, 1780, '28'), (179, 1790, '29'), (180, 1800, '30'), (181, 1810, '31'), (182, 1820, '32'), (183, 1830, '33'), (184, 1840, '34'), (185, 1850, '35'), (186, 1860, '36'), (187, 1870, '37'), (188, 1880, '38'), (189, 1890, '39'), (190, 1900, '40'), (191, 1910, '41'), (192, 1920, '42'), (193, 1930, '43'), (194, 1940, '44'), (195, 1950, '45'), (196, 1960, '46'), (197, 1970, '47'), (198, 1980, '48'), (199, 1990, '49');
+
+DEACTIVATE test_uc0, test_uc1;
+
+CREATE TABLE test_uc_table1 (x integer, y integer, s text);
+
+INSERT INTO test_uc_table1 (x, y, s) VALUES (100, 1000, '0'), (101, 1010, '1'), (102, 1020, '2'), (103, 1030, '3'), (104, 1040, '4'), (105, 1050, '5'), (106, 1060, '6'), (107, 1070, '7'), (108, 1080, '8'), (109, 1090, '9'), (110, 1100, '10'), (111, 1110, '11'), (112, 1120, '12'), (113, 1130, '13'), (114, 1140, '14'), (115, 1150, '15'), (116, 1160, '16'), (117, 1170, '17'), (118, 1180, '18'), (119, 1190, '19'), (120, 1200, '20'), (121, 1210, '21'), (122, 1220, '22'), (123, 1230, '23'), (124, 1240, '24'), (125, 1250, '25'), (126, 1260, '26'), (127, 1270, '27'), (128, 1280, '28'), (129, 1290, '29'), (130, 1300, '30'), (131, 1310, '31'), (132, 1320, '32'), (133, 1330, '33'), (134, 1340, '34'), (135, 1350, '35'), (136, 1360, '36'), (137, 1370, '37'), (138, 1380, '38'), (139, 1390, '39'), (140, 1400, '40'), (141, 1410, '41'), (142, 1420, '42'), (143, 1430, '43'), (144, 1440, '44'), (145, 1450, '45'), (146, 1460, '46'), (147, 1470, '47'), (148, 1480, '48'), (149, 1490, '49');
+
+-- Verify that table-wide combines work
+SELECT combine(avg_sum) FROM test_uc0;
+SELECT combine(expr) FROM test_uc0;
+SELECT combine(max) FROM test_uc0;
+SELECT combine(min) FROM test_uc0;
+
+-- Verify the lengths for these since the ordering is nondeterministic and they're really long
+SELECT json_object_keys(combine(json_object_agg)) AS k FROM test_uc0 ORDER BY k;
+SELECT array_length(combine(array_agg), 1) FROM test_uc0;
+SELECT length(combine(string_agg)) FROM test_uc0;
+
+-- Verify that subsets of rows are combined properly
+SELECT s, combine(avg_sum) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+SELECT s, combine(expr) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+SELECT s, combine(max) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+SELECT s, combine(min) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+
+-- Verify the lengths for these since the ordering is nondeterministic and they're really long
+SELECT s, json_object_keys(combine(json_object_agg)) AS k FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+SELECT array_length(combine(array_agg), 1) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+SELECT length(combine(string_agg)) FROM test_uc0 WHERE s > '25' GROUP BY s ORDER BY s;
+
+-- Verify that table-wide combines work
+SELECT combine(expr0) FROM test_uc1;
+SELECT combine(expr1) FROM test_uc1;
+
+-- Verify that subsets of rows are combined properly
+SELECT s, combine(expr0) FROM test_uc1 WHERE s < '25' GROUP BY s ORDER BY s;
+SELECT s, combine(expr1) FROM test_uc1 WHERE s < '25' GROUP BY s ORDER BY s;
+
+-- Verify that combines work with CV-CV joins
+SELECT combine(avg_sum), 
+combine(expr),
+combine(max),
+combine(min),
+combine(expr0),
+combine(expr1)
+FROM test_uc0 v0 JOIN test_uc1 v1 ON v0.s = v1.s;
+
+-- Verify that combines work with subsets of CV-CV joins
+SELECT v0.s,
+combine(avg_sum), 
+combine(expr),
+combine(max),
+combine(min),
+combine(expr0),
+combine(expr1)
+FROM test_uc0 v0 JOIN test_uc1 v1 ON v0.s = v1.s WHERE v0.s IN ('0', '1', '2') AND v1.s IN ('0', '1', '2')
+GROUP BY v0.s;
+
+-- Verify that combines work on CV-table joins
+SELECT combine(avg_sum), 
+combine(expr),
+combine(max),
+combine(min),
+combine(expr0),
+combine(expr1),
+sum(x),
+sum(y)
+FROM test_uc0 v0 JOIN test_uc1 v1 ON v0.s = v1.s JOIN test_uc_table1 t0 ON v0.s = t0.s;
+
+-- Verify that combines work on subsets of CV-table joins
+SELECT v0.s, combine(expr0), combine(avg_sum) FROM test_uc0 v0 
+JOIN test_uc1 v1 ON v0.s = v1.s JOIN test_uc_table1 t0 ON v0.s = t0.s
+WHERE v0.s > '25' GROUP BY v0.s;
+
+DROP CONTINUOUS VIEW test_uc0;
+DROP CONTINUOUS VIEW test_uc1;
+DROP TABLE test_uc_table1;


### PR DESCRIPTION
This gives users the ability to dynamically run combines on continuous views, which I think is pretty awesome! This diff also unifies the combine infrastructure, so that all combine metadata is now consolidated in `pipeline_combine`. All of the additional `pcombine` functions and aggregates have been ripped out. Here's how it works:
- Aggregating views for sliding-window and partition queries and are correctly generated by only looking at `pipeline_combine`
- If transition state needs to be deserialized, the combine call's argument is wrapped in a function call to the appropriate `recv` function
- CQ's, user queries, and aggregating views on top of matrels all share the exact same combine functionality 
- `combines` also work with joins against other CVs as well as regular tables
- Most of this stuff is handled by the analyzer
