### PR TITLE
#900 implement combiner group cache

### DIFF
--- a/src/backend/pipeline/Makefile
+++ b/src/backend/pipeline/Makefile
@@ -14,6 +14,6 @@ include $(top_builddir)/src/Makefile.global
 
 OBJS = combiner.o combinerReceiver.o cqanalyze.o cqplan.o cqproc.o cqwindow.o \
 			 stream.o tuplebuf.o worker.o cqmatrel.o cqvacuum.o tdigest.o \
-			 miscutils.o bloom.o hll.o cmsketch.o gcs.o cont_analyze.o cont_xact.o
+			 miscutils.o bloom.o hll.o cmsketch.o gcs.o cont_analyze.o cont_xact.o groupcache.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -150,7 +150,8 @@ ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot, ESt
  *
  * Update an existing row of a CV materialization table.
  */
-void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
+void
+ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
 {
 	HeapTuple tup = ExecMaterializeSlot(slot);
 
@@ -163,7 +164,8 @@ void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
  *
  * Insert a new row into a CV materialization table
  */
-void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
+void
+ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
 {
 	HeapTuple tup = ExecMaterializeSlot(slot);
 

--- a/src/backend/pipeline/groupcache.c
+++ b/src/backend/pipeline/groupcache.c
@@ -1,0 +1,168 @@
+/*-------------------------------------------------------------------------
+ *
+ * groupcache.c
+ *	  Cache used by the combiner to cache aggregate groups. This avoids
+ *	  on-disk lookups for groups to update.
+ *
+ * src/backend/pipeline/groupcache.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "executor/executor.h"
+#include "executor/tupletableReceiver.h"
+#include "nodes/execnodes.h"
+#include "pipeline/groupcache.h"
+
+#define ENTRY_SIZE(tup) (HEAPTUPLESIZE + (tup)->t_len + sizeof(HeapTupleEntry) + sizeof(GroupCacheEntry) + sizeof(LRUEntry))
+
+/* cache entry */
+typedef struct GroupCacheEntry
+{
+	TupleHashEntryData shared;	/* common header for hash table entries */
+	HeapTuple tuple;
+	struct LRUEntry *lru;
+} GroupCacheEntry;
+
+/* node type for the queue of cache accesses used for LRU eviction */
+typedef struct LRUEntry
+{
+	dlist_node node;
+	GroupCacheEntry *entry;
+} LRUEntry;
+
+/*
+ * evict
+ *
+ * Using an LRU policy, evict enough cache entries to free the given amount of space
+ */
+static bool
+evict(GroupCache *cache, Size len)
+{
+	dlist_node *node = dlist_tail_node(&cache->lru);
+	LRUEntry *entry = (LRUEntry *) dlist_container(LRUEntry, node, node);
+
+	while (node && cache->available < len)
+	{
+		entry = (LRUEntry *) dlist_container(LRUEntry, node, node);
+		dlist_delete(node);
+
+		if (!entry->entry)
+			break;
+
+		ExecStoreTuple(entry->entry->tuple, cache->slot, InvalidBuffer, false);
+		RemoveTupleHashEntry(cache->htab, cache->slot);
+
+		cache->available += ENTRY_SIZE(entry->entry->tuple);
+		node = dlist_tail_node(&cache->lru);
+
+		heap_free_minimal_tuple(entry->entry->shared.firstTuple);
+		heap_freetuple(entry->entry->tuple);
+		pfree(entry->entry->lru);
+	}
+
+	return (cache->available >= len);
+}
+
+/*
+ * GroupCacheCreate
+ *
+ * Create an empty GroupCache
+ */
+GroupCache *
+GroupCacheCreate(Size size, int ngroupatts, AttrNumber *groupatts,
+		Oid *groupops, TupleTableSlot *slot, MemoryContext context, MemoryContext tmpcontext)
+{
+	FmgrInfo *eq_funcs;
+	FmgrInfo *hash_funcs;
+	MemoryContext old = MemoryContextSwitchTo(context);
+	GroupCache *result = palloc0(sizeof(GroupCache));
+
+	result->available = size;
+	result->maxsize = size;
+	result->context = context;
+	result->slot = MakeSingleTupleTableSlot(slot->tts_tupleDescriptor);
+
+	dlist_init(&result->lru);
+
+	execTuplesHashPrepare(ngroupatts, groupops, &eq_funcs, &hash_funcs);
+	result->htab = BuildTupleHashTable(ngroupatts, groupatts, eq_funcs, hash_funcs, 1000,
+			sizeof(GroupCacheEntry), context, tmpcontext);
+
+	MemoryContextSwitchTo(old);
+
+	return result;
+}
+
+/*
+ * GroupCachePut
+ *
+ * Add a tuple to the GroupCache, moving its access position to the head of the LRU queue
+ */
+bool
+GroupCachePut(GroupCache *cache, TupleTableSlot *slot)
+{
+	bool isnew;
+	GroupCacheEntry *entry;
+	HeapTuple tup = ExecMaterializeSlot(slot);
+	MemoryContext old;
+	Size needed = ENTRY_SIZE(tup);
+
+	/* don't bother if there isn't possibly enough room */
+	if (needed > cache->maxsize)
+		return false;
+
+	entry = (GroupCacheEntry *) LookupTupleHashEntry(cache->htab, slot, &isnew);
+
+	old = MemoryContextSwitchTo(cache->context);
+
+	if (!isnew)
+	{
+		cache->available += ENTRY_SIZE(entry->tuple);
+		heap_freetuple(entry->tuple);
+		dlist_delete(&(entry->lru->node));
+	}
+	else
+	{
+		entry->lru = palloc0(sizeof(LRUEntry));
+	}
+
+	/* evict enough entries to make room for it */
+	if (needed > cache->available)
+		evict(cache, needed);
+
+	/* copy it into long-lived context */
+	entry->tuple = ExecCopySlotTuple(slot);
+	entry->lru->entry = entry;
+
+	dlist_push_head(&(cache->lru), &(entry->lru->node));
+
+	MemoryContextSwitchTo(old);
+
+	cache->available -= needed;
+
+	return true;
+}
+
+/*
+ * GroupCacheGet
+ *
+ * Retrieve a tuple from the GroupCache, moving its access position to the head of the LRU queue
+ * Return NULL if the GroupCache doesn't contain the given tuple
+ */
+HeapTuple
+GroupCacheGet(GroupCache *cache, TupleTableSlot *slot)
+{
+	GroupCacheEntry *entry = (GroupCacheEntry *) LookupTupleHashEntry(cache->htab, slot, NULL);
+
+	if (entry == NULL)
+		return NULL;
+
+	/* move it from its existing location to the head of the queue */
+	dlist_delete(&(entry->lru->node));
+	dlist_push_head(&(cache->lru), &(entry->lru->node));
+
+	return entry->tuple;
+}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2591,6 +2591,17 @@ static struct config_int ConfigureNamesInt[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"combiner_cache_mem", PGC_BACKEND, RESOURCES_MEM,
+			gettext_noop("Sets the maximum memory to be used by the combiner for caching. This is independent of combiner_work_mem."),
+			NULL,
+			GUC_UNIT_KB
+		},
+		&combiner_cache_mem,
+		32768, 0, MAX_KILOBYTES,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, 0, 0, 0, NULL, NULL, NULL

--- a/src/backend/utils/misc/pipelinedb.conf.sample
+++ b/src/backend/utils/misc/pipelinedb.conf.sample
@@ -605,6 +605,9 @@
 #combiner_work_mem = 256MB  # maximum amount of memory to use for combiner
                             # query executions
 
+#combiner_cache_mem = 32MB  # maximum memory to be used by the combiner for
+                            # caching; this is independent of combiner_work_mem
+
 #------------------------------------------------------------------------------
 # CONFIG FILE INCLUDES
 #------------------------------------------------------------------------------

--- a/src/include/pipeline/combiner.h
+++ b/src/include/pipeline/combiner.h
@@ -17,6 +17,7 @@
 #include "utils/resowner.h"
 
 extern int combiner_work_mem;
+extern int combiner_cache_mem;
 extern int combiner_synchronous_commit;
 
 void ContinuousQueryCombinerRun(Portal portal, ContinuousViewState *state, QueryDesc *queryDesc, ResourceOwner owner);

--- a/src/include/pipeline/groupcache.h
+++ b/src/include/pipeline/groupcache.h
@@ -1,0 +1,39 @@
+/*-------------------------------------------------------------------------
+ *
+ * groupcache.h
+ *	  Interface for aggregate group cache used by the combiner
+ *
+ * src/include/pipeline/groupcache.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef PIPELINE_GROUPCACHE_H
+#define PIPELINE_GROUPCACHE_H
+
+#include "lib/ilist.h"
+
+typedef struct GroupCache {
+	/* context to store cached entries in */
+	MemoryContext context;
+	/* underlying hashtable, keyed by group */
+	TupleHashTable htab;
+	/* slot to hash tuples with */
+	TupleTableSlot *slot;
+	/* available memory left to consume before evicting existing entries */
+	Size available;
+	/* maximum size of this cache */
+	Size maxsize;
+	/*
+	 * Queue of pointers to cache elements, ordered in descending order by last access time.
+	 * We use a a doubly linked list for constant-time deletions.
+	 */
+	dlist_head lru;
+} GroupCache;
+
+extern GroupCache *GroupCacheCreate(Size size, int ngroupatts, AttrNumber *groupatts,
+		Oid *groupops, TupleTableSlot *slot, MemoryContext context, MemoryContext tmpcontext);
+extern bool GroupCachePut(GroupCache *cache, TupleTableSlot *slot);
+extern HeapTuple GroupCacheGet(GroupCache *cache, TupleTableSlot *slot);
+extern void test_groupcache(void);
+
+#endif


### PR DESCRIPTION
Adds an LRU cache to the combiner for aggregation groups. The maximum size of the cache is configurable with `combiner_cache_mem`, which defaults to 32MB. Here are some rough perf comparisons to `master` using `-O0`:

**master**
- [100k-groups-by-second](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-second): 10000000 events emitted in 271.506 s **(36.8k eps)**
- [100k-groups-by-minute](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-minute): 10000000 events emitted in 299.099 s **(33.4k eps)**
- [100k-groups (batchsize=10000 concurrency=1 count=10M)](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups): 10000000 events emitted in 376.923 s **(26.5k eps)**

**this branch**
- [100k-groups-by-second](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-second): 10000000 events emitted in 251.505 s **(39.7k eps) (+7%)**
- [100k-groups-by-minute](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-minute): 10000000 events emitted in 210.900 s **(47.4k eps) (+42%)**
- [100k-groups (batchsize=10000 concurrency=1 count=10M)](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups): 10000000 events emitted in 185.110 s **(54.0k eps) (+103%)**
