### PR TITLE
Make \| work like \d

### DIFF
--- a/src/bin/psql/pipeline.c
+++ b/src/bin/psql/pipeline.c
@@ -28,19 +28,26 @@ listPipelineQuery(void)
 	printQueryOpt myopt = pset.popt;
 
 	initPQExpBuffer(&buf);
-	printfPQExpBuffer(&buf, "SELECT * FROM pipeline_query");
+	printfPQExpBuffer(&buf, "SELECT id, name, query FROM pipeline_query");
 
 	res = PSQLexec(buf.data, false);
 	termPQExpBuffer(&buf);
 	if (!res)
 		return false;
 
-	myopt.nullPrint = NULL;
-	myopt.title = _("List of continuous views");
-	myopt.translate_header = true;
+	if (PQntuples(res) == 0 && !pset.quiet)
+	{
+		fprintf(pset.queryFout, _("No continuous views found.\n"));
+	}
+	else
+	{
+		myopt.nullPrint = NULL;
+		myopt.title = _("List of continuous views");
+		myopt.translate_header = true;
 
-	printQuery(res, &myopt, pset.queryFout, pset.logfile);
+		printQuery(res, &myopt, pset.queryFout, pset.logfile);
+	}
+
 	PQclear(res);
-
 	return true;
 }


### PR DESCRIPTION
```
usmanm=# \d
No relations found.
usmanm=# \|
No continuous views found.
usmanm=# CREATE CONTINUOUS VIEW test_view AS SELECT x::int FROM stream;
CREATE CONTINUOUS VIEW
usmanm=# \d
             List of relations
 Schema |      Name       | Type  | Owner  
--------+-----------------+-------+--------
 public | test_view       | view  | usmanm
 public | test_view_mrel0 | table | usmanm
(2 rows)

usmanm=# \|
                            List of continuous views
 id |   name    |                             query                              
----+-----------+----------------------------------------------------------------
  0 | test_view | CREATE CONTINUOUS VIEW test_view AS SELECT x::int FROM stream;
(1 row)
```
