### PR TITLE
Fixes the memleaks in stream scans

### DIFF
--- a/src/backend/pipeline/combinerReceiver.c
+++ b/src/backend/pipeline/combinerReceiver.c
@@ -18,6 +18,7 @@
 #include "pipeline/combinerReceiver.h"
 #include "pipeline/tuplebuf.h"
 #include "miscadmin.h"
+#include "utils/memutils.h"
 
 typedef struct
 {
@@ -42,7 +43,11 @@ static void
 combiner_receive(TupleTableSlot *slot, DestReceiver *self)
 {
 	CombinerState *c = (CombinerState *) self;
+	MemoryContext old = MemoryContextSwitchTo(CQWorkerExecutionContext);
+
 	TupleBufferInsert(CombinerTupleBuffer, MakeTuple(ExecMaterializeSlot(slot), NULL), c->readers);
+
+	MemoryContextSwitchTo(old);
 }
 
 static void combiner_destroy(DestReceiver *self)

--- a/src/backend/pipeline/worker.c
+++ b/src/backend/pipeline/worker.c
@@ -139,6 +139,15 @@ retry:
 		operation = queryDesc->operation;
 
 		/*
+		 * Initialize context that lives for the duration of a single iteration
+		 * of the main worker loop
+		 */
+		CQWorkerExecutionContext = AllocSetContextCreate(estate->es_query_cxt, "CQWorkerExecutionContext",
+				ALLOCSET_DEFAULT_MINSIZE,
+				ALLOCSET_DEFAULT_INITSIZE,
+				ALLOCSET_DEFAULT_MAXSIZE);
+
+		/*
 		 * startup tuple receiver, if we will be emitting tuples
 		 */
 		estate->es_lastoid = InvalidOid;
@@ -201,6 +210,8 @@ retry:
 				last_process = GetCurrentTimestamp();
 			}
 
+			MemoryContextReset(CQWorkerExecutionContext);
+
 			/* Has the CQ been deactivated? */
 			if (!entry->active)
 				break;
@@ -234,6 +245,7 @@ retry:
 		TupleBufferUnpinAllPinnedSlots();
 
 		MemoryContextResetAndDeleteChildren(runcontext);
+		MemoryContextResetAndDeleteChildren(CQWorkerExecutionContext);
 
 		if (ContinuousQueryCrashRecovery)
 			goto retry;

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -50,6 +50,9 @@ MemoryContext MessageContext = NULL;
 MemoryContext TopTransactionContext = NULL;
 MemoryContext CurTransactionContext = NULL;
 
+/* context that lives for the duration of one CQ execution by a worker */
+MemoryContext CQWorkerExecutionContext = NULL;
+
 /* This is a transient link to the active portal's memory context: */
 MemoryContext PortalContext = NULL;
 

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -80,7 +80,7 @@ extern PGDLLIMPORT MemoryContext CacheMemoryContext;
 extern PGDLLIMPORT MemoryContext MessageContext;
 extern PGDLLIMPORT MemoryContext TopTransactionContext;
 extern PGDLLIMPORT MemoryContext CurTransactionContext;
-extern PGDLLIMPORT MemoryContext ContinuousQueryContext;
+extern PGDLLIMPORT MemoryContext CQWorkerExecutionContext;
 
 /* This is a transient link to the active portal's memory context: */
 extern PGDLLIMPORT MemoryContext PortalContext;


### PR DESCRIPTION
The only leaks we really had in `nodeStreamScan` were because we were allocating memory that needed to last for the duration of an `ExecutePlan` call and we weren't freeing it. Now there's a `CQExecutionContext` that we can use to allocate anything that needs to be used by levels of the query tree that are higher than whichever one performed the initial allocation.

This also eliminates leakage in `combine`.
