### PR TITLE
Fixes #753: make stream inference smarter about numeric inputs

### DIFF
--- a/src/backend/pipeline/stream.c
+++ b/src/backend/pipeline/stream.c
@@ -147,7 +147,7 @@ int
 InsertIntoStreamPrepared(PreparedStreamInsertStmt *pstmt)
 {
 	ListCell *lc;
-	int count;
+	int count = 0;
 	Bitmapset *targets = GetStreamTargets(pstmt->stream);
 	TupleBufferSlot* tbs = NULL;
 	TupleDesc desc = GetStreamTupleDesc(pstmt->stream, pstmt->cols);

--- a/src/test/regress/expected/pipeline_stream.out
+++ b/src/test/regress/expected/pipeline_stream.out
@@ -7,49 +7,49 @@ ACTIVATE ps0, ps1, ps2, ps3, ps4;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x03000000 | \x0000000169640000000017ffffffff00000000
- stream1 | \x02000000 | \x0000000169640000000017ffffffff00000000
- stream2 | \x04000000 | \x0000000169640000000017ffffffff00000000
- stream3 | \x08000000 | \x0000000169640000000017ffffffff00000000
- stream4 | \x10000000 | \x0000000169640000000017ffffffff00000000
- stream5 | \x10000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x03000000 | \x00000001696400000006a4ffffffff00000000
+ stream1 | \x02000000 | \x00000001696400000006a4ffffffff00000000
+ stream2 | \x04000000 | \x00000001696400000006a4ffffffff00000000
+ stream3 | \x08000000 | \x00000001696400000006a4ffffffff00000000
+ stream4 | \x10000000 | \x00000001696400000006a4ffffffff00000000
+ stream5 | \x10000000 | \x00000001696400000006a4ffffffff00000000
 (6 rows)
 
 DEACTIVATE ps1;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x01000000 | \x0000000169640000000017ffffffff00000000
- stream2 | \x04000000 | \x0000000169640000000017ffffffff00000000
- stream3 | \x08000000 | \x0000000169640000000017ffffffff00000000
- stream4 | \x10000000 | \x0000000169640000000017ffffffff00000000
- stream5 | \x10000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x01000000 | \x00000001696400000006a4ffffffff00000000
+ stream2 | \x04000000 | \x00000001696400000006a4ffffffff00000000
+ stream3 | \x08000000 | \x00000001696400000006a4ffffffff00000000
+ stream4 | \x10000000 | \x00000001696400000006a4ffffffff00000000
+ stream5 | \x10000000 | \x00000001696400000006a4ffffffff00000000
 (5 rows)
 
 DEACTIVATE ps2;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x01000000 | \x0000000169640000000017ffffffff00000000
- stream3 | \x08000000 | \x0000000169640000000017ffffffff00000000
- stream4 | \x10000000 | \x0000000169640000000017ffffffff00000000
- stream5 | \x10000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x01000000 | \x00000001696400000006a4ffffffff00000000
+ stream3 | \x08000000 | \x00000001696400000006a4ffffffff00000000
+ stream4 | \x10000000 | \x00000001696400000006a4ffffffff00000000
+ stream5 | \x10000000 | \x00000001696400000006a4ffffffff00000000
 (4 rows)
 
 DEACTIVATE ps3;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x01000000 | \x0000000169640000000017ffffffff00000000
- stream4 | \x10000000 | \x0000000169640000000017ffffffff00000000
- stream5 | \x10000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x01000000 | \x00000001696400000006a4ffffffff00000000
+ stream4 | \x10000000 | \x00000001696400000006a4ffffffff00000000
+ stream5 | \x10000000 | \x00000001696400000006a4ffffffff00000000
 (3 rows)
 
 DEACTIVATE ps4;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x01000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x01000000 | \x00000001696400000006a4ffffffff00000000
 (1 row)
 
 DEACTIVATE ps0;
@@ -62,16 +62,16 @@ ACTIVATE ps0;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x01000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x01000000 | \x00000001696400000006a4ffffffff00000000
 (1 row)
 
 ACTIVATE ps4;
 SELECT * FROM pipeline_stream ORDER BY name;
   name   |  targets   |                   desc                   
 ---------+------------+------------------------------------------
- stream0 | \x01000000 | \x0000000169640000000017ffffffff00000000
- stream4 | \x10000000 | \x0000000169640000000017ffffffff00000000
- stream5 | \x10000000 | \x0000000169640000000017ffffffff00000000
+ stream0 | \x01000000 | \x00000001696400000006a4ffffffff00000000
+ stream4 | \x10000000 | \x00000001696400000006a4ffffffff00000000
+ stream5 | \x10000000 | \x00000001696400000006a4ffffffff00000000
 (3 rows)
 
 DEACTIVATE ps0, ps4;


### PR DESCRIPTION
This fixes the `schema_inference` test failure. Basically what was happening was that if `money` was a type in the collection of types to choose a supertype from, all of the other types would be interpreted as money. When it was time to cast down to the target type of a CV's input stream, things broke because `numeric` is the only type that `money` can be cast to.

What this diff does is that whenever we're inferring from multiple numeric types, a `numeric` is added to the list of input types so that it is the preferred supertype whenever there is ambiguity, as it is the most versatile of the numeric types.
