### PR TITLE
768 stats

### DIFF
--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -19,6 +19,7 @@
 #include "catalog/pipeline_tstate_fn.h"
 #include "libpq/libpq.h"
 #include "miscadmin.h"
+#include "catalog/namespace.h"
 #include "nodes/makefuncs.h"
 #include "parser/analyze.h"
 #include "pipeline/cqanalyze.h"
@@ -318,6 +319,8 @@ GetContinousViewState(RangeVar *rv, ContinuousViewState *cv_state)
 	cv_state->maxwaitms = row->maxwaitms;
 	cv_state->emptysleepms = row->emptysleepms;
 	cv_state->parallelism = row->parallelism;
+	cv_state->viewid = RangeVarGetRelid(rv, NoLock, false);
+
 	namestrcpy(&cv_state->matrelname, NameStr(row->matrelname));
 }
 

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -867,3 +867,19 @@ RETURNS interval
 LANGUAGE INTERNAL
 STRICT IMMUTABLE
 AS 'make_interval';
+
+--
+-- PipelineDB system views
+--
+
+-- CQ process-level stats
+CREATE VIEW pipeline_proc_stats AS
+	SELECT name, type, pid, start_time,
+		input_rows, output_rows, updates, input_bytes,
+		output_bytes, updated_bytes, executions, errors FROM cq_stat_proc_get();
+
+-- Global CQ stats
+CREATE VIEW pipeline_query_stats AS
+	SELECT name, type, input_rows, output_rows, updates, input_bytes,
+		output_bytes, updated_bytes, errors FROM cq_stat_get();
+

--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -10,6 +10,7 @@
  */
 
 #include "postgres.h"
+#include "pgstat.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/reloptions.h"

--- a/src/backend/executor/nodeStreamscan.c
+++ b/src/backend/executor/nodeStreamscan.c
@@ -10,6 +10,7 @@
  */
 
 #include "postgres.h"
+#include "pgstat.h"
 
 #include "access/htup_details.h"
 #include "executor/executor.h"
@@ -96,6 +97,8 @@ StreamScanNext(StreamScanState *node)
 
 	tup = ExecStreamProject(tbs->tuple, node);
 	ExecStoreTuple(tup, slot, InvalidBuffer, false);
+
+	IncrementCQRead(1, tbs->size);
 
 	/*
 	 * We don't necessarily know when parent nodes will be done with this

--- a/src/backend/pipeline/combiner.c
+++ b/src/backend/pipeline/combiner.c
@@ -65,6 +65,8 @@ receive_tuple(TupleTableSlot *slot)
 	if (tbs == NULL)
 		return false;
 
+	IncrementCQRead(1, tbs->size);
+
 	ExecStoreTuple(heap_copytuple(tbs->tuple->heaptup), slot, InvalidBuffer, false);
 	TupleBufferUnpinSlot(reader, tbs);
 
@@ -348,11 +350,13 @@ sync_combine(char *cvname, Tuplestorestate *results,
 
 			ExecStoreTuple(updated, slot, InvalidBuffer, false);
 			ExecCQMatRelUpdate(ri, slot);
+			IncrementCQUpdate(1, HEAPTUPLESIZE + updated->t_len);
 		}
 		else
 		{
 			/* No existing tuple found, so it's an INSERT */
 			ExecCQMatRelInsert(ri, slot);
+			IncrementCQWrite(1, HEAPTUPLESIZE + slot->tts_tuple->t_len);
 		}
 	}
 	CQMatViewClose(ri);
@@ -462,6 +466,8 @@ ContinuousQueryCombinerRun(Portal portal, ContinuousViewState *state, QueryDesc 
 	MemoryContext combinectx;
 	MemoryContext tmpctx;
 
+	cq_stat_initialize(state->viewid, MyProcPid);
+
 	CQExecutionContext = AllocSetContextCreate(runctx, "CQExecutionContext",
 			ALLOCSET_DEFAULT_MINSIZE,
 			ALLOCSET_DEFAULT_INITSIZE,
@@ -522,6 +528,9 @@ retry:
 			{
 				if (TimestampDifferenceExceeds(last_receive, GetCurrentTimestamp(), empty_tuple_buffer_wait_time))
 				{
+					/* force stats flush */
+					cq_stat_report(true);
+
 					pgstat_report_activity(STATE_IDLE, queryDesc->sourceText);
 					TupleBufferWait(CombinerTupleBuffer, MyCQId, 0);
 					pgstat_report_activity(STATE_RUNNING, queryDesc->sourceText);
@@ -577,6 +586,13 @@ retry:
 
 				last_combine = GetCurrentTimestamp();
 				count = 0;
+
+				IncrementCQExecutions(1);
+
+				/*
+				 * Send stats to the collector
+				 */
+				cq_stat_report(false);
 			}
 
 
@@ -636,6 +652,8 @@ retry:
 
 		MemoryContextReset(CQExecutionContext);
 
+		IncrementCQErrors(1);
+
 		if (continuous_query_crash_recovery)
 			goto retry;
 	}
@@ -646,6 +664,12 @@ retry:
 
 	MemoryContextDelete(runctx);
 	MemoryContextSwitchTo(oldcontext);
+
+	/*
+	 * Remove proc-level stats
+	 */
+	cq_stat_report(true);
+	cq_stat_send_purge(state->viewid, MyProcPid, CQ_STAT_COMBINER);
 
 	CurrentResourceOwner = save;
 }

--- a/src/backend/pipeline/combinerReceiver.c
+++ b/src/backend/pipeline/combinerReceiver.c
@@ -13,6 +13,7 @@
 #include <sys/un.h>
 
 #include "postgres.h"
+#include "pgstat.h"
 
 #include "access/printtup.h"
 #include "pipeline/combinerReceiver.h"
@@ -44,8 +45,10 @@ combiner_receive(TupleTableSlot *slot, DestReceiver *self)
 {
 	CombinerState *c = (CombinerState *) self;
 	MemoryContext old = MemoryContextSwitchTo(CQExecutionContext);
+	TupleBufferSlot *tbs;
 
-	TupleBufferInsert(CombinerTupleBuffer, MakeTuple(ExecMaterializeSlot(slot), NULL), c->readers);
+	tbs = TupleBufferInsert(CombinerTupleBuffer, MakeTuple(ExecMaterializeSlot(slot), NULL), c->readers);
+	IncrementCQWrite(1, tbs->size);
 
 	MemoryContextSwitchTo(old);
 }

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -124,6 +124,11 @@ char	   *pgstat_stat_tmpname = NULL;
  */
 PgStat_MsgBgWriter BgWriterStats;
 
+/*
+ * If we're a CQ process, this tracks our various runtime stats
+ */
+CQStatEntry MyCQStats;
+
 /* ----------
  * Local data
  * ----------
@@ -171,6 +176,8 @@ static HTAB *pgStatFunctions = NULL;
  * sent to the collector.
  */
 static bool have_function_stats = false;
+
+CQStatEntry MyCQStats;
 
 /*
  * Tuple insertion/deletion counts for an open transaction can't be propagated
@@ -260,7 +267,7 @@ static PgStat_StatTabEntry *pgstat_get_tab_entry(PgStat_StatDBEntry *dbentry,
 static void pgstat_write_statsfiles(bool permanent, bool allDbs);
 static void pgstat_write_db_statsfile(PgStat_StatDBEntry *dbentry, bool permanent);
 static HTAB *pgstat_read_statsfiles(Oid onlydb, bool permanent, bool deep);
-static void pgstat_read_db_statsfile(Oid databaseid, HTAB *tabhash, HTAB *funchash, bool permanent);
+static void pgstat_read_db_statsfile(Oid databaseid, HTAB *tabhash, HTAB *funchash, HTAB *cont_queries, bool permanent);
 static void backend_read_statsfile(void);
 static void pgstat_read_current_status(void);
 
@@ -295,6 +302,9 @@ static void pgstat_recv_funcpurge(PgStat_MsgFuncpurge *msg, int len);
 static void pgstat_recv_recoveryconflict(PgStat_MsgRecoveryConflict *msg, int len);
 static void pgstat_recv_deadlock(PgStat_MsgDeadlock *msg, int len);
 static void pgstat_recv_tempfile(PgStat_MsgTempFile *msg, int len);
+
+static void cq_stat_recv(CQStatMsg *msg, int len);
+static void cq_stat_recv_purge(CQStatPurgeMsg *msg, int len);
 
 /* ------------------------------------------------------------
  * Public functions called from postmaster follow
@@ -3373,6 +3383,14 @@ PgstatCollectorMain(int argc, char *argv[])
 					pgstat_recv_tempfile((PgStat_MsgTempFile *) &msg, len);
 					break;
 
+				case PGSTAT_MTYPE_CQ:
+					cq_stat_recv((CQStatMsg *) &msg, len);
+					break;
+
+				case PGSTAT_MTYPE_CQ_PURGE:
+					cq_stat_recv_purge((CQStatPurgeMsg *) &msg, len);
+					break;
+
 				default:
 					break;
 			}
@@ -3493,6 +3511,12 @@ reset_dbentry_counters(PgStat_StatDBEntry *dbentry)
 									 PGSTAT_FUNCTION_HASH_SIZE,
 									 &hash_ctl,
 									 HASH_ELEM | HASH_FUNCTION);
+
+	hash_ctl.keysize = sizeof(int64);
+	hash_ctl.entrysize = sizeof(CQStatEntry);
+	hash_ctl.hash = tag_hash;
+	dbentry->cont_queries = hash_create("Per-CQ", 256, &hash_ctl,
+					   HASH_ELEM | HASH_FUNCTION);
 }
 
 /*
@@ -3765,8 +3789,10 @@ pgstat_write_db_statsfile(PgStat_StatDBEntry *dbentry, bool permanent)
 {
 	HASH_SEQ_STATUS tstat;
 	HASH_SEQ_STATUS fstat;
+	HASH_SEQ_STATUS qstat;
 	PgStat_StatTabEntry *tabentry;
 	PgStat_StatFuncEntry *funcentry;
+	CQStatEntry *cqentry;
 	FILE	   *fpout;
 	int32		format_id;
 	Oid			dbid = dbentry->databaseid;
@@ -3818,6 +3844,17 @@ pgstat_write_db_statsfile(PgStat_StatDBEntry *dbentry, bool permanent)
 	{
 		fputc('F', fpout);
 		rc = fwrite(funcentry, sizeof(PgStat_StatFuncEntry), 1, fpout);
+		(void) rc;				/* we'll check for error with ferror */
+	}
+
+	/*
+	 * Walk through the database's continuous query stats table.
+	 */
+	hash_seq_init(&qstat, dbentry->cont_queries);
+	while ((cqentry = (CQStatEntry *) hash_seq_search(&qstat)) != NULL)
+	{
+		fputc('Q', fpout);
+		rc = fwrite(cqentry, sizeof(CQStatEntry), 1, fpout);
 		(void) rc;				/* we'll check for error with ferror */
 	}
 
@@ -4039,6 +4076,13 @@ pgstat_read_statsfiles(Oid onlydb, bool permanent, bool deep)
 												 &hash_ctl,
 								   HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
 
+				hash_ctl.keysize = sizeof(int64);
+				hash_ctl.entrysize = sizeof(CQStatEntry);
+				hash_ctl.hash = tag_hash;
+				hash_ctl.hcxt = pgStatLocalContext;
+				dbentry->cont_queries = hash_create("Per-CQ", 256, &hash_ctl,
+								   HASH_ELEM | HASH_FUNCTION | HASH_CONTEXT);
+
 				/*
 				 * If requested, read the data from the database-specific
 				 * file. If there was onlydb specified (!= InvalidOid), we
@@ -4049,6 +4093,7 @@ pgstat_read_statsfiles(Oid onlydb, bool permanent, bool deep)
 					pgstat_read_db_statsfile(dbentry->databaseid,
 											 dbentry->tables,
 											 dbentry->functions,
+											 dbentry->cont_queries,
 											 permanent);
 
 				break;
@@ -4089,13 +4134,16 @@ done:
  * ----------
  */
 static void
-pgstat_read_db_statsfile(Oid databaseid, HTAB *tabhash, HTAB *funchash,
+pgstat_read_db_statsfile(Oid databaseid, HTAB *tabhash, HTAB *funchash, HTAB *cont_queries,
 						 bool permanent)
 {
 	PgStat_StatTabEntry *tabentry;
 	PgStat_StatTabEntry tabbuf;
 	PgStat_StatFuncEntry funcbuf;
 	PgStat_StatFuncEntry *funcentry;
+	CQStatEntry cqbuf;
+	CQStatEntry *cqentry;
+
 	FILE	   *fpin;
 	int32		format_id;
 	bool		found;
@@ -4207,6 +4255,38 @@ pgstat_read_db_statsfile(Oid databaseid, HTAB *tabhash, HTAB *funchash,
 				}
 
 				memcpy(funcentry, &funcbuf, sizeof(funcbuf));
+				break;
+
+				/*
+				 * 'Q'	A CQStatEntry follows.
+				 */
+			case 'Q':
+				if (fread(&cqbuf, 1, sizeof(CQStatEntry), fpin) != sizeof(CQStatEntry))
+				{
+					ereport(pgStatRunningInCollector ? LOG : WARNING,
+							(errmsg("corrupted statistics file \"%s\"",
+									statfile)));
+					goto done;
+				}
+
+				/*
+				 * Skip if CQ belongs to a not requested database.
+				 */
+				if (cont_queries == NULL)
+					break;
+
+				cqentry = (CQStatEntry *) hash_search(cont_queries,
+												(void *) &cqbuf.key, HASH_ENTER, &found);
+
+				if (found)
+				{
+					ereport(pgStatRunningInCollector ? LOG : WARNING,
+							(errmsg("corrupted statistics file \"%s\"",
+									statfile)));
+					goto done;
+				}
+
+				memcpy(cqentry, &cqbuf, sizeof(cqbuf));
 				break;
 
 				/*
@@ -4777,6 +4857,8 @@ pgstat_recv_dropdb(PgStat_MsgDropdb *msg, int len)
 			hash_destroy(dbentry->tables);
 		if (dbentry->functions != NULL)
 			hash_destroy(dbentry->functions);
+		if (dbentry->cont_queries != NULL)
+			hash_destroy(dbentry->cont_queries);
 
 		if (hash_search(pgStatDBHash,
 						(void *) &dbid,
@@ -5213,4 +5295,201 @@ pgstat_db_requested(Oid databaseid)
 	}
 
 	return false;
+}
+
+/*
+ * cq_stat_fetch_all
+ *
+ * Get all stats, which includes proc-level CQ-level stats
+ */
+HTAB *
+cq_stat_fetch_all(void)
+{
+	PgStat_StatDBEntry *dbentry;
+	/*
+	 * If not done for this transaction, read the statistics collector stats
+	 * file into some hash tables.
+	 */
+	backend_read_statsfile();
+
+	dbentry = pgstat_get_db_entry(MyDatabaseId, true);
+	if (!dbentry)
+		return NULL;
+
+	return dbentry->cont_queries;
+}
+
+
+/*
+ * cq_stat_initialize
+ *
+ * Create a new stats instance for the given CQ proc
+ */
+void
+cq_stat_initialize(Oid viewid, int32 pid)
+{
+	MemSet(&MyCQStats, 0, sizeof(CQStatEntry));
+
+	MyCQStats.start_ts = GetCurrentTimestamp();
+
+	SetCQStatView(MyCQStats.key, viewid);
+	SetCQStatProcPid(MyCQStats.key, pid);
+	SetCQStatProcType(MyCQStats.key, IsWorker ? CQ_STAT_WORKER : CQ_STAT_COMBINER);
+}
+
+/*
+ * cq_stat_report
+ *
+ * Send PipelineDB CQ stats
+ */
+void
+cq_stat_report(bool force)
+{
+	static TimestampTz last_report = 0;
+	TimestampTz now;
+	CQStatMsg msg;
+
+	/*
+	 * Don't send a message unless it's been at least PGSTAT_STAT_INTERVAL
+	 * msec since we last sent one, or the caller wants to force stats out.
+	 */
+	now = GetCurrentTimestamp();
+	if (!force &&
+		!TimestampDifferenceExceeds(last_report, now, PGSTAT_STAT_INTERVAL))
+		return;
+	last_report = now;
+
+	MemSet(&msg, 0, sizeof(CQStatMsg));
+	msg.m_entry = MyCQStats;
+	msg.m_databaseid = MyDatabaseId;
+
+	pgstat_setheader(&msg.m_hdr, PGSTAT_MTYPE_CQ);
+	pgstat_send(&msg, sizeof(msg));
+
+	MyCQStats.input_rows = 0;
+	MyCQStats.output_rows = 0;
+	MyCQStats.updates = 0;
+	MyCQStats.input_bytes = 0;
+	MyCQStats.output_bytes = 0;
+	MyCQStats.updated_bytes = 0;
+	MyCQStats.executions = 0;
+	MyCQStats.errors = 0;
+}
+
+/*
+ * cq_stat_get_entry
+ *
+ * Retrieve a CQ stats entry matching the given parameters
+ */
+CQStatEntry *
+cq_stat_get_entry(PgStat_StatDBEntry *dbentry, Oid viewoid, int pid, int ptype)
+{
+	CQStatEntry *result;
+	bool found;
+	int64 key = 0;
+
+	SetCQStatView(key, viewoid);
+	SetCQStatProcPid(key, pid);
+	SetCQStatProcType(key, ptype);
+
+	result = (CQStatEntry *) hash_search(dbentry->cont_queries, (void *) &key, HASH_ENTER, &found);
+	if (!found)
+	{
+		MemSet(result, 0, sizeof(CQStatEntry));
+		result->key = key;
+	}
+
+	return result;
+}
+
+/*
+ * cq_stat_recv
+ *
+ * Receive PipelineDB CQ stats
+ */
+static void
+cq_stat_recv(CQStatMsg *msg, int len)
+{
+	CQStatEntry stats = msg->m_entry;
+	CQStatEntry *existing;
+	PgStat_StatDBEntry *db;
+	Oid viewid = GetCQStatView(stats.key);
+	int pid = GetCQStatProcPid(stats.key);
+	int ptype = GetCQStatProcType(stats.key);
+
+	db = pgstat_get_db_entry(msg->m_databaseid, false);
+
+	/*
+	 * Aggregate the process-level stats
+	 */
+	existing = cq_stat_get_entry(db, viewid, pid, ptype);
+	if (!existing->start_ts)
+		existing->start_ts = stats.start_ts;
+
+	existing->input_rows += stats.input_rows;
+	existing->output_rows += stats.output_rows;
+	existing->input_bytes += stats.input_bytes;
+	existing->output_bytes += stats.output_bytes;
+	existing->updates += stats.updates;
+	existing->updated_bytes += stats.updated_bytes;
+	existing->executions += stats.executions;
+	existing->errors += stats.errors;
+
+	/*
+	 * Now aggregate the CQ-level stats across all procs of this type
+	 */
+	existing = cq_stat_get_entry(db, viewid, 0, ptype);
+	existing->input_rows += stats.input_rows;
+	existing->output_rows += stats.output_rows;
+	existing->input_bytes += stats.input_bytes;
+	existing->output_bytes += stats.output_bytes;
+	existing->updates += stats.updates;
+	existing->updated_bytes += stats.updated_bytes;
+	existing->errors += stats.errors;
+}
+
+/*
+ * cq_stat_send_purge
+ *
+ * Send a message to the collector indicating that the given CQ proc's
+ * stats can be discarded
+ */
+void
+cq_stat_send_purge(Oid viewid, int pid, int64 ptype)
+{
+	CQStatPurgeMsg msg;
+
+	MemSet(&msg, 0, sizeof(CQStatPurgeMsg));
+
+	SetCQStatView(msg.m_key, viewid);
+	SetCQStatProcPid(msg.m_key, pid);
+	SetCQStatProcType(msg.m_key, IsWorker ? CQ_STAT_WORKER : CQ_STAT_COMBINER);
+
+	msg.m_databaseid = MyDatabaseId;
+
+	pgstat_setheader(&msg.m_hdr, PGSTAT_MTYPE_CQ_PURGE);
+	pgstat_send(&msg, sizeof(msg));
+}
+
+/*
+ * cq_stat_recv_purge
+ *
+ * Remove an obsolete CQ proc's stats
+ */
+static void
+cq_stat_recv_purge(CQStatPurgeMsg *msg, int len)
+{
+	PgStat_StatDBEntry *dbentry;
+
+
+	dbentry = pgstat_get_db_entry(msg->m_databaseid, false);
+
+	/*
+	 * No need to purge if we don't even know the database.
+	 */
+	if (!dbentry || !dbentry->cont_queries)
+		return;
+
+	/* Remove from hashtable if present; we don't care if it's not. */
+	(void) hash_search(dbentry->cont_queries, (void *) &msg->m_key, HASH_REMOVE, NULL);
 }

--- a/src/backend/utils/adt/Makefile
+++ b/src/backend/utils/adt/Makefile
@@ -35,7 +35,7 @@ OBJS = acl.o arrayfuncs.o array_selfuncs.o array_typanalyze.o \
 	tsvector.o tsvector_op.o tsvector_parser.o \
 	txid.o uuid.o varbit.o varchar.o varlena.o version.o \
 	windowfuncs.o xid.o xml.o hllfuncs.o bloomfuncs.o tdigestfuncs.o \
-	cmsketchfuncs.o
+	cmsketchfuncs.o cqstatfuncs.o
 
 like.o: like.c like_match.c
 

--- a/src/backend/utils/adt/cqstatfuncs.c
+++ b/src/backend/utils/adt/cqstatfuncs.c
@@ -1,0 +1,236 @@
+/*-------------------------------------------------------------------------
+ *
+ * cqstatfuncs.c
+ *		Functions for retrieving CQ statistics
+ *
+ * IDENTIFICATION
+ *	  src/backend/utils/adt/cqstatfuncs.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+#include "pgstat.h"
+#include "funcapi.h"
+
+#include "access/htup_details.h"
+#include "catalog/pg_type.h"
+#include "utils/builtins.h"
+#include "utils/cqstatfuncs.h"
+#include "utils/rel.h"
+
+/*
+ * cq_stat_proc_get
+ *
+ * Look up CQ process-level stats in the stats hashtables
+ * and return them in the form of rows so that we can use
+ * this function as a data source in views
+ */
+Datum
+cq_stat_proc_get(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	HTAB *stats;
+	CQStatEntry *entry;
+	HASH_SEQ_STATUS *iter;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		TupleDesc	tupdesc;
+		MemoryContext oldcontext;
+
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		/* build tupdesc for result tuples */
+		tupdesc = CreateTemplateTupleDesc(12, false);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "name", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "type", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "pid", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "start_time", TIMESTAMPTZOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "input_rows", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "output_rows", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "updated_rows", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "input_bytes", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "output_bytes", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 10, "updated_bytes", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 11, "executions", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 12, "errors", INT8OID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		stats = cq_stat_fetch_all();
+		if (!stats)
+			SRF_RETURN_DONE(funcctx);
+
+		iter = palloc0(sizeof(HASH_SEQ_STATUS));
+		hash_seq_init(iter, stats);
+
+		funcctx->user_fctx = (void *) iter;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = (FuncCallContext *) fcinfo->flinfo->fn_extra;
+	iter = (HASH_SEQ_STATUS *) funcctx->user_fctx;
+
+	while ((entry = (CQStatEntry *) hash_seq_search(iter)) != NULL)
+	{
+		Datum values[12];
+		bool nulls[12];
+		HeapTuple tup;
+		Datum result;
+		int pid = GetCQStatProcPid(entry->key);
+		Oid viewoid = GetCQStatView(entry->key);
+		Relation rel;
+		char *viewname;
+
+		/* keep scanning if it's a CQ-level stats entry */
+		if (!pid)
+			continue;
+
+		/* ignore and purge stale stats entries */
+		rel = try_relation_open(viewoid, NoLock);
+		if (!rel)
+		{
+			cq_stat_send_purge(viewoid, pid, GetCQStatProcType(entry->key));
+			continue;
+		}
+
+		viewname = RelationGetRelationName(rel);
+		heap_close(rel, NoLock);
+
+		/*
+		 * If a pid doesn't exist, kill() with signal 0 will fail and set
+		 * errno to ESRCH
+		 */
+		if (kill(pid, 0) == -1 && errno == ESRCH)
+		{
+			/* stale proc, purge it */
+			cq_stat_send_purge(viewoid, pid, GetCQStatProcType(entry->key));
+			continue;
+		}
+
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, 0, sizeof(nulls));
+
+		values[0] = CStringGetTextDatum(viewname);
+		values[1] = CStringGetTextDatum((GetCQStatProcType(entry->key) == CQ_STAT_WORKER ? "worker" : "combiner"));
+		values[2] = Int32GetDatum(pid);
+		values[3] = TimestampTzGetDatum(entry->start_ts);
+		values[4] = Int64GetDatum(entry->input_rows);
+		values[5] = Int64GetDatum(entry->output_rows);
+		values[6] = Int64GetDatum(entry->updates);
+		values[7] = Int64GetDatum(entry->input_bytes);
+		values[8] = Int64GetDatum(entry->output_bytes);
+		values[9] = Int64GetDatum(entry->updated_bytes);
+		values[10] = Int64GetDatum(entry->executions);
+		values[11] = Int64GetDatum(entry->errors);
+
+		tup = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		result = HeapTupleGetDatum(tup);
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}
+
+/*
+ * cq_stat_get
+ *
+ * Look up all-time CQ-level stats in the stats hashtables
+ * and return them in the form of rows so that we can use
+ * this function as a data source in views.
+ */
+Datum
+cq_stat_get(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	HTAB *stats;
+	CQStatEntry *entry;
+	HASH_SEQ_STATUS *iter;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+
+		TupleDesc	tupdesc;
+		MemoryContext oldcontext;
+
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		/* build tupdesc for result tuples */
+		tupdesc = CreateTemplateTupleDesc(9, false);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "name", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "type", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "input_rows", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "output_rows", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "updates", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 6, "input_bytes", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 7, "output_bytes", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 8, "updated_bytes", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 9, "errors", INT8OID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		stats = cq_stat_fetch_all();
+		if (!stats)
+			SRF_RETURN_DONE(funcctx);
+
+		iter = palloc0(sizeof(HASH_SEQ_STATUS));
+		hash_seq_init(iter, stats);
+
+		funcctx->user_fctx = (void *) iter;
+
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = (FuncCallContext *) fcinfo->flinfo->fn_extra;
+	iter = (HASH_SEQ_STATUS *) funcctx->user_fctx;
+
+	while ((entry = (CQStatEntry *) hash_seq_search(iter)) != NULL)
+	{
+		Datum values[9];
+		bool nulls[9];
+		HeapTuple tup;
+		Datum result;
+		int pid = GetCQStatProcPid(entry->key);
+		Oid viewoid = GetCQStatView(entry->key);
+		Relation rel;
+		char *viewname;
+
+		/* keep scanning if it's a proc-level stats entry */
+		if (pid)
+			continue;
+
+		/* just ignore stale stats entries */
+		rel = try_relation_open(viewoid, NoLock);
+		if (!rel)
+			continue;
+
+		viewname = RelationGetRelationName(rel);
+		heap_close(rel, NoLock);
+
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, 0, sizeof(nulls));
+
+		values[0] = CStringGetTextDatum(viewname);
+		values[1] = CStringGetTextDatum((GetCQStatProcType(entry->key) == CQ_STAT_WORKER ? "worker" : "combiner"));
+		values[2] = Int64GetDatum(entry->input_rows);
+		values[3] = Int64GetDatum(entry->output_rows);
+		values[4] = Int64GetDatum(entry->updates);
+		values[5] = Int64GetDatum(entry->input_bytes);
+		values[6] = Int64GetDatum(entry->output_bytes);
+		values[7] = Int64GetDatum(entry->updated_bytes);
+		values[8] = Int64GetDatum(entry->errors);
+
+		tup = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		result = HeapTupleGetDatum(tup);
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5288,6 +5288,12 @@ DESCR("count-min sketch merge aggregate");
 DATA(insert OID = 4354 ( cmsketch_count	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 23 "5038 2283" _null_ _null_ _null_ _null_ cmsketch_count _null_ _null_ _null_ ));
 DESCR("count-min sketch estimate count");
 
+DATA(insert OID = 4355 ( cq_stat_proc_get PGNSP PGUID 12 1 1000 0 0 f f f f t t s 0 0 2249 "" "{25,25,23,1184,20,20,20,20,20,20,20,20}" "{o,o,o,o,o,o,o,o,o,o,o,o}" "{name,type,pid,start_time,input_rows,output_rows,updates,input_bytes,output_bytes,updated_bytes,executions,errors}" _null_ cq_stat_proc_get _null_ _null_ _null_ ));
+DESCR("get CQ process-level stats");
+
+DATA(insert OID = 4356 ( cq_stat_get PGNSP PGUID 12 1 1000 0 0 f f f f t t s 0 0 2249 "" "{25,25,20,20,20,20,20,20,20}" "{o,o,o,o,o,o,o,o,o}" "{name,type,input_rows,output_rows,updates,input_bytes,output_bytes,updated_bytes,errors}" _null_ cq_stat_get _null_ _null_ _null_ ));
+DESCR("get CQ-level stats");
+
 /*
  * Symbolic values for provolatile column: these indicate whether the result
  * of a function is dependent *only* on the values of its explicit arguments,

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -26,6 +26,7 @@ typedef struct ContinuousViewState
 	int16 parallelism;
 	NameData matrelname;
 	CQProcessType ptype;
+	Oid viewid;
 } ContinuousViewState;
 
 List *GetAllContinuousViewNames(void);

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -164,6 +164,7 @@ extern int MyCQId;
 extern bool IsCombiner;
 extern bool IsWorker;
 extern int MyWorkerId;
+
 #define IsCQBackgroundProcess (IsCombiner || IsWorker)
 #define PIPELINE_PY_TEST "PIPELINE_PY_TESTS"
 #define PIPELINE_DISABLE_SANITIZE "PIPELINE_DISABLE_SANITIZE"

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -62,7 +62,9 @@ typedef enum StatMsgType
 	PGSTAT_MTYPE_FUNCPURGE,
 	PGSTAT_MTYPE_RECOVERYCONFLICT,
 	PGSTAT_MTYPE_TEMPFILE,
-	PGSTAT_MTYPE_DEADLOCK
+	PGSTAT_MTYPE_DEADLOCK,
+	PGSTAT_MTYPE_CQ,
+	PGSTAT_MTYPE_CQ_PURGE
 } StatMsgType;
 
 /* ----------
@@ -584,6 +586,11 @@ typedef struct PgStat_StatDBEntry
 	 */
 	HTAB	   *tables;
 	HTAB	   *functions;
+
+	/*
+	 * PipelineDB CQ stats
+	 */
+	HTAB	   *cont_queries;
 } PgStat_StatDBEntry;
 
 
@@ -636,7 +643,6 @@ typedef struct PgStat_StatFuncEntry
 	PgStat_Counter f_total_time;	/* times in microseconds */
 	PgStat_Counter f_self_time;
 } PgStat_StatFuncEntry;
-
 
 /*
  * Archiver statistics kept in the stats collector
@@ -950,5 +956,108 @@ extern PgStat_StatFuncEntry *pgstat_fetch_stat_funcentry(Oid funcid);
 extern int	pgstat_fetch_stat_numbackends(void);
 extern PgStat_ArchiverStats *pgstat_fetch_stat_archiver(void);
 extern PgStat_GlobalStats *pgstat_fetch_global(void);
+
+/*
+ *	QQ stats process type
+ */
+typedef enum CQStatsType
+{
+	CQ_STAT_COMBINER,
+	CQ_STAT_WORKER,
+} CQStatsType;
+
+/*
+ * PipelineDB stats for continuous queries
+ */
+/*
+ * The collector's data per continuous-query
+ */
+typedef struct CQStatEntry
+{
+	/*
+	 * Three values are packed into this key:
+	 *
+	 * [00:32]: Continuous view Oid
+	 * [32:63]: Continuous query process id (all 0's for view-level stats)
+	 *
+	 *  Note: pids can only be a maximum of 2^22, so we don't actually need
+	 * 	all 32 bits here which is why we can use the last bit for proc type
+	 *
+	 * [63:64]: Continuous query process type, as defined by the above CQ_STAT_*
+	 *
+	 * This compound key format allows us to keep process-level and query-level
+	 * statistics in the same hashtable without having to add much complexity
+	 * to the current stats de/serialization scheme, which expects a single-level
+	 * hashtable having fixed-size entries.
+	 */
+	int64 key;
+
+	TimestampTz start_ts;
+	PgStat_Counter input_rows;
+	PgStat_Counter output_rows;
+	PgStat_Counter updates;
+	PgStat_Counter input_bytes;
+	PgStat_Counter output_bytes;
+	PgStat_Counter updated_bytes;
+	PgStat_Counter executions;
+	PgStat_Counter errors;
+} CQStatEntry;
+
+/*
+ * Message for procs to wrap stats data in
+ */
+typedef struct CQStatMsg
+{
+	PgStat_MsgHdr m_hdr;
+	Oid m_databaseid;
+	CQStatEntry m_entry;
+} CQStatMsg;
+
+/*
+ * Message for dying CQ procs to send to the collector for cleanup
+ */
+typedef struct CQStatPurgeMsg
+{
+	PgStat_MsgHdr m_hdr;
+	int64 m_key;
+	Oid m_databaseid;
+} CQStatPurgeMsg;
+
+extern CQStatEntry MyCQStats;
+
+#define SetCQStatView(key, view) ((key) |= (int64) (view))
+#define SetCQStatProcPid(key, pid) ((key) |= ((int64 ) (pid) << 30L))
+#define SetCQStatProcType(key, type) ((key) |= ((int64) (type) << 63L))
+
+#define GetCQStatView(key) (0xFFFF & (key))
+#define GetCQStatProcPid(key) (0xFFFF & (key >> 30L))
+#define GetCQStatProcType(key) (0x1 & (key >> 63L))
+
+#define IncrementCQRead(rows, nbytes) \
+	do { \
+			MyCQStats.input_rows += (rows); \
+			MyCQStats.input_bytes += (nbytes); \
+	} while(0)
+
+#define IncrementCQWrite(rows, nbytes) \
+	do { \
+			MyCQStats.output_rows += (rows); \
+			MyCQStats.output_bytes += (nbytes); \
+	} while(0)
+
+#define IncrementCQUpdate(count, nbytes) \
+	do { \
+			MyCQStats.updates += (count); \
+			MyCQStats.updated_bytes += (nbytes); \
+	} while(0)
+
+#define IncrementCQExecutions(n) (MyCQStats.executions += (n))
+#define IncrementCQErrors(n) (MyCQStats.errors += (n))
+
+HTAB *cq_stat_fetch_all(void);
+void cq_stat_initialize(Oid viewid, int32 pid);
+void cq_stat_report(bool force);
+void cq_stat_send_purge(Oid viewid, int pid, int64 ptype);
+CQStatEntry *cq_stat_get_entry(PgStat_StatDBEntry *dbentry, Oid viewoid, int pid, int ptype);
 
 #endif   /* PGSTAT_H */

--- a/src/include/utils/cqstatfuncs.h
+++ b/src/include/utils/cqstatfuncs.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * cqstatfuncs.h
+
+ *	  Interface for CQ stats functions
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef CQSTATFUNCS_H
+#define CQSTATFUNCS_H
+
+/* CQ process-level stats */
+extern Datum cq_stat_proc_get(PG_FUNCTION_ARGS);
+
+/* CQ all-time stats */
+extern Datum cq_stat_get(PG_FUNCTION_ARGS);
+
+#endif

--- a/src/test/py/base.py
+++ b/src/test/py/base.py
@@ -215,6 +215,18 @@ class PipelineDB(object):
         s = on and 'on' or 'off'
         return self.execute('SET debug_sync_stream_insert = %s' % s)
 
+    def begin(self):
+        """
+        Begin a transaction
+        """
+        return self.execute('BEGIN')
+
+    def commit(self):
+        """
+        Commit a transaction
+        """
+        return self.execute('COMMIT')
+
 
 @pytest.fixture
 def clean_db(request):

--- a/src/test/py/test_cq_stats.py
+++ b/src/test/py/test_cq_stats.py
@@ -1,0 +1,59 @@
+from base import pipeline, clean_db
+import random
+import time
+
+
+def test_cq_stats(pipeline, clean_db):
+    """
+    Verify that CQ statistics collection works
+    """
+    # 10 rows
+    q = 'SELECT x::integer %% 10 AS g, COUNT(*) FROM stream GROUP BY g'
+    pipeline.create_cv('test_10_groups', q)
+    
+    # 1 row
+    q = 'SELECT COUNT(*) FROM stream'
+    pipeline.create_cv('test_1_group', q)
+    
+    pipeline.activate()
+    
+    values = [(random.randint(1, 1024),) for n in range(1000)]
+    
+    pipeline.insert('stream', ('x',), values)
+    
+    proc_rows = 0
+    cq_rows = 0
+    while proc_rows != 4 and cq_rows != 4:
+        pipeline.begin()
+        proc_result = pipeline.execute('SELECT * FROM pipeline_proc_stats')
+        cq_result = pipeline.execute('SELECT * FROM pipeline_query_stats')
+        pipeline.commit()
+        proc_rows = len(list(proc_result))
+        cq_rows = len(list(cq_result))
+    
+    assert proc_rows == 4
+    assert cq_rows == 4
+    
+    pipeline.deactivate()
+
+    # Proc-level stats should be gone now
+    pipeline.begin()
+    result = pipeline.execute('SELECT * FROM pipeline_proc_stats')
+    pipeline.commit()
+    
+    assert not result.first()
+    
+    time.sleep(0.5)
+    
+    # But CQ-level stats should still be there
+    result = pipeline.execute("SELECT * FROM pipeline_query_stats WHERE name = 'test_10_groups' AND type = 'worker'").first()
+    assert result['input_rows'] == 1000
+    
+    result = pipeline.execute("SELECT * FROM pipeline_query_stats WHERE name = 'test_10_groups' AND type = 'combiner'").first()
+    assert result['output_rows'] == 10
+    
+    result = pipeline.execute("SELECT * FROM pipeline_query_stats WHERE name = 'test_1_group' AND type = 'worker'").first()
+    assert result['input_rows'] == 1000
+    
+    result = pipeline.execute("SELECT * FROM pipeline_query_stats WHERE name = 'test_1_group' AND type = 'combiner'").first()
+    assert result['output_rows'] == 1

--- a/src/test/regress/expected/cont_sw_hs_agg.out
+++ b/src/test/regress/expected/cont_sw_hs_agg.out
@@ -183,7 +183,7 @@ SELECT * FROM test_sw_dense_rank2;
          31 |   51
 (1 row)
 
--- Now use a small windoww to verify that sliding window results change over time
+-- Now use a small window to verify that sliding window results change over time
 CREATE CONTINUOUS VIEW test_sw_hs_change AS SELECT 
 rank(5, -5) WITHIN GROUP (ORDER BY x::integer, y::integer),
 dense_rank(5, -5) WITHIN GROUP (ORDER BY x, y),

--- a/src/test/regress/expected/rules.out
+++ b/src/test/regress/expected/rules.out
@@ -2088,6 +2088,29 @@ pg_views| SELECT n.nspname AS schemaname,
    FROM (pg_class c
      LEFT JOIN pg_namespace n ON ((n.oid = c.relnamespace)))
   WHERE (c.relkind = 'v'::"char");
+pipeline_proc_stats| SELECT cq_stat_proc_get.name,
+    cq_stat_proc_get.type,
+    cq_stat_proc_get.pid,
+    cq_stat_proc_get.start_time,
+    cq_stat_proc_get.input_rows,
+    cq_stat_proc_get.output_rows,
+    cq_stat_proc_get.updates,
+    cq_stat_proc_get.input_bytes,
+    cq_stat_proc_get.output_bytes,
+    cq_stat_proc_get.updated_bytes,
+    cq_stat_proc_get.executions,
+    cq_stat_proc_get.errors
+   FROM cq_stat_proc_get() cq_stat_proc_get(name, type, pid, start_time, input_rows, output_rows, updates, input_bytes, output_bytes, updated_bytes, executions, errors);
+pipeline_query_stats| SELECT cq_stat_get.name,
+    cq_stat_get.type,
+    cq_stat_get.input_rows,
+    cq_stat_get.output_rows,
+    cq_stat_get.updates,
+    cq_stat_get.input_bytes,
+    cq_stat_get.output_bytes,
+    cq_stat_get.updated_bytes,
+    cq_stat_get.errors
+   FROM cq_stat_get() cq_stat_get(name, type, input_rows, output_rows, updates, input_bytes, output_bytes, updated_bytes, errors);
 raster_columns| SELECT current_database() AS r_table_catalog,
     n.nspname AS r_table_schema,
     c.relname AS r_table_name,

--- a/src/test/regress/sql/cont_sw_hs_agg.sql
+++ b/src/test/regress/sql/cont_sw_hs_agg.sql
@@ -78,7 +78,7 @@ SELECT * FROM test_sw_dense_rank0;
 SELECT * FROM test_sw_dense_rank1;
 SELECT * FROM test_sw_dense_rank2;
 
--- Now use a small windoww to verify that sliding window results change over time
+-- Now use a small window to verify that sliding window results change over time
 CREATE CONTINUOUS VIEW test_sw_hs_change AS SELECT 
 rank(5, -5) WITHIN GROUP (ORDER BY x::integer, y::integer),
 dense_rank(5, -5) WITHIN GROUP (ORDER BY x, y),


### PR DESCRIPTION
This adds two new stats tables:
- `pipeline_proc_stats`: Process-level stats for continuous queries. When procs die, their records are deleted from this view.
- `pipeline_query_stats`: Query-level stats for continuous queries. This view has the all-time aggregates for all CQ procs that have ever run for a continuous view.

Here's what they look like:

```
derek=# \d pipeline_proc_stats;
        View "pg_catalog.pipeline_proc_stats"
    Column     |           Type           | Modifiers 
---------------+--------------------------+-----------
 name          | text                     | 
 type          | text                     | 
 pid           | integer                  | 
 start_time    | timestamp with time zone | 
 input_rows    | bigint                   | 
 output_rows   | bigint                   | 
 updates       | bigint                   | 
 input_bytes   | bigint                   | 
 output_bytes  | bigint                   | 
 updated_bytes | bigint                   | 
 executions    | bigint                   | 
 errors        | bigint                   | 

derek=# \d pipeline_query_stats;
View "pg_catalog.pipeline_query_stats"
    Column     |  Type  | Modifiers 
---------------+--------+-----------
 name          | text   | 
 type          | text   | 
 input_rows    | bigint | 
 output_rows   | bigint | 
 updates       | bigint | 
 input_bytes   | bigint | 
 output_bytes  | bigint | 
 updated_bytes | bigint | 
 errors        | bigint | 

```

Note: this PR is affected by #779 .
