### PR TITLE
#613 speed up pytests by using batch inserts

### DIFF
--- a/src/test/py/test_count_distinct.py
+++ b/src/test/py/test_count_distinct.py
@@ -10,10 +10,10 @@ def test_hll_count_distinct(pipeline, clean_db):
     pipeline.create_cv('test_count_distinct', q)
     pipeline.activate()
     
-    values = [random.randint(1, 1024) for n in range(1000)]
-    for v in values:
-        pipeline.execute('INSERT INTO stream (x) VALUES (%d)' % v)
+    desc = ('x',)
+    values = [(random.randint(1, 1024),) for n in range(1000)]
         
+    pipeline.insert('stream', desc, values)
     pipeline.deactivate()
     
     expected = len(set(values))

--- a/src/test/py/test_sliding_windows.py
+++ b/src/test/py/test_sliding_windows.py
@@ -11,8 +11,8 @@ def assert_result_changes(func, args):
                        "SELECT %s(%s) FROM stream WHERE arrival_timestamp > clock_timestamp() - interval '2 seconds'" % (func, args))
     pipeline.activate(name)
     
-    for n in range(1000):
-        pipeline.execute('INSERT INTO stream (x, y, z) VALUES (%d, \'%s\', %d)' % (n, str(n), n + 1))
+    rows = [(n, str(n), n + 1) for n in range(1000)]
+    pipeline.insert('stream', ('x', 'y', 'z'), rows)
     
     pipeline.deactivate(name)
     current = 1

--- a/src/test/py/test_stream_table_joins.py
+++ b/src/test/py/test_stream_table_joins.py
@@ -15,9 +15,8 @@ def _join(left, right, cols):
     return result
 
 def _insert(pipeline, table, rows, sleep=0):
-    cols = ', '.join(['col%d' % c for c in range(len(rows[0]))])
-    values = ', '.join([str(row) for row in rows])
-    pipeline.execute('INSERT INTO %s (%s) VALUES %s' % (table, cols, values))
+    cols = ['col%d' % c for c in range(len(rows[0]))]
+    pipeline.insert(table, cols, rows)
     if sleep:
         time.sleep(sleep)
 


### PR DESCRIPTION
This makes the pytests about 2x as fast. Not a huge deal, but there wasn't really a good reason not to do this.

Also note that I changed `test_percentile_cont_agg` to use a `<=` instead of `<` when checking margin of error.
