### PR TITLE
Make null equality work with bitmap index scans

### DIFF
--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -90,36 +90,65 @@ make_cv_columndef(char *name, Oid type, Oid typemod)
  * such as single-column GROUP BYs, it's straightforward.
  */
 static void
-create_indices_on_mat_relation(Oid matreloid, RangeVar *matrelname, SelectStmt *workerstmt, SelectStmt *viewstmt)
+create_indices_on_mat_relation(Oid matreloid, RangeVar *matrelname, SelectStmt *workerstmt, SelectStmt *viewstmt, Query *query)
 {
 	IndexStmt *index;
 	IndexElem *indexcol;
-	Node *node;
-	ColumnRef *col;
-	char *namespace;
-	char *name;
+	char *indexcolname = NULL;
 
 	if (IsSlidingWindowSelectStmt(workerstmt))
-		node = (Node *) GetColumnRefInSlidingWindowExpr(viewstmt);
-	else if (list_length(workerstmt->groupClause) == 1)
-		node = linitial(workerstmt->groupClause);
-	else
-		return;
-
-	if (IsA(node, TypeCast))
 	{
-		TypeCast *tc = (TypeCast *) node;
-		node = tc->arg;
+		ColumnRef *col;
+		Node *node = NULL;
+		char *namespace;
+
+		node = (Node *) GetColumnRefInSlidingWindowExpr(viewstmt);
+
+		if (!IsA(node, ColumnRef))
+			elog(ERROR, "unexpected sliding window expression type found: %d", nodeTag(node));
+
+		col = (ColumnRef *) node;
+		DeconstructQualifiedName(col->fields, &namespace, &indexcolname);
+	}
+	else if (query->groupClause)
+	{
+		/*
+		 * Choose the lowest-cardinality type as the index column,
+		 * as that's the best we can hope to do at this point.
+		 */
+		ListCell *lc;
+		int16 len;
+		int16 best = -1;
+
+		foreach(lc, query->groupClause)
+		{
+			ListCell *tc;
+			SortGroupClause *g = (SortGroupClause *) lfirst(lc);
+			TargetEntry *te;
+
+			foreach(tc, query->targetList)
+			{
+				te = (TargetEntry *) lfirst(tc);
+				if (te->ressortgroupref == g->tleSortGroupRef)
+					break;
+			}
+
+			len = get_typlen(exprType((Node *) te->expr));
+
+			if (best == -1 || (len > 0 && len < best))
+			{
+				best = len;
+				indexcolname = te->resname;
+			}
+
+		}
 	}
 
-	Assert(IsA(node, ColumnRef));
-	col = (ColumnRef *) node;
+	if (indexcolname == NULL)
+		return;
 
 	indexcol = makeNode(IndexElem);
-
-	DeconstructQualifiedName(col->fields, &namespace, &name);
-
-	indexcol->name = name;
+	indexcol->name = indexcolname;
 	indexcol->expr = NULL;
 	indexcol->indexcolname = NULL;
 	indexcol->collation = NULL;
@@ -308,7 +337,7 @@ ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *queryst
 	 * Index the materialization table smartly if we can
 	 */
 	allowSystemTableMods = saveAllowSystemTableMods;
-	create_indices_on_mat_relation(reloid, mat_relation, workerselect, viewselect);
+	create_indices_on_mat_relation(reloid, mat_relation, workerselect, viewselect, query);
 }
 
 /*

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2529,7 +2529,6 @@ _copyQuery(const Query *from)
 	else
 		COPY_SCALAR_FIELD(cq_state);
 	COPY_SCALAR_FIELD(is_continuous);
-	COPY_SCALAR_FIELD(cq_activate_stmt);
 	COPY_SCALAR_FIELD(is_combine);
 
 	return newnode;

--- a/src/backend/optimizer/path/joinpath.c
+++ b/src/backend/optimizer/path/joinpath.c
@@ -172,9 +172,6 @@ add_paths_to_joinrel(PlannerInfo *root,
 	Relids		param_source_rels = NULL;
 	Relids		extra_lateral_rels = NULL;
 	ListCell   *lc;
-	RangeTblEntry *outer = planner_rt_fetch(outerrel->relid, root);
-	RangeTblEntry *inner = planner_rt_fetch(innerrel->relid, root);
-	bool group_lookup = false;
 
 	/*
 	 * If this is a stream-table join, then there is only one
@@ -345,27 +342,7 @@ add_paths_to_joinrel(PlannerInfo *root,
 	 * this so that we can predictably control performance and take advantage of
 	 * certain assumptions we can make about matrels and their indices.
 	 */
-	if (IsCombiner && (outer && inner) &&
-			((outer->rtekind == RTE_VALUES && inner->rtekind == RTE_RELATION) ||
-			(inner->rtekind == RTE_VALUES && outer->rtekind == RTE_RELATION)))
-	{
-		RangeVar *matrelrv;
-		Relation rel;
-		Oid relid = outer->rtekind == RTE_RELATION ? outer->relid : inner->relid;
-
-		rel = heap_open(relid, NoLock);
-		matrelrv = makeRangeVar(NULL, RelationGetRelationName(rel), -1);
-		relation_close(rel, NoLock);
-
-		if (IsAMatRel(matrelrv, NULL))
-			group_lookup = true;
-	}
-
-	/*
-	 * If we're doing a lookup of physical matrel tuples, there's only
-	 * one plan to consider.
-	 */
-	if (group_lookup)
+	if (root->parse->is_combine_lookup)
 	{
 		physical_group_lookup(root, joinrel, outerrel, innerrel,
 							param_source_rels, extra_lateral_rels,

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2723,8 +2723,6 @@ create_physical_group_lookup_plan(PlannerInfo *root, PhysicalGroupLookupPath *be
 	PhysicalGroupLookup *node = makeNode(PhysicalGroupLookup);
 	Plan *tmp;
 	NestLoop *nl;
-	ListCell *lc;
-	List *quals = NIL;
 
 	/* make sure the VALUES scan is the outer */
 	if (!IsA(outer_plan, ValuesScan))
@@ -2737,59 +2735,7 @@ create_physical_group_lookup_plan(PlannerInfo *root, PhysicalGroupLookupPath *be
 	nl = create_nestloop_plan(root,
 			(NestPath *) best_path, outer_plan, inner_plan);
 
-	/*
-	 * Currently this join will only check for equality of the group columns
-	 * between the VALUES list and matrel. This is insufficient for groupings
-	 * containing nulls, because (null == null) is not true. Here we add an
-	 * additional predicate that will cause our join to correctly return a row
-	 * when the outer and inner column are both null. That is, this join
-	 * considers two null columns equal.
-	 *
-	 * This is congruent with the SQL standard, which specifies that grouping
-	 * on null will collect all rows to a single null group.
-	 */
-	foreach(lc, nl->join.joinqual)
-	{
-		OpExpr *op;
-		Expr *left;
-		Expr *right;
-		NullTest *leftnull;
-		NullTest *rightnull;
-		Expr *newqual;
-		Expr *bothnull;
-
-		if (!IsA(lfirst(lc), OpExpr))
-			elog(ERROR, "unrecognized join qual: %d", nodeTag(lfirst(lc)));
-
-		op = (OpExpr *) lfirst(lc);
-
-		if (list_length(op->args) != 2)
-			elog(ERROR, "unexpected number of join qual arguments: %d", list_length(op->args));
-
-		left = linitial(op->args);
-		right = lsecond(op->args);
-
-		leftnull = makeNode(NullTest);
-		leftnull->arg = left;
-		leftnull->nulltesttype = IS_NULL;
-
-		rightnull = makeNode(NullTest);
-		rightnull->arg = right;
-		rightnull->nulltesttype = IS_NULL;
-
-		/*
-		 * qual is now of the form:
-		 *
-		 * (left.col = right.col) OR (left.col is null AND right.col is null)
-		 */
-		bothnull = makeBoolExpr(AND_EXPR, list_make2(leftnull, rightnull), -1);
-		newqual = makeBoolExpr(OR_EXPR, list_make2(op, bothnull), -1);
-
-		quals = lappend(quals, newqual);
-	}
-
 	node->plan.lefttree = (Plan *) nl;
-	nl->join.joinqual = quals;
 
 	return node;
 }

--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -15,6 +15,7 @@
 #include "postgres.h"
 
 #include "catalog/pg_type.h"
+#include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/clauses.h"
 #include "optimizer/joininfo.h"
@@ -72,6 +73,7 @@ static bool check_redundant_nullability_qual(PlannerInfo *root, Node *clause);
 static void check_mergejoinable(RestrictInfo *restrictinfo);
 static void check_hashjoinable(RestrictInfo *restrictinfo);
 
+static Node *allow_null_equality(Node *n);
 
 /*****************************************************************************
  *
@@ -1309,6 +1311,9 @@ distribute_qual_to_rels(PlannerInfo *root, Node *clause,
 	 */
 	relids = pull_varnos(clause);
 
+	if (root->parse->is_combine_lookup)
+		clause = allow_null_equality(clause);
+
 	/*
 	 * In ordinary SQL, a WHERE or JOIN/ON clause can't reference any rels
 	 * that aren't within its syntactic scope; however, if we pulled up a
@@ -2121,4 +2126,55 @@ check_hashjoinable(RestrictInfo *restrictinfo)
 	if (op_hashjoinable(opno, exprType(leftarg)) &&
 		!contain_volatile_functions((Node *) clause))
 		restrictinfo->hashjoinoperator = opno;
+}
+
+/*
+ * set_null_equality
+ * 		We join a VALUES list against a matrel to look up the groupings that
+ * 		need to be physically updated by a combiner. Without modification, this
+ * 		join will only check for equality of the group columns between the VALUES
+ * 		list and matrel between the VALUES list and matrel. This is insufficient
+ * 		for groupings containing nulls, because (null == null) is not true.
+ *
+ * 		Here we add an additional predicate that will cause our join to correctly
+ * 		return a row when the outer and inner column are both null. That is, this
+ * 		join considers two null columns equal.
+ *
+ * 		This is congruent with the SQL standard, which specifies that grouping
+ * 		on null will collect all rows to a single null group.
+ */
+static Node *
+allow_null_equality(Node *clause)
+{
+	OpExpr *op;
+	Expr *left;
+	Expr *right;
+	NullTest *leftnull;
+	NullTest *rightnull;
+	Expr *bothnull;
+
+	op = (OpExpr *) clause;
+
+	if (list_length(op->args) != 2)
+		elog(ERROR, "unexpected number of join qual arguments: %d", list_length(op->args));
+
+	left = linitial(op->args);
+	right = lsecond(op->args);
+
+	leftnull = makeNode(NullTest);
+	leftnull->arg = left;
+	leftnull->nulltesttype = IS_NULL;
+
+	rightnull = makeNode(NullTest);
+	rightnull->arg = right;
+	rightnull->nulltesttype = IS_NULL;
+
+	/*
+	 * qual is now of the form:
+	 *
+	 * (left.col = right.col) OR (left.col is null AND right.col is null)
+	 */
+	bothnull = makeBoolExpr(AND_EXPR, list_make2(leftnull, rightnull), -1);
+
+	return (Node *) makeBoolExpr(OR_EXPR, list_make2(op, bothnull), -1);
 }

--- a/src/backend/pipeline/combiner.c
+++ b/src/backend/pipeline/combiner.c
@@ -323,6 +323,7 @@ get_cached_groups_plan(CombineState *cstate, List *values)
 
 	qlist = pg_analyze_and_rewrite((Node *) sel, NULL, NULL, 0);
 	query = (Query *) linitial(qlist);
+	query->is_combine_lookup = true;
 
 	if (cstate->ngroupatts > 0)
 	{

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -157,22 +157,13 @@ typedef struct Query
 	/*
 	 * Continuous query fields
 	 */
-	bool		is_continuous; /* should this be executed continuously? */
-
-	/*
-	 * The original ACTIVATE statement that activated this query. It's useful to
-	 * keep this around because an ACTIVATE query gets rewritten as the target CQ,
-	 * and then flagged as continuous. However, we don't want to send this rewritten
-	 * query to the datanodes when running a RemoteQuery, because we want them to
-	 * know that it's a CQ. So for CQs, we send the original ACTIVATE to the datanodes.
-	 */
-	char		*cq_activate_stmt;
-
-	RangeVar	*cq_target; /* output relation of this CQ, if any */
-
-	bool		is_combine; /* is this query being run as a merge query? */
+	bool is_continuous; /* should this be executed continuously? */
+	RangeVar *cq_target; /* output relation of this CQ, if any */
+	bool is_combine; /* is this query being run as a merge query? */
+	bool is_combine_lookup; /* is this query a combiner looking up groups to combine with? */
 
 	struct ContinuousViewState	*cq_state; /* put `struct` here to avoid circular dependency */
+
 } Query;
 
 

--- a/src/test/py/base.py
+++ b/src/test/py/base.py
@@ -212,6 +212,7 @@ class PipelineDB(object):
           else:
             values.append(str(r))
         values = ', '.join(values)
+        values = values.replace("'null'", 'null')
 
         return self.execute('INSERT INTO %s (%s) VALUES %s' % (target, header, values))
 

--- a/src/test/py/test_grouping.py
+++ b/src/test/py/test_grouping.py
@@ -1,0 +1,39 @@
+from base import pipeline, clean_db
+import random
+
+
+def test_null_groups(pipeline, clean_db):
+    """
+    Verify that null group columns are considered equal
+    """
+    q = """
+    SELECT x::integer, y::integer, z::integer, COUNT(*) FROM stream
+    GROUP BY x, y, z;
+    """
+    desc = ('x', 'y', 'z')
+    pipeline.create_cv('test_null_groups', q)
+    pipeline.create_table('test_null_groups_t', x='integer', y='integer', z='integer')
+    
+    rows = []
+    for n in range(10000):
+        vals = list(random.randint(0, 10) for n in range(3))
+        vals = map(lambda n: random.random() < 0.1 and 'null' or n, vals)
+        rows.append(tuple(vals))
+
+    pipeline.activate()
+
+    pipeline.insert('stream', desc, rows)
+    pipeline.insert('test_null_groups_t', desc, rows)
+    
+    pipeline.deactivate()
+    
+    table_q = """
+    SELECT x, y, z, COUNT(*) FROM test_null_groups_t
+    GROUP BY x, y, z ORDER BY x, y, z;
+    """
+    expected = list(pipeline.execute(table_q))
+    result = list(pipeline.execute('SELECT x, y, z, count FROM test_null_groups ORDER BY x, y, z'))
+    
+    for r, e in zip(result, expected):
+        assert r == e
+

--- a/src/test/regress/expected/cont_window.out
+++ b/src/test/regress/expected/cont_window.out
@@ -8,6 +8,8 @@ CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PART
  sum    | numeric                  |           | main     |              | 
  _1     | bytea                    |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
+Indexes:
+    "cqwindow0_mrel0__0_idx" btree (_0)
 
 \d+ cqwindow0;
                 View "public.cqwindow0"
@@ -66,6 +68,8 @@ CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITIO
  avg    | numeric                  |           | main     |              | 
  _1     | bigint[]                 |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
+Indexes:
+    "cqwindow1_mrel0__0_idx" btree (_0)
 
 \d+ cqwindow1;
                 View "public.cqwindow1"

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -430,10 +430,46 @@ View definition:
  k0     | text(0) |           | extended |              | 
  k1     | integer |           | plain    |              | 
  count  | bigint  |           | plain    |              | 
+Indexes:
+    "cqgroupby_mrel0_k1_idx" btree (k1)
 
 CREATE SCHEMA test_create_cont_view;
 CREATE CONTINUOUS VIEW test_create_cont_view.error AS SELECT k0::text FROM stream;
 ERROR:  continuous views cannot be given a namespace
+CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM stream
+GROUP BY a, b, c, d, e;
+\d+ multigroupindex;
+                 View "public.multigroupindex"
+ Column |       Type       | Modifiers | Storage  | Description 
+--------+------------------+-----------+----------+-------------
+ a      | text(0)          |           | extended | 
+ b      | bigint           |           | plain    | 
+ c      | integer          |           | plain    | 
+ d      | smallint         |           | plain    | 
+ e      | double precision |           | plain    | 
+ count  | bigint           |           | plain    | 
+View definition:
+ SELECT multigroupindex_mrel0.a,
+    multigroupindex_mrel0.b,
+    multigroupindex_mrel0.c,
+    multigroupindex_mrel0.d,
+    multigroupindex_mrel0.e,
+    multigroupindex_mrel0.count
+   FROM multigroupindex_mrel0;
+
+\d+ multigroupindex_mrel0;
+                     Table "public.multigroupindex_mrel0"
+ Column |       Type       | Modifiers | Storage  | Stats target | Description 
+--------+------------------+-----------+----------+--------------+-------------
+ a      | text(0)          |           | extended |              | 
+ b      | bigint           |           | plain    |              | 
+ c      | integer          |           | plain    |              | 
+ d      | smallint         |           | plain    |              | 
+ e      | double precision |           | plain    |              | 
+ count  | bigint           |           | plain    |              | 
+Indexes:
+    "multigroupindex_mrel0_d_idx" btree (d)
+
 DROP CONTINUOUS VIEW cqcreate0;
 DROP CONTINUOUS VIEW cqcreate1;
 DROP CONTINUOUS VIEW cqcreate2;
@@ -452,3 +488,4 @@ DROP CONTINUOUS VIEW cqaggexpr2;
 DROP CONTINUOUS VIEW cqaggexpr3;
 DROP CONTINUOUS VIEW cqaggexpr4;
 DROP CONTINUOUS VIEW cqgroupby;
+DROP CONTINUOUS VIEW multigroupindex;

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -85,6 +85,12 @@ CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM 
 CREATE SCHEMA test_create_cont_view;
 CREATE CONTINUOUS VIEW test_create_cont_view.error AS SELECT k0::text FROM stream;
 
+CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM stream
+GROUP BY a, b, c, d, e;
+
+\d+ multigroupindex;
+\d+ multigroupindex_mrel0;
+
 DROP CONTINUOUS VIEW cqcreate0;
 DROP CONTINUOUS VIEW cqcreate1;
 DROP CONTINUOUS VIEW cqcreate2;
@@ -103,3 +109,4 @@ DROP CONTINUOUS VIEW cqaggexpr2;
 DROP CONTINUOUS VIEW cqaggexpr3;
 DROP CONTINUOUS VIEW cqaggexpr4;
 DROP CONTINUOUS VIEW cqgroupby;
+DROP CONTINUOUS VIEW multigroupindex;


### PR DESCRIPTION
Always index on grouped CVs. This diff also adds the null equality expression earlier in the planner for combiner group lookups, which makes it work properly with bitmap index scans.
