### PR TITLE
896 lookup perf

### DIFF
--- a/src/backend/executor/nodePhysicalGroupLookup.c
+++ b/src/backend/executor/nodePhysicalGroupLookup.c
@@ -41,6 +41,9 @@ ExecInitPhysicalGroupLookup(PhysicalGroupLookup *node, EState *estate, int eflag
 	resultdesc = ExecTypeFromTL(innerPlan(outer)->targetlist, false);
 	ExecAssignResultType(&state->ps, resultdesc);
 
+	if (IsA(innerPlan(nl), SeqScan))
+		elog(WARNING, "sequential scan being used in combiner group lookup");
+
 	return state;
 }
 

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -95,7 +95,7 @@ CQMatViewClose(ResultRelInfo *rinfo)
  * This is a trimmed-down version of ExecInsertIndexTuples
  */
 void
-ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot)
+ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot, EState *estate)
 {
 	int			i;
 	int			numIndexes;
@@ -131,7 +131,14 @@ ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot)
 		if (!indexInfo->ii_ReadyForInserts)
 			continue;
 
-		FormIndexDatum(indexInfo, slot, NULL, values, isnull);
+		/* Index expressions need an EState to be eval'd in */
+		if (indexInfo->ii_Expressions)
+		{
+			ExprContext *econtext = GetPerTupleExprContext(estate);
+			econtext->ecxt_scantuple = slot;
+		}
+
+		FormIndexDatum(indexInfo, slot, estate, values, isnull);
 
 		index_insert(relationDescs[i], values, isnull, &(tup->t_self),
 				heapRelation, relationDescs[i]->rd_index->indisunique ? UNIQUE_CHECK_YES : UNIQUE_CHECK_NO);
@@ -143,12 +150,12 @@ ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot)
  *
  * Update an existing row of a CV materialization table.
  */
-void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot)
+void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
 {
 	HeapTuple tup = ExecMaterializeSlot(slot);
 
 	simple_heap_update(ri->ri_RelationDesc, &tup->t_self, tup);
-	ExecInsertCQMatRelIndexTuples(ri, slot);
+	ExecInsertCQMatRelIndexTuples(ri, slot, estate);
 }
 
 /*
@@ -156,10 +163,10 @@ void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot)
  *
  * Insert a new row into a CV materialization table
  */
-void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot)
+void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
 {
 	HeapTuple tup = ExecMaterializeSlot(slot);
 
 	heap_insert(ri->ri_RelationDesc, tup, GetCurrentCommandId(true), 0, NULL);
-	ExecInsertCQMatRelIndexTuples(ri, slot);
+	ExecInsertCQMatRelIndexTuples(ri, slot, estate);
 }

--- a/src/backend/utils/adt/Makefile
+++ b/src/backend/utils/adt/Makefile
@@ -35,7 +35,7 @@ OBJS = acl.o arrayfuncs.o array_selfuncs.o array_typanalyze.o \
 	tsvector.o tsvector_op.o tsvector_parser.o \
 	txid.o uuid.o varbit.o varchar.o varlena.o version.o \
 	windowfuncs.o xid.o xml.o hllfuncs.o bloomfuncs.o tdigestfuncs.o \
-	cmsketchfuncs.o cqstatfuncs.o gcsfuncs.o
+	cmsketchfuncs.o cqstatfuncs.o gcsfuncs.o hashfuncs.o
 
 like.o: like.c like_match.c
 

--- a/src/backend/utils/adt/hashfuncs.c
+++ b/src/backend/utils/adt/hashfuncs.c
@@ -1,0 +1,88 @@
+/*-------------------------------------------------------------------------
+ *
+ * hashfuncs.c
+ *
+ * IDENTIFICATION
+ *	  src/backend/utils/adt/hashfuncs.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "catalog/pg_type.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/primnodes.h"
+#include "pipeline/miscutils.h"
+#include "utils/datum.h"
+#include "utils/hashfuncs.h"
+#include "utils/memutils.h"
+#include "utils/typcache.h"
+
+/*
+ * init_hash_group
+ *
+ * Retrieve hash functions for each argument type in the arg list
+ */
+static void
+init_hash_group(PG_FUNCTION_ARGS)
+{
+	ListCell *lc;
+	FuncExpr *func;
+	MemoryContext old;
+	FmgrInfo *hashfuncs;
+	int i = 0;
+
+	old = MemoryContextSwitchTo(fcinfo->flinfo->fn_mcxt);
+	func = (FuncExpr *) fcinfo->flinfo->fn_expr;
+	hashfuncs = palloc0(sizeof(FmgrInfo) * PG_NARGS());
+
+	foreach(lc, func->args)
+	{
+		Oid type = exprType((Node *) lfirst(lc));
+		TypeCacheEntry *typ = lookup_type_cache(type, TYPECACHE_HASH_PROC | TYPECACHE_HASH_PROC_FINFO);
+
+		if (type == UNKNOWNOID)
+			elog(ERROR, "could not determine expression type of argument %d", i + 1);
+
+		hashfuncs[i] = typ->hash_proc_finfo;
+		i++;
+	}
+
+	MemoryContextSwitchTo(old);
+
+	fcinfo->flinfo->fn_extra = (void *) hashfuncs;
+}
+
+/*
+ * hash_group
+ *
+ * Hashes a variadic number of arguments into a single 32-bit integer
+ */
+extern Datum
+hash_group(PG_FUNCTION_ARGS)
+{
+	int i;
+	uint32 result = 0;
+	FmgrInfo *hashfuncs;
+
+	if (fcinfo->flinfo->fn_extra == NULL)
+		init_hash_group(fcinfo);
+
+	hashfuncs = (FmgrInfo *) fcinfo->flinfo->fn_extra;
+
+	for (i=0; i<PG_NARGS(); i++)
+	{
+		Datum d = (Datum) PG_GETARG_DATUM(i);
+		uint32 hash;
+
+		result = (result << 1) | ((result & 0x80000000) ? 1 : 0);
+
+		if (PG_ARGISNULL(i))
+			continue;
+
+		hash = DatumGetUInt32(FunctionCall1(&hashfuncs[i], d));
+		result ^= hash;
+	}
+
+	PG_RETURN_INT32(result);
+}

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5358,6 +5358,10 @@ DESCR("truncate timestamp with time zone to minute");
 DATA(insert OID = 4372 (  second	   PGNSP PGUID 12 1 0 0 0 f f f f t f s 1 0 1184 "1184" _null_ _null_ _null_ _null_ timestamptz_second _null_ _null_ _null_ ));
 DESCR("truncate timestamp with time zone to second");
 
+DATA(insert OID = 4373 (  hash_group	   PGNSP PGUID 12 1 0 2276 0 f f f f f f i 1 0 23 "2276" "{2276}" "{v}" _null_ _null_ hash_group _null_ _null_ _null_ ));
+DESCR("hash one or more values into a 32-bit integer");
+#define HASH_GROUP_OID 4373
+
 /*
  * Symbolic values for provolatile column: these indicate whether the result
  * of a function is dependent *only* on the values of its explicit arguments,

--- a/src/include/pipeline/cqmatrel.h
+++ b/src/include/pipeline/cqmatrel.h
@@ -14,8 +14,8 @@ char *GetUniqueMatRelName(char *cvname, char* nspname);
 
 ResultRelInfo *CQMatViewOpen(Relation matrel);
 void CQMatViewClose(ResultRelInfo *rinfo);
-void ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot);
-void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot);
-void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot);
+void ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot, EState *estate);
+void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);
+void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);
 
 #endif

--- a/src/include/utils/hashfuncs.h
+++ b/src/include/utils/hashfuncs.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * hashfuncs.h
+ *
+ * IDENTIFICATION
+ *	  src/include/utils/hashfuncs.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef HASHFUNCS_H
+#define HASHFUNCS_H
+
+#include "postgres.h"
+#include "fmgr.h"
+
+extern Datum hash_group(PG_FUNCTION_ARGS);
+
+#endif

--- a/src/test/regress/expected/cont_count_distinct.out
+++ b/src/test/regress/expected/cont_count_distinct.out
@@ -68,7 +68,7 @@ SELECT * FROM test_distinct_sw_count;
  _1     | hll                      |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
-    "test_distinct_sw_count_mrel0__0_idx" UNIQUE, btree (_0)
+    "test_distinct_sw_count_mrel0_expr_idx" btree (hash_group(_0))
 
 SELECT pg_sleep(1);
  pg_sleep 

--- a/src/test/regress/expected/cont_window.out
+++ b/src/test/regress/expected/cont_window.out
@@ -8,7 +8,7 @@ CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PART
  _1     | bytea                    |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
-    "cqwindow0_mrel0__0_idx" btree (_0)
+    "cqwindow0_mrel0_expr_idx" btree (hash_group(_0, key))
 
 \d+ cqwindow0;
                 View "public.cqwindow0"
@@ -68,7 +68,7 @@ CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITIO
  _1     | bigint[]                 |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
-    "cqwindow1_mrel0__0_idx" btree (_0)
+    "cqwindow1_mrel0_expr_idx" btree (hash_group(_0, key))
 
 \d+ cqwindow1;
                 View "public.cqwindow1"

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -104,7 +104,7 @@ View definition:
  sum    | numeric |           | main     |              | 
  _0     | bytea   |           | extended |              | 
 Indexes:
-    "cqcreate3_mrel0_key_idx" UNIQUE, btree (key)
+    "cqcreate3_mrel0_expr_idx" btree (hash_group(key))
 
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM stream GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate4';
@@ -133,7 +133,7 @@ View definition:
  _1     | bytea   |           | extended |              | 
  _0     | text(0) |           | extended |              | 
 Indexes:
-    "cqcreate4_mrel0__0_idx" UNIQUE, btree (_0)
+    "cqcreate4_mrel0_expr_idx" btree (hash_group(_0))
 
 -- Sliding window queries
 CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second);
@@ -200,7 +200,7 @@ View definition:
  _1     | text(0)                  |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
-    "cqcreate6_mrel0__0_idx" btree (_0)
+    "cqcreate6_mrel0_expr_idx" btree (hash_group(_1, _0))
 
 -- These use a combine state column
 CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, AVG(y::integer) AS int_avg, AVG(ts0::timestamp - ts1::timestamp) AS internal_avg FROM stream GROUP BY key;
@@ -231,7 +231,7 @@ View definition:
  internal_avg | interval           |           | plain    |              | 
  _2           | interval[]         |           | extended |              | 
 Indexes:
-    "cvavg_mrel0_key_idx" UNIQUE, btree (key)
+    "cvavg_mrel0_expr_idx" btree (hash_group(key))
 
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM stream;
 \d+ cvjson;
@@ -320,7 +320,7 @@ View definition:
  string_agg | text    |           | extended |              | 
  _0         | bytea   |           | extended |              | 
 Indexes:
-    "cvtext_mrel0_key_idx" UNIQUE, btree (key)
+    "cvtext_mrel0_expr_idx" btree (hash_group(key))
 
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM stream;
@@ -361,7 +361,7 @@ View definition:
  _2     | double precision[] |           | extended |              | 
  _1     | integer            |           | plain    |              | 
 Indexes:
-    "cqaggexpr2_mrel0_key_idx" UNIQUE, btree (key)
+    "cqaggexpr2_mrel0_expr_idx" btree (hash_group(key))
 
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key;
 \d+ cqaggexpr3;
@@ -385,7 +385,7 @@ View definition:
  value  | bigint                   |           | plain    |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
-    "cqaggexpr3_mrel0__0_idx" btree (_0)
+    "cqaggexpr3_mrel0_expr_idx" btree (hash_group(key, _0))
 
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM stream GROUP BY key;
 \d+ cqaggexpr4;
@@ -407,7 +407,7 @@ View definition:
  _0     | double precision   |           | plain    |              | 
  _1     | double precision[] |           | extended |              | 
 Indexes:
-    "cqaggexpr4_mrel0_key_idx" UNIQUE, btree (key)
+    "cqaggexpr4_mrel0_expr_idx" btree (hash_group(key))
 
 CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM stream GROUP BY k0, k1;
 \d+ cqgroupby
@@ -431,7 +431,7 @@ View definition:
  k1     | integer |           | plain    |              | 
  count  | bigint  |           | plain    |              | 
 Indexes:
-    "cqgroupby_mrel0_k1_idx" btree (k1)
+    "cqgroupby_mrel0_expr_idx" btree (hash_group(k0, k1))
 
 CREATE SCHEMA test_create_cont_view;
 CREATE CONTINUOUS VIEW test_create_cont_view.error AS SELECT k0::text FROM stream;
@@ -468,7 +468,7 @@ View definition:
  e      | double precision |           | plain    |              | 
  count  | bigint           |           | plain    |              | 
 Indexes:
-    "multigroupindex_mrel0_d_idx" btree (d)
+    "multigroupindex_mrel0_expr_idx" btree (hash_group(a, b, c, d, e))
 
 DROP CONTINUOUS VIEW cqcreate0;
 DROP CONTINUOUS VIEW cqcreate1;


### PR DESCRIPTION
CV groups are now hashed into a single 32-bit value, which is then used as the matrel index key. This drastically reduces the index scan overhead when the combiner is looking up existing groups, because non-matching index keys are identified much sooner. The downsides of this approach are 1) dealing with collisions, and 2) hashing overhead. But given the significant decrease in index scan overhead that this gets us, it is empirically worth it. The 32-bit index keys also keep the physical size of the index small, and independent of the actual group size.

Basically, the problem scenario was many large groups with many similar columns, such as:

```
(0, 0, 0, 0, 0, 0, 0)
(0, 0, 0, 0, 0, 0, 1)
(0, 0, 0, 0, 0, 0, 2)
(0, 0, 0, 0, 0, 0, 3)
(0, 0, 0, 0, 0, 0, 4)
...
```

If the combiner were to look for the group `(0, 0, 0, 0, 0, 0, n)`, it would have to compare it against many similar index tuples, potentially causing the the lookup join to be `m * n`. Now the lookup join is `m * log(n)`, where `m` is no greater than the batch size and `n` is the total number of index entries.
