### PR TITLE
736 pstmt

### DIFF
--- a/src/backend/commands/prepare.c
+++ b/src/backend/commands/prepare.c
@@ -29,6 +29,7 @@
 #include "parser/parse_type.h"
 #include "rewrite/rewriteHandler.h"
 #include "tcop/pquery.h"
+#include "tcop/tcopprot.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/snapmgr.h"
@@ -58,7 +59,7 @@ PrepareQuery(PrepareStmt *stmt, const char *queryString)
 	Oid		   *argtypes = NULL;
 	int			nargs;
 	Query	   *query;
-	List	   *query_list;
+	List	   *query_list = NIL;
 	int			i;
 
 	/*
@@ -148,8 +149,18 @@ PrepareQuery(PrepareStmt *stmt, const char *queryString)
 			break;
 	}
 
-	/* Rewrite the query. The result could be 0, 1, or many queries. */
-	query_list = QueryRewrite(query);
+	if (IsA(stmt->query, InsertStmt) && InsertTargetIsStream((InsertStmt *) stmt->query))
+	{
+		InsertStmt *ins = (InsertStmt *) stmt->query;
+
+		StorePreparedStreamInsert(stmt->name, ins->relation->relname, ins->cols);
+	}
+	else
+	{
+		/* Rewrite the query. The result could be 0, 1, or many queries. */
+		query_list = QueryRewrite(query);
+	}
+
 
 	/* Finish filling in the CachedPlanSource */
 	CompleteCachedPlan(plansource,
@@ -198,9 +209,18 @@ ExecuteQuery(ExecuteStmt *stmt, IntoClause *intoClause,
 	char	   *query_string;
 	int			eflags;
 	long		count;
+	PreparedStreamInsertStmt *stream_insert_stmt = FetchPreparedStreamInsert(stmt->name);
 
 	/* Look it up in the hash table */
 	entry = FetchPreparedStatement(stmt->name, true);
+
+	if (stream_insert_stmt)
+	{
+		InsertStmt *ins = (InsertStmt *) entry->plansource->raw_parse_tree;
+		exec_stream_inserts(ins, NULL, list_make1(stmt->params));
+
+		return;
+	}
 
 	/* Shouldn't find a non-fixed-result cached plan */
 	if (!entry->plansource->fixed_result)
@@ -582,6 +602,9 @@ DropPreparedStatement(const char *stmt_name, bool showError)
 		/* Now we can remove the hash table entry */
 		hash_search(prepared_queries, entry->stmt_name, HASH_REMOVE, NULL);
 	}
+
+	/* just in case it's a prepared stream insert */
+	DropPreparedStreamInsert(stmt_name);
 }
 
 /*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -848,8 +848,8 @@ pg_plan_queries(List *querytrees, int cursorOptions, ParamListInfo boundParams)
 	return stmt_list;
 }
 
-static void
-exec_stream_inserts(InsertStmt *ins)
+void
+exec_stream_inserts(InsertStmt *ins, PreparedStreamInsertStmt *pstmt, List *values)
 {
 	CommandDest dest = whereToSendOutput;
 	MemoryContext oldcontext;
@@ -861,7 +861,16 @@ exec_stream_inserts(InsertStmt *ins)
 	BeginCommand("INSERT", dest);
 
 	PushActiveSnapshot(GetTransactionSnapshot());
-	count = InsertIntoStream(ins);
+	if (pstmt)
+	{
+		count = InsertIntoStreamPrepared(pstmt);
+	}
+	else
+	{
+		List *vals = values ? values : ((SelectStmt *) ins->selectStmt)->valuesLists;
+
+		count = InsertIntoStream(ins, vals);
+	}
 	PopActiveSnapshot();
 
 	sprintf(buf, "INSERT 0 %d", count);
@@ -895,7 +904,7 @@ exec_simple_query(const char *query_string)
 	/*
 	 * Report query to various monitoring facilities.
 	 */
-	debug_query_string = NULL;//query_string;
+	debug_query_string = query_string;
 
 	pgstat_report_activity(STATE_RUNNING, query_string);
 
@@ -961,7 +970,7 @@ exec_simple_query(const char *query_string)
 
 			if (InsertTargetIsStream(ins))
 			{
-				exec_stream_inserts(ins);
+				exec_stream_inserts(ins, NULL, NIL);
 				continue;
 			}
 		}
@@ -1269,6 +1278,7 @@ exec_parse_message(const char *query_string,	/* string to execute */
 	bool		is_named;
 	bool		save_log_statement_stats = log_statement_stats;
 	char		msec_str[32];
+	bool stream_insert = false;
 
 	/*
 	 * Report query to various monitoring facilities.
@@ -1343,25 +1353,38 @@ exec_parse_message(const char *query_string,	/* string to execute */
 				(errcode(ERRCODE_SYNTAX_ERROR),
 		errmsg("cannot insert multiple commands into a prepared statement")));
 
+
 	if (parsetree_list != NIL)
 	{
 		raw_parse_tree = (Node *) linitial(parsetree_list);
+		stream_insert = IsA(raw_parse_tree, InsertStmt) && InsertTargetIsStream((InsertStmt *) raw_parse_tree);
 
-		if (IsA(raw_parse_tree, InsertStmt) && InsertTargetIsStream((InsertStmt *) raw_parse_tree))
+		if (stream_insert)
 		{
-			if (numParams > 0)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								errmsg("prepared stream insertions are currently not supported")));
-
+			InsertStmt *ins = (InsertStmt *) raw_parse_tree;
+			/*
+			 * If there aren't any parameters then we can bail early and insert into the stream now.
+			 * When we have params, a little more work is required for stream insertions.
+			 */
 			MemoryContextSwitchTo(oldcontext);
 
 			/* cache these so the following BIND and EXECUTE stages have access to them */
 			oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 			stream_inserts = copyObject(parsetree_list);
-			MemoryContextSwitchTo(oldcontext);
 
-			return;
+			if (numParams == 0)
+			{
+				parsetree_list = NIL;
+			}
+			else
+			{
+				/*
+				 * We'll add the Eval'd params to this during BIND
+				 */
+				StorePreparedStreamInsert(stmt_name, ins->relation->relname, ins->cols);
+			}
+
+			MemoryContextSwitchTo(oldcontext);
 		}
 	}
 
@@ -1439,7 +1462,10 @@ exec_parse_message(const char *query_string,	/* string to execute */
 		if (log_parser_stats)
 			ShowUsage("PARSE ANALYSIS STATISTICS");
 
-		querytree_list = pg_rewrite_query(query);
+		if (!stream_insert)
+			querytree_list = pg_rewrite_query(query);
+		else
+			querytree_list = NIL;
 
 		/* Done with the snapshot used for parsing */
 		if (snapshot_set)
@@ -1559,16 +1585,12 @@ exec_bind_message(StringInfo input_message)
 	bool		save_log_statement_stats = log_statement_stats;
 	bool		snapshot_set = false;
 	char		msec_str[32];
+	MemoryContext param_context;
+	PreparedStreamInsertStmt *stream_insert_stmt = NULL;
 
 	/* Get the fixed part of the message */
 	portal_name = pq_getmsgstring(input_message);
 	stmt_name = pq_getmsgstring(input_message);
-
-	if (stream_inserts != NULL)
-	{
-		/* fast path, nothing to but pass execution along to the EXECUTE stage */
-		return;
-	}
 
 	ereport(DEBUG2,
 			(errmsg("bind %s to %s",
@@ -1593,14 +1615,23 @@ exec_bind_message(StringInfo input_message)
 					 errmsg("unnamed prepared statement does not exist")));
 	}
 
+	if (psrc && psrc->raw_parse_tree && IsA(psrc->raw_parse_tree, InsertStmt))
+		stream_insert_stmt = FetchPreparedStreamInsert(portal_name);
+
+	if (!stream_insert_stmt && stream_inserts != NULL)
+	{
+		/*
+		 * It's a stream PREPARE/EXECUTE stream INSERT without a prepared statement
+		 */
+		return;
+	}
+
 	/*
 	 * Report query to various monitoring facilities.
 	 */
 	debug_query_string = psrc->query_string;
 
 	pgstat_report_activity(STATE_RUNNING, psrc->query_string);
-
-	set_ps_display("BIND", false);
 
 	if (save_log_statement_stats)
 		ResetUsage();
@@ -1667,13 +1698,16 @@ exec_bind_message(StringInfo input_message)
 	else
 		portal = CreatePortal(portal_name, false, false);
 
+
 	/*
 	 * Prepare to copy stuff into the portal's memory context.  We do all this
 	 * copying first, because it could possibly fail (out-of-memory) and we
 	 * don't want a failure to occur between GetCachedPlan and
 	 * PortalDefineQuery; that would result in leaking our plancache refcount.
 	 */
-	oldContext = MemoryContextSwitchTo(PortalGetHeapMemory(portal));
+	param_context = stream_insert_stmt ? EventContext : PortalGetHeapMemory(portal);
+
+	oldContext = MemoryContextSwitchTo(param_context);
 
 	/* Copy the plan's query string into the portal */
 	query_string = pstrdup(psrc->query_string);
@@ -1691,9 +1725,9 @@ exec_bind_message(StringInfo input_message)
 	 * snapshot active till we're done, so that plancache.c doesn't have to
 	 * take new ones.
 	 */
-	if (numParams > 0 ||
+	if (!stream_insert_stmt && (numParams > 0 ||
 		(psrc->raw_parse_tree &&
-		 analyze_requires_snapshot(psrc->raw_parse_tree)))
+		 analyze_requires_snapshot(psrc->raw_parse_tree))))
 	{
 		PushActiveSnapshot(GetTransactionSnapshot());
 		snapshot_set = true;
@@ -1873,9 +1907,17 @@ exec_bind_message(StringInfo input_message)
 					  cplan->stmt_list,
 					  cplan);
 
+
 	/* Done with the snapshot used for parameter I/O and parsing/planning */
 	if (snapshot_set)
 		PopActiveSnapshot();
+
+	if (stream_insert_stmt)
+	{
+		AddPreparedStreamInsert(stream_insert_stmt, params);
+
+		return;
+	}
 
 	/*
 	 * And we're ready to start portal execution.
@@ -1943,29 +1985,40 @@ exec_execute_message(const char *portal_name, long max_rows)
 	bool		execute_is_fetch;
 	bool		was_logged = false;
 	char		msec_str[32];
+	PreparedStreamInsertStmt *stream_insert_stmt;
 
 	/* Adjust destination to tell printtup.c what to do */
 	dest = whereToSendOutput;
 	if (dest == DestRemote)
 		dest = DestRemoteExecute;
 
+	stream_insert_stmt = FetchPreparedStreamInsert(portal_name);
 	/*
-	 * If we're INSERT into a stream, short circuit everything
+	 * If we're INSERTing into a stream, short circuit everything
 	 */
-	if (stream_inserts)
+	if (HasPendingInserts(stream_insert_stmt) || stream_inserts)
 	{
 		ListCell *lc;
-
 		/*
 		 * PARSE should have already put us in a transaction, but this is a noop in that case
 		 * so we might as well make sure
 		 */
 		start_xact_command();
 
-		foreach(lc, stream_inserts)
+		if (stream_insert_stmt)
 		{
-			InsertStmt *ins = (InsertStmt *) lfirst(lc);
-			exec_stream_inserts(ins);
+			/* we already have the eval'd values */
+			exec_stream_inserts(NULL, stream_insert_stmt, NIL);
+		}
+		else
+		{
+			/* we have parsed expressions and they still need to be eval'd */
+			foreach(lc, stream_inserts)
+			{
+				InsertStmt *ins = (InsertStmt *) lfirst(lc);
+				exec_stream_inserts(ins, NULL, NIL);
+			}
+			stream_inserts = NULL;
 		}
 
 		finish_xact_command();
@@ -2498,7 +2551,7 @@ exec_describe_portal_message(const char *portal_name)
 {
 	Portal		portal;
 
-	if (stream_inserts)
+	if (stream_inserts || HasPendingInserts(FetchPreparedStreamInsert(portal_name)))
 	{
 		pq_putemptymessage('n');	/* NoData */
 		return;

--- a/src/include/pipeline/stream.h
+++ b/src/include/pipeline/stream.h
@@ -13,6 +13,7 @@
 
 #include "postgres.h"
 #include "nodes/bitmapset.h"
+#include "nodes/params.h"
 #include "nodes/parsenodes.h"
 #include "utils/hsearch.h"
 #include "utils/timestamp.h"
@@ -23,11 +24,32 @@
 #define PlanIsStreaming(stmt) ((stmt)->is_continuous || false)
 #define ARRIVAL_TIMESTAMP "arrival_timestamp"
 
+/* returns true if the given PreparedStreamInsertStmt has pending inserts */
+#define HasPendingInserts(pstmt) (pstmt && (pstmt)->inserts)
+
+typedef struct PreparedStreamInsertStmt
+{
+	char name[NAMEDATALEN];
+	/* destination stream for INSERTs */
+	char *stream;
+	/* column names for INSERTs */
+	List *cols;
+	/* List of ParamListInfoData for the INSERT */
+	List *inserts;
+	/* TupleDesc for these INSERTs */
+	TupleDesc desc;
+} PreparedStreamInsertStmt;
+
 /* Whether or not to wait on the inserted event to be consumed by the CV*/
 extern bool DebugSyncStreamInsert;
 
+extern PreparedStreamInsertStmt *StorePreparedStreamInsert(const char *name, const char *stream, List *cols);
+extern void AddPreparedStreamInsert(PreparedStreamInsertStmt *stmt, ParamListInfoData *params);
+extern PreparedStreamInsertStmt *FetchPreparedStreamInsert(const char *name);
+extern void DropPreparedStreamInsert(const char *name);
 extern bool InsertTargetIsStream(InsertStmt *ins);
-extern int InsertIntoStream(InsertStmt *ins);
+extern int InsertIntoStreamPrepared(PreparedStreamInsertStmt *pstmt);
+extern int InsertIntoStream(InsertStmt *ins, List *values);
 extern bool IsInputStream(const char *stream);
 
 #endif

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -22,6 +22,7 @@
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
 #include "nodes/plannodes.h"
+#include "pipeline/stream.h"
 #include "storage/procsignal.h"
 #include "utils/guc.h"
 
@@ -57,6 +58,7 @@ extern PlannedStmt *pg_plan_query(Query *querytree, int cursorOptions,
 			  ParamListInfo boundParams);
 extern List *pg_plan_queries(List *querytrees, int cursorOptions,
 				ParamListInfo boundParams);
+extern void exec_stream_inserts(InsertStmt *ins, PreparedStreamInsertStmt *pstmt, List *values);
 
 extern bool check_max_stack_depth(int *newval, void **extra, GucSource source);
 extern void assign_max_stack_depth(int newval, void *extra);

--- a/src/test/py/test_prepared_inserts.py
+++ b/src/test/py/test_prepared_inserts.py
@@ -1,0 +1,33 @@
+from base import pipeline, clean_db
+import getpass
+import random
+import psycopg2
+import time
+
+
+def test_prepared_inserts(pipeline, clean_db):
+  """
+  Verify that we can PREPARE and EXECUTE an INSERT statement
+  """
+  conn = psycopg2.connect('dbname=pipeline user=%s host=localhost port=%s' % (getpass.getuser(), pipeline.port))
+  db = conn.cursor()
+  db.execute('CREATE CONTINUOUS VIEW test_prepared0 AS SELECT x::integer, COUNT(*), sum(y::integer) FROM stream GROUP BY x')
+  db.execute('CREATE CONTINUOUS VIEW test_prepared1 AS SELECT x::integer, COUNT(*), sum(y::float8) FROM stream GROUP BY x')
+  conn.commit()
+  
+  db.execute('ACTIVATE')
+
+  db.execute('PREPARE ins AS INSERT INTO stream (x, y) VALUES ($1, $2)')
+
+  for n in range(10000):
+    row = (n % 100, random.random())
+    db.execute('EXECUTE ins (%s, %s)' % row)
+
+  db.execute('DEACTIVATE')
+
+  result = list(pipeline.execute('SELECT * FROM test_prepared0 ORDER BY x'))
+
+  assert len(result) == 100
+
+  for n in range(100):
+    assert result[n]['count'] == 100

--- a/src/test/regress/expected/prepared_stream_insert.out
+++ b/src/test/regress/expected/prepared_stream_insert.out
@@ -1,0 +1,53 @@
+SET debug_sync_stream_insert = 'on';
+CREATE CONTINUOUS VIEW prep_insert0 AS SELECT COUNT(*) FROM prep_insert_stream;
+CREATE CONTINUOUS VIEW prep_insert1 AS SELECT sum(x::float8) AS fsum, sum(y::int8) AS isum FROM prep_insert_stream;
+CREATE CONTINUOUS VIEW prep_insert2 AS SELECT sum(x::integer) AS isum, sum(y::int4) AS i4sum FROM prep_insert_stream;
+ACTIVATE prep_insert0, prep_insert1, prep_insert2;
+PREPARE prep0 AS INSERT INTO prep_insert_stream (x) VALUES ($1);
+PREPARE prep1 AS INSERT INTO prep_insert_stream (x, y) VALUES ($1, $2);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+DEACTIVATE prep_insert0, prep_insert1, prep_insert2;
+SELECT * FROM prep_insert0;
+ count 
+-------
+    24
+(1 row)
+
+SELECT * FROM prep_insert1;
+ fsum | isum 
+------+------
+ 27.5 |   10
+(1 row)
+
+SELECT * FROM prep_insert2;
+ isum | i4sum 
+------+-------
+   31 |    10
+(1 row)
+
+DROP CONTINUOUS VIEW prep_insert0;
+DROP CONTINUOUS VIEW prep_insert1;
+DROP CONTINUOUS VIEW prep_insert2;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -153,7 +153,7 @@ test: stream_table_join user_combine cqlimit
 # ----------
 # Another group of parallel tests
 # ----------
-test: stream_exprs schema_inference
+test: stream_exprs schema_inference prepared_stream_insert
 
 # These are run in serial because they each activate many CVs.
 # If they are run in parallel the CPU can potentially get starved.

--- a/src/test/regress/sql/prepared_stream_insert.sql
+++ b/src/test/regress/sql/prepared_stream_insert.sql
@@ -1,0 +1,46 @@
+SET debug_sync_stream_insert = 'on';
+
+CREATE CONTINUOUS VIEW prep_insert0 AS SELECT COUNT(*) FROM prep_insert_stream;
+CREATE CONTINUOUS VIEW prep_insert1 AS SELECT sum(x::float8) AS fsum, sum(y::int8) AS isum FROM prep_insert_stream;
+CREATE CONTINUOUS VIEW prep_insert2 AS SELECT sum(x::integer) AS isum, sum(y::int4) AS i4sum FROM prep_insert_stream;
+
+ACTIVATE prep_insert0, prep_insert1, prep_insert2;
+
+PREPARE prep0 AS INSERT INTO prep_insert_stream (x) VALUES ($1);
+PREPARE prep1 AS INSERT INTO prep_insert_stream (x, y) VALUES ($1, $2);
+
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+EXECUTE prep0(1.5);
+
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+EXECUTE prep1(1, 1.1);
+
+DEACTIVATE prep_insert0, prep_insert1, prep_insert2;
+
+SELECT * FROM prep_insert0;
+SELECT * FROM prep_insert1;
+SELECT * FROM prep_insert2;
+
+DROP CONTINUOUS VIEW prep_insert0;
+DROP CONTINUOUS VIEW prep_insert1;
+DROP CONTINUOUS VIEW prep_insert2;


### PR DESCRIPTION
Adds support for prepared statements for stream `INSERTs`. So clients can do things like:

```
PREPARE ins AS INSERT INTO stream (x, y) VALUES (?, ?);
EXECUTE(1, 2);
EXECUTE(3, 4);
...
```
