### PR TITLE
#906 matrel fillfactor 100 -> 50

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -8318,10 +8318,11 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 		;
 
 create_cv_target:
-		qualified_name
+		qualified_name opt_reloptions
 				{
 					$$ = makeNode(IntoClause);
 					$$->rel = $1;
+					$$->options = $2;
 				}
 
 opt_check_option:

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -32,6 +32,7 @@
 #include "access/xact.h"
 #include "catalog/namespace.h"
 #include "commands/async.h"
+#include "commands/pipelinecmds.h"
 #include "commands/prepare.h"
 #include "commands/vacuum.h"
 #include "commands/variable.h"
@@ -2599,6 +2600,17 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&combiner_cache_mem,
 		32768, 0, MAX_KILOBYTES,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"continuous_view_fillfactor", PGC_BACKEND, QUERY_TUNING_OTHER,
+			gettext_noop("Sets the default fillfactor to use for continuous views. Defaults to 50."),
+			NULL,
+			GUC_UNIT_KB
+		},
+		&continuous_view_fillfactor,
+		50, 1, 100,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/pipelinedb.conf.sample
+++ b/src/backend/utils/misc/pipelinedb.conf.sample
@@ -608,6 +608,9 @@
 #combiner_cache_mem = 32MB  # maximum memory to be used by the combiner for
                             # caching; this is independent of combiner_work_mem
 
+#continuous_view_fillfactor = 50 # Sets the default fillfactor to use for
+                                 # continuous views
+
 #------------------------------------------------------------------------------
 # CONFIG FILE INCLUDES
 #------------------------------------------------------------------------------

--- a/src/include/commands/pipelinecmds.h
+++ b/src/include/commands/pipelinecmds.h
@@ -13,6 +13,9 @@
 
 #include "nodes/parsenodes.h"
 
+/* GUC parameter */
+extern int continuous_view_fillfactor;
+
 void ExecCreateContinuousViewStmt(CreateContinuousViewStmt *stmt, const char *querystring);
 void ExecDropContinuousViewStmt(DropStmt *stmt);
 int ExecActivateContinuousViewStmt(ActivateContinuousViewStmt *stmt, bool recovery);

--- a/src/test/regress/expected/cont_count_distinct.out
+++ b/src/test/regress/expected/cont_count_distinct.out
@@ -53,6 +53,7 @@ SELECT * FROM test_distinct_count;
 --------+--------+-----------+----------+--------------+-------------
  count  | bigint |           | plain    |              | 
  _0     | hll    |           | extended |              | 
+Options: fillfactor=50
 
 SELECT * FROM test_distinct_sw_count;
  count 
@@ -69,6 +70,7 @@ SELECT * FROM test_distinct_sw_count;
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "test_distinct_sw_count_mrel0_expr_idx" btree (hash_group(_0))
+Options: fillfactor=50
 
 SELECT pg_sleep(1);
  pg_sleep 

--- a/src/test/regress/expected/cont_window.out
+++ b/src/test/regress/expected/cont_window.out
@@ -9,6 +9,7 @@ CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PART
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqwindow0_mrel0_expr_idx" btree (hash_group(_0, key))
+Options: fillfactor=50
 
 \d+ cqwindow0;
                 View "public.cqwindow0"
@@ -69,6 +70,7 @@ CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITIO
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqwindow1_mrel0_expr_idx" btree (hash_group(_0, key))
+Options: fillfactor=50
 
 \d+ cqwindow1;
                 View "public.cqwindow1"

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -26,6 +26,7 @@ View definition:
  Column |  Type   | Modifiers | Storage | Stats target | Description 
 --------+---------+-----------+---------+--------------+-------------
  key    | integer |           | plain   |              | 
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqcreate1 AS SELECT substring(url::text, 1, 2) FROM stream;
 SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate1';
@@ -48,6 +49,7 @@ View definition:
   Column   | Type | Modifiers | Storage  | Stats target | Description 
 -----------+------+-----------+----------+--------------+-------------
  substring | text |           | extended |              | 
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqcreate2 AS SELECT key::integer, substring(value::text, 1, 2) AS s FROM stream;
 SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate2';
@@ -73,6 +75,7 @@ View definition:
 --------+---------+-----------+----------+--------------+-------------
  key    | integer |           | plain    |              | 
  s      | text    |           | extended |              | 
+Options: fillfactor=50
 
 -- Group by projections
 CREATE CONTINUOUS VIEW cqcreate3 AS SELECT key::text, COUNT(*), SUM(value::int8) FROM stream GROUP BY key;
@@ -105,6 +108,7 @@ View definition:
  _0     | bytea   |           | extended |              | 
 Indexes:
     "cqcreate3_mrel0_expr_idx" btree (hash_group(key))
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM stream GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate4';
@@ -134,6 +138,7 @@ View definition:
  _0     | text(0) |           | extended |              | 
 Indexes:
     "cqcreate4_mrel0_expr_idx" btree (hash_group(_0))
+Options: fillfactor=50
 
 -- Sliding window queries
 CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second);
@@ -167,6 +172,7 @@ View definition:
  _0     | timestamp(0) with time zone |           | plain    |              | 
 Indexes:
     "cqcreate5_mrel0__0_idx" btree (_0)
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqcreate6 AS SELECT COUNT(*) FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate6';
@@ -201,6 +207,7 @@ View definition:
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqcreate6_mrel0_expr_idx" btree (hash_group(_1, _0))
+Options: fillfactor=50
 
 -- These use a combine state column
 CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, AVG(y::integer) AS int_avg, AVG(ts0::timestamp - ts1::timestamp) AS internal_avg FROM stream GROUP BY key;
@@ -232,6 +239,7 @@ View definition:
  _2           | interval[]         |           | extended |              | 
 Indexes:
     "cvavg_mrel0_expr_idx" btree (hash_group(key))
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM stream;
 \d+ cvjson;
@@ -249,6 +257,7 @@ View definition:
 -----------+-------+-----------+----------+--------------+-------------
  count_col | json  |           | extended |              | 
  _0        | bytea |           | extended |              | 
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cvjsonobj AS SELECT json_object_agg(key::text, value::integer) FROM stream;
 \d+ cvjsonobj;
@@ -266,6 +275,7 @@ View definition:
 -----------------+-------+-----------+----------+--------------+-------------
  json_object_agg | json  |           | extended |              | 
  _0              | bytea |           | extended |              | 
+Options: fillfactor=50
 
 -- But these aggregates don't
 CREATE CONTINUOUS VIEW cvcount AS SELECT SUM(x::integer + y::float8) AS sum_col FROM stream;
@@ -283,6 +293,7 @@ View definition:
  Column  |       Type       | Modifiers | Storage | Stats target | Description 
 ---------+------------------+-----------+---------+--------------+-------------
  sum_col | double precision |           | plain   |              | 
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cvarray AS SELECT COUNT(*) as count_col FROM stream;
 \d+ cvarray;
@@ -299,6 +310,7 @@ View definition:
   Column   |  Type  | Modifiers | Storage | Stats target | Description 
 -----------+--------+-----------+---------+--------------+-------------
  count_col | bigint |           | plain   |              | 
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text, 1, 2), ',') FROM stream GROUP BY key;
 \d+ cvtext;
@@ -321,6 +333,7 @@ View definition:
  _0         | bytea   |           | extended |              | 
 Indexes:
     "cvtext_mrel0_expr_idx" btree (hash_group(key))
+Options: fillfactor=50
 
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM stream;
@@ -339,6 +352,7 @@ View definition:
 --------+--------+-----------+---------+--------------+-------------
  _0     | bigint |           | plain   |              | 
  _1     | bigint |           | plain   |              | 
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::integer) AS value FROM stream GROUP BY key;
 \d+ cqaggexpr2;
@@ -362,6 +376,7 @@ View definition:
  _1     | integer            |           | plain    |              | 
 Indexes:
     "cqaggexpr2_mrel0_expr_idx" btree (hash_group(key))
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM stream WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key;
 \d+ cqaggexpr3;
@@ -386,6 +401,7 @@ View definition:
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqaggexpr3_mrel0_expr_idx" btree (hash_group(key, _0))
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM stream GROUP BY key;
 \d+ cqaggexpr4;
@@ -408,6 +424,7 @@ View definition:
  _1     | double precision[] |           | extended |              | 
 Indexes:
     "cqaggexpr4_mrel0_expr_idx" btree (hash_group(key))
+Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM stream GROUP BY k0, k1;
 \d+ cqgroupby
@@ -432,12 +449,15 @@ View definition:
  count  | bigint  |           | plain    |              | 
 Indexes:
     "cqgroupby_mrel0_expr_idx" btree (hash_group(k0, k1))
+Options: fillfactor=50
 
 CREATE SCHEMA test_create_cont_view;
 CREATE CONTINUOUS VIEW test_create_cont_view.error AS SELECT k0::text FROM stream;
 ERROR:  continuous views cannot be given a namespace
 CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM stream
 GROUP BY a, b, c, d, e;
+--A user-specified fillfactor should override the default
+CREATE CONTINUOUS VIEW withff WITH (fillfactor = 42) AS SELECT COUNT(*) FROM stream;
 \d+ multigroupindex;
                  View "public.multigroupindex"
  Column |       Type       | Modifiers | Storage  | Description 
@@ -469,6 +489,7 @@ View definition:
  count  | bigint           |           | plain    |              | 
 Indexes:
     "multigroupindex_mrel0_expr_idx" btree (hash_group(a, b, c, d, e))
+Options: fillfactor=50
 
 DROP CONTINUOUS VIEW cqcreate0;
 DROP CONTINUOUS VIEW cqcreate1;

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -88,6 +88,9 @@ CREATE CONTINUOUS VIEW test_create_cont_view.error AS SELECT k0::text FROM strea
 CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM stream
 GROUP BY a, b, c, d, e;
 
+--A user-specified fillfactor should override the default
+CREATE CONTINUOUS VIEW withff WITH (fillfactor = 42) AS SELECT COUNT(*) FROM stream;
+
 \d+ multigroupindex;
 \d+ multigroupindex_mrel0;
 


### PR DESCRIPTION
This changes the default `fillfactor` for matrels from 100 to 50. This means that inserted tuples will only occupy up to 50% of a given page, with the remaining space being left for updates to the page's tuples. This gives us a small but easy performance increase on matrels, since they are presumably update-heavy relations.

Some rough perf comparisons on `-O0`:

**master**
- [100k-groups-by-second](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-second): 10000000 events emitted in 251.505 s **(39.7k eps)**
- [100k-groups-by-minute](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-minute): 10000000 events emitted in 210.900 s **(47.4k eps)**
- [100k-groups (batchsize=10000 concurrency=1 count=10M)](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups): 10000000 events emitted in 185.110 s **(54.0k eps)**

**this branch**
- [100k-groups-by-second](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-second): 10000000 events emitted in 226.391 s **(44.1k eps) (+11%)**
- [100k-groups-by-minute](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups-by-minute): 10000000 events emitted in 174.739 s **(57.2k eps) (+20%)**
- [100k-groups (batchsize=10000 concurrency=1 count=10M)](https://github.com/pipelinedb/juggernaut/blob/master/100k-groups): 10000000 events emitted in 156.610 s **(63.8k eps) (+18%)**
