### PR TITLE
629 general bottlenecks

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -274,6 +274,12 @@ typedef struct StreamProjectionInfo
 	 * may be cached across projections
 	 */
 	int *attrmap;
+
+	/*
+	 * Serialized event descriptor used to detect when a new event descriptor
+	 * has arrived without having to fully unpack it
+	 */
+	bytea *raweventdesc;
 } StreamProjectionInfo;
 
 /* ----------------


### PR DESCRIPTION
There actually aren't too many general bottlenecks wasting CPU. This adds an optimization to `nodeStreamScan` that allows `StreamScanNext` to look at an event's `TupleDesc` without having to fully unpack it, which was using a relatively decent amount of CPU. This allows `StreamScanNext` to keep reusing a `TupleDesc` for as long as possible.

We were also spending a lot of cycles decompressing Bloom filters for `DISTINCT` queries, so those get stored uncompressed now because there's only one per CQ anyways. This made a noticeable perf improvement.
