### PR TITLE
Use spalloc when creating shared TupleDesc

### DIFF
--- a/src/backend/pipeline/streambuf.c
+++ b/src/backend/pipeline/streambuf.c
@@ -35,16 +35,7 @@ int StreamBufferBlocks;
 static void
 spfree_tupledesc(TupleDesc desc)
 {
-// FIXME(derekjn) these spfree calls seem to be
-// causing spalloc calls from other procs to fail when
-// each is being called frequently
-//
-//	int i;
-//	for (i=0; i<desc->natts; i++)
-//		spfree(desc->attrs[i]);
-//
-//	spfree(desc->attrs);
-//	spfree(desc);
+	spfree(desc);
 }
 
 /*


### PR DESCRIPTION
```
usmanm=# CREATE CONTINUOUS VIEW test_view AS SELECT key::text, COUNT(*) FROM test_stream GROUP BY key;
CREATE CONTINUOUS VIEW
usmanm=# ACTIVATE;
ACTIVATE 1
usmanm=# INSERT INTO test_stream (key, value) VALUES ('key', 42);
INSERT 0 1
usmanm=# SELECT * FROM test_view;
 key | count 
-----+-------
 key |     1
(1 row)

usmanm@usmanm-x1:~/pipelinedb/pipeline/emit (master)*$ ./generate-inserts --stream test_stream --key=str --value=int --batchsize=100000 --n=1 | pipeline
INSERT 0 100000
usmanm@usmanm-x1:~/pipelinedb/pipeline/emit (master)*$ ./generate-inserts --stream test_stream --key=str --value=int --batchsize=100000 --n=1 | pipeline
INSERT 0 100000
usmanm@usmanm-x1:~/pipelinedb/pipeline/emit (master)*$ ./generate-inserts --stream test_stream --key=str --value=int --batchsize=100000 --n=1 | pipeline
INSERT 0 100000
usmanm@usmanm-x1:~/pipelinedb/pipeline/emit (master)*$ ./generate-inserts --stream test_stream --key=str --value=int --batchsize=1000000 --n=1 | pipeline
INSERT 0 1000000
usmanm@usmanm-x1:~/pipelinedb/pipeline/emit (master)*$ pipeline -c "SELECT sum(count) FROM test_view"
   sum   
---------
 1300001
(1 row)
```
