### PR TITLE
Smarter waiting on TupleBuffer events

### DIFF
--- a/src/backend/pipeline/tuplebuf.c
+++ b/src/backend/pipeline/tuplebuf.c
@@ -30,7 +30,7 @@
 #define MAGIC 0xDEADBABE /* x_x */
 #define INIT_CQS BITS_PER_BITMAPWORD
 #define MURMUR_SEED 0x9eaca8149c92387e
-#define INSERT_SLEEP_MS 1
+#define INSERT_SLEEP_MS 5
 
 #define BufferOffset(buf, ptr) ((int32) ((char *) (ptr) - (buf)->start))
 #define BufferEnd(buf) ((buf)->start + (buf)->size)
@@ -54,6 +54,7 @@ int TupleBufferBlocks;
 int EmptyTupleBufferWaitTime;
 
 static List *MyPinnedSlots = NIL;
+static List *MyReaders = NIL;
 
 typedef struct
 {
@@ -111,11 +112,11 @@ TupleBufferInsert(TupleBuffer *buf, Tuple *tuple, Bitmapset *bms)
 	char *start;
 	char *pos;
 	char *end;
-	bool was_empty;
 	TupleBufferSlot *slot;
 	Size size;
 	Size tupsize;
 	int desclen = tuple->desc ? VARSIZE(tuple->desc) : 0;
+	TimestampTz start_wait;
 
 	if (bms == NULL)
 	{
@@ -131,6 +132,8 @@ TupleBufferInsert(TupleBuffer *buf, Tuple *tuple, Bitmapset *bms)
 
 	LWLockAcquire(buf->head_lock, LW_EXCLUSIVE);
 	LWLockAcquire(buf->tail_lock, LW_SHARED);
+
+	memcpy(&buf->writer_latch, &MyProc->procLatch, sizeof(Latch));
 
 	/* If the buffer is empty, we'll have to reset the tail, so upgrade to an EXCLUSIVE lock. */
 	if (TupleBufferIsEmpty(buf))
@@ -162,11 +165,18 @@ TupleBufferInsert(TupleBuffer *buf, Tuple *tuple, Bitmapset *bms)
 			}
 		}
 
+		start_wait = GetCurrentTimestamp();
+
 		/* If there isn't enough space, then wait for the tail to move on till there is enough. */
 		while (!HasEnoughSize(start, end, size))
 		{
 			LWLockRelease(buf->tail_lock);
-			pg_usleep(INSERT_SLEEP_MS * 1000);
+
+			if (TimestampDifferenceExceeds(start_wait, GetCurrentTimestamp(), EmptyTupleBufferWaitTime))
+				pg_usleep(INSERT_SLEEP_MS * 1000);
+			else
+				WaitLatch((&buf->writer_latch), WL_LATCH_SET, 0);
+
 			LWLockAcquire(buf->tail_lock, LW_SHARED);
 
 			if (TupleBufferIsEmpty(buf))
@@ -183,8 +193,6 @@ TupleBufferInsert(TupleBuffer *buf, Tuple *tuple, Bitmapset *bms)
 				end = (char *) buf->tail;
 		}
 	}
-
-	was_empty = TupleBufferIsEmpty(buf);
 
 	pos = start;
 
@@ -238,9 +246,28 @@ TupleBufferInsert(TupleBuffer *buf, Tuple *tuple, Bitmapset *bms)
 	slot->magic = MAGIC;
 	buf->head_id = buf->head->id;
 
-	/* Notify all readers if we were empty. */
-	if (was_empty)
-		TupleBufferNotifyAndClearWaiters(buf);
+	/* Notify any readers waiting for a CQ that is set for this slot. */
+	SpinLockAcquire(&buf->mutex);
+	if (!bms_is_empty(buf->waiters))
+	{
+		Bitmapset *notify = bms_intersect(slot->readby, buf->waiters);
+
+		if (!bms_is_empty(notify))
+		{
+			int i;
+
+			buf->waiters = bms_del_members(buf->waiters, notify);
+
+			while ((i = bms_first_member(notify)) >= 0)
+				TupleBufferNotify(buf, i);
+		}
+
+		bms_free(notify);
+	}
+	SpinLockRelease(&buf->mutex);
+
+	/* Mark this latch as invalid. */
+	buf->writer_latch.owner_pid = 0;
 
 	LWLockRelease(buf->tail_lock);
 	LWLockRelease(buf->head_lock);
@@ -311,6 +338,8 @@ TupleBufferInit(char *name, Size size, LWLock *head_lock, LWLock *tail_lock, uin
 		TupleBufferExpandLatchArray(buf, INIT_CQS);
 
 		SpinLockInit(&buf->mutex);
+
+		MemSet(&buf->writer_latch, 0, sizeof(Latch));
 	}
 
 	LWLockRelease(PipelineMetadataLock);
@@ -333,6 +362,9 @@ TupleBufferOpenReader(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, uint8
 	reader->num_readers = num_readers;
 	reader->slot = NULL;
 	reader->slot_id = 0;
+
+	MyReaders = lappend(MyReaders, reader);
+
 	return reader;
 }
 
@@ -342,6 +374,7 @@ TupleBufferOpenReader(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, uint8
 void
 TupleBufferCloseReader(TupleBufferReader *reader)
 {
+	MyReaders = list_delete(MyReaders, reader);
 	pfree(reader);
 }
 
@@ -465,6 +498,9 @@ unpin_slot(int32_t cq_id, TupleBufferSlot *slot)
 			if (TupleBufferIsEmpty(buf))
 				break;
 
+			if (buf->writer_latch.owner_pid)
+				SetLatch(&buf->writer_latch);
+
 			buf->tail_id = buf->tail->id;
 		}
 		while (bms_is_empty(buf->tail->readby));
@@ -500,22 +536,6 @@ TupleBufferInitLatch(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, Latch 
 	memcpy(&buf->latches[cq_id][reader_id], proclatch, sizeof(Latch));
 }
 
-static void
-clear_readers(Bitmapset *readers)
-{
-	int i;
-	for (i = 0; i < readers->nwords; i++)
-		readers->words[i] = 0;
-}
-
-static void
-notify_readers(TupleBuffer *buf, Bitmapset *readers)
-{
-	int32 id;
-	while ((id = bms_first_member(readers)) >= 0)
-		TupleBufferNotify(buf, id);
-}
-
 /*
  * TupleBufferWait
  */
@@ -523,35 +543,11 @@ void
 TupleBufferWait(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id)
 {
 	SpinLockAcquire(&buf->mutex);
-
-	if (!TupleBufferIsEmpty(buf))
-	{
-		SpinLockRelease(&buf->mutex);
-		return;
-	}
-
 	bms_add_member(buf->waiters, cq_id);
 	ResetLatch((&buf->latches[cq_id][reader_id]));
 	SpinLockRelease(&buf->mutex);
 
 	WaitLatch((&buf->latches[cq_id][reader_id]), WL_LATCH_SET, 0);
-}
-
-/*
- * TupleBufferNotifyAndClearWaiters
- */
-void
-TupleBufferNotifyAndClearWaiters(TupleBuffer *buf)
-{
-	Bitmapset *waiters;
-
-	SpinLockAcquire(&buf->mutex);
-	waiters = bms_copy(buf->waiters);
-	clear_readers(buf->waiters);
-	SpinLockRelease(&buf->mutex);
-
-	notify_readers(buf, waiters);
-	bms_free(waiters);
 }
 
 /*
@@ -606,14 +602,7 @@ TupleBufferExpandLatchArray(TupleBuffer *buf, uint32_t cq_id)
 	waiters->nwords = buf->max_cqs / BITS_PER_BITMAPWORD;
 
 	if (max_cqs)
-	{
-		uint16_t i;
-
 		memcpy(latches, buf->latches, sizeof(Latch *) * max_cqs);
-		for (i = 1; i <= max_cqs; i++)
-			if (bms_is_member(i, buf->waiters))
-				waiters = bms_add_member(waiters, i);
-	}
 
 	SpinLockAcquire(&buf->mutex);
 
@@ -625,6 +614,11 @@ TupleBufferExpandLatchArray(TupleBuffer *buf, uint32_t cq_id)
 
 	if (max_cqs)
 	{
+		uint16_t i;
+		for (i = 1; i <= max_cqs; i++)
+			if (bms_is_member(i, tmp_waiters))
+				waiters = bms_add_member(waiters, i);
+
 		spfree(tmp_latches);
 		spfree(tmp_waiters);
 	}
@@ -664,6 +658,35 @@ TupleBufferClearPinnedSlots(void)
 	MyPinnedSlots = NIL;
 
 	MemoryContextSwitchTo(oldcontext);
+}
+
+/*
+ * TupleBufferHasUnreadSlots
+ */
+bool
+TupleBufferHasUnreadSlots(void)
+{
+	ListCell *lc;
+
+	foreach(lc, MyReaders)
+	{
+		TupleBufferReader *reader = (TupleBufferReader *) lfirst(lc);
+
+		if (!NoUnreadSlots(reader) && !TupleBufferIsEmpty(reader->buf))
+			return true;
+	}
+
+	return false;
+}
+
+/*
+ * TupleBufferClearReaders
+ */
+void
+TupleBufferClearReaders(void)
+{
+	list_free_deep(MyReaders);
+	MyReaders = NIL;
 }
 
 /*

--- a/src/backend/pipeline/worker.c
+++ b/src/backend/pipeline/worker.c
@@ -129,6 +129,7 @@ ContinuousQueryWorkerRun(Portal portal, ContinuousViewState *state, QueryDesc *q
 	elog(LOG, "\"%s\" worker %d running", queryDesc->plannedstmt->cq_target->relname, MyProcPid);
 
 	MarkWorkerAsRunning(MyCQId, MyWorkerId);
+	pgstat_report_activity(STATE_RUNNING, queryDesc->sourceText);
 
 	TupleBufferInitLatch(WorkerTupleBuffer, MyCQId, MyWorkerId, &MyProc->procLatch);
 
@@ -160,11 +161,9 @@ retry:
 
 		for (;;)
 		{
-			TupleBufferResetNotify(WorkerTupleBuffer, MyCQId, MyWorkerId);
-
-			if (TupleBufferIsEmpty(WorkerTupleBuffer))
+			if (!TupleBufferHasUnreadSlots())
 			{
-				if (TimestampDifferenceExceeds(last_process, GetCurrentTimestamp(), EmptyTupleBufferWaitTime * 1000))
+				if (TimestampDifferenceExceeds(last_process, GetCurrentTimestamp(), EmptyTupleBufferWaitTime))
 				{
 					pgstat_report_activity(STATE_IDLE, queryDesc->sourceText);
 					TupleBufferWait(WorkerTupleBuffer, MyCQId, MyWorkerId);
@@ -173,6 +172,8 @@ retry:
 				else
 					pg_usleep(CQ_DEFAULT_SLEEP_MS * 1000);
 			}
+
+			TupleBufferResetNotify(WorkerTupleBuffer, MyCQId, MyWorkerId);
 
 			StartTransactionCommand();
 			set_snapshot(estate, cqowner);
@@ -244,6 +245,7 @@ retry:
 			CommitTransactionCommand();
 
 		TupleBufferUnpinAllPinnedSlots();
+		TupleBufferClearReaders();
 
 		/* This resets the es_query_ctx and in turn the CQExecutionContext */
 		MemoryContextResetAndDeleteChildren(runcontext);

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2577,24 +2577,24 @@ static struct config_int ConfigureNamesInt[] =
 
 
 	{
-		{"stream_buffer_size", PGC_BACKEND, RESOURCES_MEM,
-			gettext_noop("Sets the maximum size of the stream buffer."),
+		{"tuple_buffer_size", PGC_BACKEND, RESOURCES_MEM,
+			gettext_noop("Sets the maximum size of the tuple buffer."),
 			NULL,
 			GUC_UNIT_BLOCKS
 		},
 		&TupleBufferBlocks,
-		4096, 0, INT_MAX,
+		8192, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 
 	{
-		{"empty_stream_buffer_wait_time", PGC_BACKEND, RESOURCES_MEM,
-			gettext_noop("Wait time in seconds that the worker waits for on an empty buffer before going to sleep."),
+		{"empty_tuple_buffer_wait_time", PGC_BACKEND, RESOURCES_MEM,
+			gettext_noop("Time in milliseconds that the worker waits for on an empty tuple buffer before going to sleep."),
 			NULL,
 			GUC_UNIT_S
 		},
 		&EmptyTupleBufferWaitTime,
-		2, 0, INT_MAX,
+		250, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/pipeline/tuplebuf.h
+++ b/src/include/pipeline/tuplebuf.h
@@ -62,6 +62,7 @@ typedef struct TupleBuffer
 	uint16_t max_cqs;
 	Bitmapset *waiters;
 	Latch **latches;
+	Latch writer_latch;
 } TupleBuffer;
 
 /* Pointer into a stream buffer from the perspective of a continuous query */
@@ -86,22 +87,25 @@ extern TupleBuffer *TupleBufferInit(char *name, Size size, LWLock *head_lock, LW
 extern Size TupleBuffersShmemSize(void);
 extern TupleBufferSlot *TupleBufferInsert(TupleBuffer *buf, Tuple *event, Bitmapset *readers);
 extern bool TupleBufferIsEmpty(TupleBuffer *buf);
+
 extern void TupleBufferInitLatch(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, Latch *proclatch);
 extern void TupleBufferWait(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id);
 extern void TupleBufferNotifyAndClearWaiters(TupleBuffer *buf);
 extern void TupleBufferResetNotify(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id);
 extern void TupleBufferExpandLatchArray(TupleBuffer *buf, uint32_t cq_id);
 extern void TupleBufferNotify(TupleBuffer *buf, uint32_t cq_id);
-extern void TupleBufferDrain(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, uint8_t num_readers);
 
 extern TupleBufferReader *TupleBufferOpenReader(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, uint8_t num_readers);
 extern void TupleBufferCloseReader(TupleBufferReader *reader);
 extern TupleBufferSlot *TupleBufferPinNextSlot(TupleBufferReader *reader);
 extern void TupleBufferUnpinSlot(TupleBufferReader *reader, TupleBufferSlot *slot);
 extern void TupleBufferWaitOnSlot(TupleBufferSlot *slot, int sleepms);
+extern void TupleBufferDrain(TupleBuffer *buf, uint32_t cq_id, uint8_t reader_id, uint8_t num_readers);
 
 extern void TupleBufferUnpinAllPinnedSlots(void);
 extern void TupleBufferClearPinnedSlots(void);
+extern bool TupleBufferHasUnreadSlots(void);
+extern void TupleBufferClearReaders(void);
 
 extern TupleDesc TupleHeaderUnpack(char *raw);
 extern char *TupleHeaderPack(TupleDesc desc);


### PR DESCRIPTION
Each CQ background process now starts waiting if it has nothing left in it's TupleBuffer to read. Previously they would only start waiting once the TupleBuffer was empty. This is sub-optimal in cases when one of the CQ workers has much lower throughput than the others.

The INSERT thread will also now sleep if the TupleBuffer is full.
