### PR TITLE
#915 end and reinitialize CQ plans across transactions

### DIFF
--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -90,6 +90,7 @@ static event_trigger_support_data event_trigger_support[] = {
 	{"SCHEMA", true},
 	{"SEQUENCE", true},
 	{"SERVER", true},
+	{"STREAM", true},
 	{"TABLE", true},
 	{"TABLESPACE", false},
 	{"TRIGGER", true},
@@ -942,6 +943,7 @@ EventTriggerSupportsObjectType(ObjectType obtype)
 		case OBJECT_RULE:
 		case OBJECT_SCHEMA:
 		case OBJECT_SEQUENCE:
+		case OBJECT_STREAM:
 		case OBJECT_TABLE:
 		case OBJECT_TRIGGER:
 		case OBJECT_TSCONFIGURATION:

--- a/src/backend/utils/error/assert.c
+++ b/src/backend/utils/error/assert.c
@@ -34,9 +34,9 @@ ExceptionalCondition(const char *conditionName,
 		write_stderr("TRAP: ExceptionalCondition: bad arguments\n");
 	else
 	{
-		write_stderr("TRAP: %s(\"%s\", File: \"%s\", Line: %d)\n",
+		write_stderr("TRAP: %s(\"%s\", File: \"%s\", Line: %d, PID: %d)\n",
 					 errorType, conditionName,
-					 fileName, lineNumber);
+					 fileName, lineNumber, getpid());
 	}
 
 	/* Usually this shouldn't be needed, but make sure the msg went out */


### PR DESCRIPTION
All tests pass now with assertions enabled. CQ plans are initialized and ended across executions. Technically we only need to do this for nodes that scan relations, but it seems like the correct thing to do in general so we do it for all plans, regardless of whether or not they contain table/index scan nodes.

From this point on, I would **strongly** recommend doing all development with the `--enable-cassert` configuration option and a healthy use of `Assert`.
