### PR TITLE
777 license key system

### DIFF
--- a/bin/generate-license
+++ b/bin/generate-license
@@ -1,0 +1,51 @@
+#! /usr/bin/python
+
+import argparse
+from Crypto.Cipher import AES
+from Crypto import Random
+
+import calendar
+import datetime
+from datetime import timedelta
+
+import binascii
+
+__all__ = ['encode', 'decode']
+
+key = 'THEPIPELINEKEY00'
+pad = lambda s: s + (16 - len(s) % 16) * ' '
+
+def encode(d):
+    j = pad(d)
+    iv = Random.new().read(AES.block_size)
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    return binascii.hexlify(iv + cipher.encrypt(j))
+
+def decode(d):
+    enc = binascii.unhexlify(str(d))
+    iv = enc[:16]
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    return unpad(cipher.decrypt(enc[16:]))
+
+def get_utc_timestamp():
+    return calendar.timegm(datetime.datetime.utcnow().utctimetuple())
+
+def generate_license_key(start_ts=None, end_ts=None, days=30):
+    if not start_ts:
+        start_ts = get_utc_timestamp()
+    if not end_ts:
+        end_ts = start_ts + days * 86400
+
+    s = '%d:%d' % (start_ts, end_ts)
+    end_ts = datetime.datetime.utcfromtimestamp(long(end_ts))
+    return encode(s), end_ts
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--days', action='store', dest='days', required=True, type=int,
+                    help='Duration in days until the key expires')
+    args = parser.parse_args()
+    key, expires = generate_license_key(days=args.days)
+    print key
+    print 'valid until', expires
+

--- a/configure
+++ b/configure
@@ -1512,7 +1512,7 @@ Optional Packages:
   --with-pam              build with PAM support
   --with-ldap             build with LDAP support
   --with-bonjour          build with Bonjour support
-  --with-openssl          build with OpenSSL support
+  --without-openssl       build without OpenSSL support
   --with-selinux          build with SELinux support
   --without-readline      do not use GNU Readline nor BSD Libedit for editing
   --with-libedit-preferred
@@ -5537,7 +5537,9 @@ $as_echo "#define USE_SSL 1" >>confdefs.h
   esac
 
 else
-  with_openssl=no
+  with_openssl=yes
+
+$as_echo "#define USE_SSL 1" >>confdefs.h
 
 fi
 
@@ -16409,3 +16411,4 @@ else
   as_fn_error $? "check library not found (http://check.sourceforge.net/web/install.html)" "$LINENO" 5
 fi
 ac_cv_lib_check=ac_cv_lib_check_main
+

--- a/configure.in
+++ b/configure.in
@@ -664,7 +664,7 @@ AC_MSG_RESULT([$with_bonjour])
 # OpenSSL
 #
 AC_MSG_CHECKING([whether to build with OpenSSL support])
-PGAC_ARG_BOOL(with, openssl, no, [build with OpenSSL support],
+PGAC_ARG_BOOL(with, openssl, yes, [build with OpenSSL support],
               [AC_DEFINE([USE_SSL], 1, [Define to build with (Open)SSL support. (--with-openssl)])])
 AC_MSG_RESULT([$with_openssl])
 AC_SUBST(with_openssl)

--- a/src/backend/postmaster/Makefile
+++ b/src/backend/postmaster/Makefile
@@ -12,7 +12,7 @@ subdir = src/backend/postmaster
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS = autovacuum.o bgworker.o bgwriter.o checkpointer.o fork_process.o \
+OBJS = autovacuum.o bgworker.o bgwriter.o checkpointer.o fork_process.o license.o \
 	pgarch.o pgstat.o postmaster.o startup.o syslogger.o walwriter.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/postmaster/license.c
+++ b/src/backend/postmaster/license.c
@@ -1,0 +1,98 @@
+
+#include "postgres.h"
+
+#include <openssl/aes.h>
+#include <sys/time.h>
+#include <stdio.h>
+#include "postmaster/license.h"
+#include "storage/shmem.h"
+#include "utils/builtins.h"
+#include "utils/timestamp.h"
+
+const unsigned char pipeline_key[] = {0x54, 0x48, 0x45, 0x50, 0x49, 0x50, 0x45, 0x4c, 0x49, 0x4e, 0x45, 0x4b, 0x45, 0x59, 0x30, 0x30};
+
+typedef struct LicenseKey
+{
+	int start_time;
+	int end_time;
+} LicenseKey;
+
+/*
+ * Decode the license key into shmem do we only need to do it once
+ */
+static void
+decode_license_key(LicenseKey *key, bool fail)
+{
+	char in[1024];
+	char out[1024];
+	char tmp[11];
+	int colon, end;
+	AES_KEY wctx;
+	int level = fail ? ERROR : WARNING;
+
+	memset(out, 0, 1024);
+
+	hex_decode(license_key, strlen(license_key), in);
+	in[strlen(license_key)/2 + 1] = '\0';
+
+	AES_set_decrypt_key(pipeline_key, 128, &wctx);
+	AES_cbc_encrypt((unsigned char *)in+16, (unsigned char *)out, strlen(in) - 16, &wctx, (unsigned char *)in, AES_DECRYPT);
+
+	out[strlen(in)-16+1] = '\0';
+
+	/* time start */
+	colon = strchr(out, ':') - out;
+	if (colon != 10)
+	{
+		elog(level, "invalid license key found in pipelinedb.conf");
+		return;
+	}
+
+	strncpy(tmp, out, colon);
+	tmp[colon] = '\0';
+
+	key->start_time = atoi(tmp);
+
+	/* time end */
+	end = strchr(out, '\0') - out;
+	strncpy(tmp, out + colon + 1, end-colon);
+	tmp[end-colon] = '\0';
+
+	key->end_time = atoi(tmp);
+}
+
+/*
+ * CheckLicense
+ *
+ * Check if the license key is still valid based on the current time.
+ *
+ * XXX(derekjn) Ideally this should call out to an external license server
+ */
+void
+CheckLicense(bool fail) {
+	struct timeval tv;
+	int current_time;
+	int level = fail ? ERROR : WARNING;
+	LicenseKey *key;
+	bool found;
+
+	if (!license_key)
+	{
+		elog(level, "license_key not set in pipelinedb.conf");
+		return;
+	}
+
+	gettimeofday(&tv, NULL);
+
+	current_time = tv.tv_sec;
+
+	key = ShmemInitStruct("LicenseKey", sizeof(LicenseKey), &found);
+	if (!found)
+		decode_license_key(key, fail);
+
+	if (current_time > key->end_time)
+	{
+		elog(level, "license key is expired");
+		return;
+	}
+}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -104,6 +104,7 @@
 #include "postmaster/autovacuum.h"
 #include "postmaster/bgworker_internals.h"
 #include "postmaster/fork_process.h"
+#include "postmaster/license.h"
 #include "postmaster/pgarch.h"
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
@@ -534,6 +535,10 @@ splash(void)
 	printf(" / ____/ / /_/ /  __/ / / / / /  __/ /_/ / /_/ /\n");
 	printf("/_/   /_/ .___/\\___/_/_/_/ /_/\\___/_____/_____/\n");
 	printf("       /_/\n\n");
+
+#ifdef REQUIRE_LICENSE
+			CheckLicense(false);
+#endif
 }
 
 /*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -70,6 +70,7 @@
 #include "pg_getopt.h"
 #include "postmaster/autovacuum.h"
 #include "postmaster/postmaster.h"
+#include "postmaster/license.h"
 #include "replication/slot.h"
 #include "replication/walsender.h"
 #include "rewrite/rewriteHandler.h"
@@ -1076,6 +1077,17 @@ exec_simple_query(const char *query_string)
 
 			continue;
 		}
+
+		/*
+		 * Read-time license check--we still allow users to ingest data with an
+		 * expired license, but we block reads.
+		 */
+#ifdef REQUIRE_LICENSE
+		if (IsA(parsetree, SelectStmt))
+		{
+			CheckLicense(true);
+		}
+#endif
 
 		/*
 		 * Set up a snapshot if parse analysis/planning will need one.

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -60,6 +60,7 @@
 #include "postmaster/postmaster.h"
 #include "postmaster/syslogger.h"
 #include "postmaster/walwriter.h"
+#include "postmaster/license.h"
 #include "replication/slot.h"
 #include "replication/syncrep.h"
 #include "replication/walreceiver.h"
@@ -3323,6 +3324,18 @@ static struct config_string ConfigureNamesString[] =
 		"",
 		check_application_name, assign_application_name, NULL
 	},
+
+	{
+		{"license_key", PGC_POSTMASTER, CONN_AUTH_SECURITY,
+			gettext_noop("License key for the PipelineDB instance."),
+			NULL,
+			0
+		},
+		&license_key,
+		NULL,
+		NULL, NULL, NULL,
+	},
+
 
 	/* End-of-list marker */
 	{

--- a/src/backend/utils/misc/pipelinedb.conf.sample
+++ b/src/backend/utils/misc/pipelinedb.conf.sample
@@ -56,6 +56,7 @@
 
 # - Connection Settings -
 
+#license_key = '' # PipelineDB-issued license key
 #listen_addresses = 'localhost'		# what IP address(es) to listen on;
 					# comma-separated list of addresses;
 					# defaults to 'localhost'; use '*' for all

--- a/src/include/postmaster/license.h
+++ b/src/include/postmaster/license.h
@@ -1,0 +1,10 @@
+
+#ifndef LICENSE_H
+#define LICENSE_H
+
+char *license_key;
+
+void CheckLicense(bool fail);
+
+#endif /* LICENSE_H */
+


### PR DESCRIPTION
This gives us rudimentary support for license keys. It's enabled by adding `-DREQUIRE_LICENSE` as a `CFLAG`, so it won't interfere with local development. 
