### PR TITLE
Remove streamdesc member from RangeTblEntry

### DIFF
--- a/src/backend/executor/nodeStreamscan.c
+++ b/src/backend/executor/nodeStreamscan.c
@@ -20,6 +20,7 @@
 #include "parser/parse_coerce.h"
 #include "catalog/pipeline_stream_fn.h"
 #include "pipeline/tuplebuf.h"
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 
@@ -41,7 +42,7 @@ map_field_positions(TupleDesc evdesc, TupleDesc desc)
 		result[i] = -1;
 		for (j = 0; j < desc->natts; j++)
 		{
-			if (strcmp(NameStr(evdesc->attrs[i]->attname), NameStr(desc->attrs[j]->attname)) == 0)
+			if (pg_strcasecmp(NameStr(evdesc->attrs[i]->attname), NameStr(desc->attrs[j]->attname)) == 0)
 			{
 				result[i] = j;
 				break;
@@ -72,6 +73,27 @@ init_proj_info(StreamProjectionInfo *pi, StreamTuple *tuple)
 	memcpy(pi->raweventdesc, tuple->desc, VARSIZE(tuple->desc) + VARHDRSZ);
 
 	MemoryContextSwitchTo(old);
+}
+
+/*
+ * init_scan_desc
+ *
+ * We need to apply attribute names to the descriptor since names are how we
+ * resolve the positions of input attributes on raw events.
+ */
+static void
+init_scan_desc(TupleDesc desc, List *colnames)
+{
+	ListCell *lc;
+	int i = 0;
+
+	Assert(desc->natts == list_length(colnames));
+
+	foreach(lc, colnames)
+	{
+		Value *v = (Value *) lfirst(lc);
+		namestrcpy(&(desc->attrs[i++]->attname), strVal(v));
+	}
 }
 
 static TupleTableSlot *
@@ -253,8 +275,10 @@ ExecInitStreamScan(StreamScan *node, EState *estate, int eflags)
 													 ALLOCSET_DEFAULT_MAXSIZE);
 
 	state->pi->econtext = CreateStandaloneExprContext();
-	state->pi->resultdesc = node->desc;
+	state->pi->resultdesc = ExecTypeFromTL(node->targetlist, false);
 	state->pi->raweventdesc = NULL;
+
+	init_scan_desc(state->pi->resultdesc, node->colnames);
 
 	/*
 	 * Miscellaneous initialization
@@ -279,7 +303,7 @@ ExecInitStreamScan(StreamScan *node, EState *estate, int eflags)
 
 	state->ss.ps.ps_TupFromTlist = false;
 
-	ExecAssignScanType(&state->ss, node->desc);
+	ExecAssignScanType(&state->ss, state->pi->resultdesc);
 
 	/*
 	 * Initialize result tuple type and projection info.

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -928,14 +928,6 @@ _outRangeVar(StringInfo str, const RangeVar *node)
 }
 
 static void
-_outStreamDesc(StringInfo str, const StreamDesc *node)
-{
-	WRITE_NODE_TYPE("STREAMDESC");
-
-	WRITE_NODE_FIELD(name);
-}
-
-static void
 _outIntoClause(StringInfo str, const IntoClause *node)
 {
 	WRITE_NODE_TYPE("INTOCLAUSE");
@@ -2968,9 +2960,6 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_RangeVar:
 				_outRangeVar(str, obj);
-				break;
-			case T_StreamDesc:
-				_outStreamDesc(str, obj);
 				break;
 			case T_IntoClause:
 				_outIntoClause(str, obj);

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -867,23 +867,10 @@ build_physical_tlist(PlannerInfo *root, RelOptInfo *rel)
 	switch (rte->rtekind)
 	{
 		case RTE_RELATION:
-			if (rte->streamdesc)
-			{
-				desc = rte->streamdesc->desc;
-				numattrs = desc->natts;
-			}
-			else if (root->parse->isCombine)
-			{
-				/* XXX PipelineDB: why is rte NULL here for merge queries? */
-				return NIL;
-			}
-			else
-			{
-				/* Assume we already have adequate lock */
-				relation = heap_open(rte->relid, NoLock);
-				desc = relation->rd_att;
-				numattrs = RelationGetNumberOfAttributes(relation);
-			}
+			/* Assume we already have adequate lock */
+			relation = heap_open(rte->relid, NoLock);
+			desc = relation->rd_att;
+			numattrs = RelationGetNumberOfAttributes(relation);
 
 			for (attrno = 1; attrno <= numattrs; attrno++)
 			{
@@ -934,6 +921,7 @@ build_physical_tlist(PlannerInfo *root, RelOptInfo *rel)
 			}
 			break;
 
+		case RTE_STREAM:
 		case RTE_FUNCTION:
 		case RTE_VALUES:
 		case RTE_CTE:

--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -137,14 +137,6 @@ build_simple_rel(PlannerInfo *root, int relid, RelOptKind reloptkind)
 			get_relation_info(root, rte->relid, rte->inh, rel);
 			break;
 		case RTE_STREAM:
-			/* it's a stream, get the stream's RTE to look at the number of inferred attributes */
-			rel->min_attr = 0;
-			rel->max_attr = rte->streamdesc->desc->natts;
-			rel->reltablespace = InvalidOid;
-
-			rel->attr_needed = (Relids *) palloc0((rel->max_attr + 1) * sizeof(Relids));
-			rel->attr_widths = (int32 *) palloc0((rel->max_attr + 1) * sizeof(int32));
-			break;
 		case RTE_SUBQUERY:
 		case RTE_FUNCTION:
 		case RTE_VALUES:

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1126,25 +1126,6 @@ transformFromClauseItem(ParseState *pstate, Node *n,
 
 		return (Node *) j;
 	}
-	else if (IsA(n, StreamDesc))
-	{
-		StreamDesc *desc = (StreamDesc *) n;
-		RangeTblRef *rtr;
-		RangeTblEntry *rte;
-		int rtindex;
-
-		rte = transformStreamDesc(pstate, desc);
-
-		/* assume new rte is at end */
-		rtindex = list_length(pstate->p_rtable);
-		Assert(rte == rt_fetch(rtindex, pstate->p_rtable));
-		*top_rte = rte;
-		*top_rti = rtindex;
-		*namespace = list_make1(makeDefaultNSItem(rte));
-		rtr = makeNode(RangeTblRef);
-		rtr->rtindex = rtindex;
-		return (Node *) rtr;
-	}
 	else
 		elog(ERROR, "unrecognized node type: %d", (int) nodeTag(n));
 	return NULL;				/* can't get here, keep compiler quiet */

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -28,6 +28,7 @@
 #include "parser/parsetree.h"
 #include "parser/parse_relation.h"
 #include "parser/parse_type.h"
+#include "pipeline/cont_analyze.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -608,29 +609,6 @@ scanRTEForColumn(ParseState *pstate, RangeTblEntry *rte, char *colname,
 		}
 	}
 
-	/*
-	 * If the RTE represents a stream look for the column in the stream's inferred tuple descriptor
-	 */
-	if (rte->streamdesc && result == NULL)
-	{
-		Form_pg_attribute *attrs = rte->streamdesc->desc->attrs;
-		int i;
-		for (i=0; i<rte->streamdesc->desc->natts; i++)
-		{
-			if (strcmp(NameStr(attrs[i]->attname), colname) == 0)
-			{
-				AttrNumber attnum = i + 1;
-				int sublevels_up;
-				int vnum = RTERangeTablePosn(pstate, rte, &sublevels_up);
-				var = makeVar(vnum, attnum, attrs[i]->atttypid, attrs[i]->atttypmod,
-						attrs[i]->attcollation, sublevels_up);
-
-				result = (Node *) var;
-				break;
-			}
-		}
-	}
-
 	return result;
 }
 
@@ -1040,6 +1018,7 @@ addRangeTableEntry(ParseState *pstate,
 	char	   *refname = alias ? alias->aliasname : relation->relname;
 	LOCKMODE	lockmode;
 	Relation	rel;
+	TupleDesc desc;
 
 	rte->rtekind = RTE_RELATION;
 	rte->alias = alias;
@@ -1051,23 +1030,51 @@ addRangeTableEntry(ParseState *pstate,
 	 * depending on whether we're doing SELECT FOR UPDATE/SHARE.
 	 */
 	lockmode = isLockedRefname(pstate, refname) ? RowShareLock : AccessShareLock;
-	rel = parserOpenTable(pstate, relation, lockmode);
-	rte->relid = RelationGetRelid(rel);
-	rte->relkind = rel->rd_rel->relkind;
+
+	rel = heap_openrv_extended(relation, lockmode, true);
+
+	if (rel != NULL && !RangeVarIsForTypedStream(relation))
+	{
+		/* it's an actual relation */
+		heap_close(rel, lockmode);
+		rel = parserOpenTable(pstate, relation, lockmode);
+		rte->relid = RelationGetRelid(rel);
+		rte->relkind = rel->rd_rel->relkind;
+		desc = rel->rd_att;
+	}
+	else if (pstate->p_is_continuous_view)
+	{
+		/*
+		 * It could be a strongly typed stream, but even if the rel doesn't exist, assume it's a stream
+		 */
+		rte->rtekind = RTE_STREAM;
+		inh = false;
+		desc = ParserGetStreamDescr(pstate, relation, rte);
+	}
+	else if (rel == NULL || RangeVarIsForTypedStream(relation))
+	{
+		/*
+		 * It's either a bad access attempt, or an attempt to access a typed stream outside of a continuous
+		 * view. Either way, throw the appropriate error.
+		 */
+		parserOpenTable(pstate, relation, lockmode);
+		Assert(false);
+	}
 
 	/*
 	 * Build the list of effective column names using user-supplied aliases
 	 * and/or actual column names.
 	 */
 	rte->eref = makeAlias(refname, NIL);
-	buildRelationAliases(rel->rd_att, alias, rte->eref);
+	buildRelationAliases(desc, alias, rte->eref);
 
 	/*
 	 * Drop the rel refcount, but keep the access lock till end of transaction
 	 * so that the table can't be deleted or have its schema modified
 	 * underneath us.
 	 */
-	heap_close(rel, NoLock);
+	if (rel)
+		heap_close(rel, NoLock);
 
 	/*
 	 * Set flags and access permissions.
@@ -1841,13 +1848,6 @@ expandRTE(RangeTblEntry *rte, int rtindex, int sublevels_up,
 					rtindex, sublevels_up, location,
 					include_dropped, colnames, colvars);
 			break;
-		case RTE_STREAM:
-			/* Stream RTE */
-			Assert(rte->streamdesc);
-			expandTupleDesc(rte->streamdesc->desc, rte->eref, rte->streamdesc->desc->natts, 0, rtindex,
-					sublevels_up, location, include_dropped,
-					colnames, colvars);
-			break;
 		case RTE_SUBQUERY:
 			{
 				/* Subquery RTE */
@@ -2115,6 +2115,7 @@ expandRTE(RangeTblEntry *rte, int rtindex, int sublevels_up,
 				}
 			}
 			break;
+		case RTE_STREAM:
 		case RTE_CTE:
 			{
 				ListCell   *aliasp_item = list_head(rte->eref->colnames);
@@ -2340,11 +2341,6 @@ get_rte_attribute_name(RangeTblEntry *rte, AttrNumber attnum)
 		attnum > 0 && attnum <= list_length(rte->alias->colnames))
 		return strVal(list_nth(rte->alias->colnames, attnum - 1));
 
-	if (rte->streamdesc)
-	{
-		if (attnum > 0 && attnum <= rte->streamdesc->desc->natts)
-			return NameStr(rte->streamdesc->desc->attrs[attnum - 1]->attname);
-	}
 	/*
 	 * If the RTE is a relation, go to the system catalogs not the
 	 * eref->colnames list.  This is a little slower but it will give the
@@ -2411,11 +2407,10 @@ get_rte_attribute_type(RangeTblEntry *rte, AttrNumber attnum,
 		case RTE_STREAM:
 			{
 				/* Stream RTE --- get the attribute's type info from the streamdesc */
-				Form_pg_attribute att_tup = rte->streamdesc->desc->attrs[attnum - 1];
-
-				*vartype = att_tup->atttypid;
-				*vartypmod = att_tup->atttypmod;
-				*varcollid = att_tup->attcollation;
+				Assert(attnum > 0 && attnum <= list_length(rte->ctecoltypes));
+				*vartype = list_nth_oid(rte->ctecoltypes, attnum - 1);
+				*vartypmod = list_nth_int(rte->ctecoltypmods, attnum - 1);
+				*varcollid = list_nth_oid(rte->ctecolcollations, attnum - 1);
 			}
 			break;
 		case RTE_SUBQUERY:

--- a/src/backend/pipeline/cont_analyze.c
+++ b/src/backend/pipeline/cont_analyze.c
@@ -230,166 +230,6 @@ compare_attrs(const void *a, const void *b)
 }
 
 /*
- * make_streamdesc
- *
- * Create a StreamDesc and build and attach a TupleDesc to it
- */
-static Node *
-make_streamdesc(RangeVar *rv, ContAnalyzeContext *context)
-{
-	List *attrs = NIL;
-	ListCell *lc;
-	StreamDesc *desc = makeNode(StreamDesc);
-	TupleDesc tupdesc;
-	bool onestream = list_length(context->streams) == 1 && list_length(context->rels) == 0;
-	AttrNumber attnum = 1;
-	bool sawArrivalTime = false;
-	Form_pg_attribute *attrsArray;
-	int i;
-
-	desc->name = rv;
-
-	if (RangeVarIsForTypedStream(rv))
-	{
-		Relation rel = heap_openrv_extended(rv, AccessShareLock, false);
-		TupleDesc td = RelationGetDescr(rel);
-
-		for (i = 0; i < td->natts; i++)
-		{
-			attrs = lappend(attrs, td->attrs[i]);
-			attnum++;
-		}
-
-		heap_close(rel, AccessShareLock);
-	}
-	else
-	{
-		foreach(lc, context->types)
-		{
-			Oid oid;
-			TypeCast *tc = (TypeCast *) lfirst(lc);
-			ColumnRef *ref = (ColumnRef *) tc->arg;
-			Form_pg_attribute attr;
-			char *colname;
-			bool alreadyExists = false;
-			ListCell *lc;
-
-			if (list_length(ref->fields) == 2)
-			{
-				/* find the columns that belong to this stream desc */
-				char *colrelname = strVal(linitial(ref->fields));
-				char *relname = rv->alias ? rv->alias->aliasname : rv->relname;
-				if (pg_strcasecmp(relname, colrelname) != 0)
-					continue;
-			}
-
-			if ((list_length(ref->fields) == 1) && !onestream)
-				ereport(ERROR,
-						(errcode(ERRCODE_AMBIGUOUS_COLUMN),
-						 errmsg("column reference is ambiguous"),
-						 parser_errposition(context->pstate, ref->location)));
-
-			colname = FigureColname((Node *) ref);
-
-			/* Dedup */
-			foreach (lc, attrs)
-			{
-				Form_pg_attribute attr = (Form_pg_attribute) lfirst(lc);
-				if (pg_strcasecmp(colname, NameStr(attr->attname)) == 0)
-				{
-					alreadyExists = true;
-					break;
-				}
-			}
-
-			if (alreadyExists)
-				continue;
-
-			if (pg_strcasecmp(colname, ARRIVAL_TIMESTAMP) == 0)
-					sawArrivalTime = true;
-
-			oid = LookupTypeNameOid(NULL, tc->typeName, false);
-			attr = (Form_pg_attribute) palloc(sizeof(FormData_pg_attribute));
-			attr->attnum = attnum++;
-			attr->atttypid = oid;
-
-			namestrcpy(&attr->attname, colname);
-			attrs = lappend(attrs, attr);
-		}
-	}
-
-	if (!sawArrivalTime)
-	{
-		Oid oid = LookupTypeNameOid(NULL, makeTypeName("timestamptz"), false);
-		Form_pg_attribute attr = (Form_pg_attribute) palloc(sizeof(FormData_pg_attribute));
-		attr->attnum = attnum++;
-		attr->atttypid = oid;
-		namestrcpy(&attr->attname, ARRIVAL_TIMESTAMP);
-		attrs = lappend(attrs, attr);
-	}
-
-	attrsArray = (Form_pg_attribute *) palloc(list_length(attrs) * sizeof(Form_pg_attribute));
-	i = 0;
-
-	foreach(lc, attrs)
-	{
-		attrsArray[i] = (Form_pg_attribute) lfirst(lc);
-		i++;
-	}
-
-	qsort(attrsArray, list_length(attrs), sizeof(Form_pg_attribute), &compare_attrs);
-
-	tupdesc = CreateTemplateTupleDesc(list_length(attrs), false);
-
-	for (i = 0; i < list_length(attrs); i++)
-	{
-		Form_pg_attribute attr = attrsArray[i];
-
-		/* PipelineDB XXX: should we be able to handle non-zero dimensions here? */
-		TupleDescInitEntry(tupdesc, attr->attnum, NameStr(attr->attname),
-				attr->atttypid, InvalidOid, 0);
-	}
-
-	pfree(attrsArray);
-	desc->desc = tupdesc;
-
-	return (Node *) desc;
-}
-
-/*
- * replace_stream_rangevar_with_streamdesc
- *
- * Doing this as early as possible simplifies the rest of the analyze path.
- */
-static Node*
-replace_stream_rangevar_with_streamdesc(Node *node, ContAnalyzeContext *context)
-{
-	if (IsA(node, RangeVar))
-	{
-		ListCell *lc;
-		foreach(lc, context->streams)
-		{
-			RangeVar *rv = (RangeVar *) lfirst(lc);
-			if (equal(rv, node))
-				return make_streamdesc(rv, context);
-		}
-
-		/* not a stream */
-		return node;
-	}
-	else if (IsA(node, JoinExpr))
-	{
-		JoinExpr *join = (JoinExpr *) node;
-		join->larg = replace_stream_rangevar_with_streamdesc(join->larg, context);
-		join->rarg = replace_stream_rangevar_with_streamdesc(join->rarg, context);
-
-		return (Node *) join;
-	}
-	else
-		return node;
-}
-
-/*
  * find_clock_timestamp_expr
  *
  * This function picks out the part of the where clause
@@ -882,17 +722,9 @@ ValidateContQuery(CreateContViewStmt *stmt, const char *sql)
 	collect_windows(select, context);
 	if (context->windows)
 	{
-		List *fromClause = NIL;
-
-		foreach(lc, select->fromClause)
-		{
-			Node *n = (Node *) lfirst(lc);
-			Node *newnode = replace_stream_rangevar_with_streamdesc(n, context);
-
-			fromClause = lappend(fromClause, newnode);
-		}
-
-		transformFromClause(context->pstate, fromClause);
+		context->pstate->p_is_continuous_view = true;
+		context->pstate->p_cont_view_context = context;
+		transformFromClause(context->pstate, select->fromClause);
 
 		foreach(lc, context->windows)
 		{
@@ -934,57 +766,161 @@ ValidateContQuery(CreateContViewStmt *stmt, const char *sql)
 }
 
 /*
+ * ParserGetStreamDescr
+ *
+ * Get a parse-time tuple descriptor for the given stream
+ */
+TupleDesc
+ParserGetStreamDescr(ParseState *pstate, RangeVar *rv, RangeTblEntry *rte)
+{
+	ContAnalyzeContext *context = pstate->p_cont_view_context;
+	List *attrs = NIL;
+	ListCell *lc;
+	TupleDesc tupdesc;
+	bool onestream = list_length(context->streams) == 1 && list_length(context->rels) == 0;
+	AttrNumber attnum = 1;
+	bool sawArrivalTime = false;
+	Form_pg_attribute *attrsArray;
+	int i;
+
+	/*
+	 * We cheat a little and use the CTE fields here, because they're exactly
+	 * what we need for stream type information. Eventually we can add our own
+	 * identical fields if we need to.
+	 */
+	rte->ctecoltypes = NIL;
+	rte->ctecoltypmods = NIL;
+	rte->ctecolcollations = NIL;
+
+	if (RangeVarIsForTypedStream(rv))
+	{
+		Relation rel = heap_openrv_extended(rv, AccessShareLock, false);
+		TupleDesc td = RelationGetDescr(rel);
+
+		for (i = 0; i < td->natts; i++)
+		{
+			attrs = lappend(attrs, td->attrs[i]);
+			attnum++;
+		}
+
+		heap_close(rel, AccessShareLock);
+	}
+	else
+	{
+		foreach(lc, context->types)
+		{
+			TypeCast *tc = (TypeCast *) lfirst(lc);
+			ColumnRef *ref = (ColumnRef *) tc->arg;
+			Form_pg_attribute attr;
+			char *colname;
+			bool alreadyExists = false;
+			ListCell *lc;
+			Type type;
+			int32 typemod;
+
+			if (list_length(ref->fields) == 2)
+			{
+				/* find the columns that belong to this stream desc */
+				char *colrelname = strVal(linitial(ref->fields));
+				char *relname = rv->alias ? rv->alias->aliasname : rv->relname;
+				if (pg_strcasecmp(relname, colrelname) != 0)
+					continue;
+			}
+
+			if ((list_length(ref->fields) == 1) && !onestream)
+				ereport(ERROR,
+						(errcode(ERRCODE_AMBIGUOUS_COLUMN),
+						 errmsg("column reference is ambiguous"),
+						 parser_errposition(context->pstate, ref->location)));
+
+			colname = FigureColname((Node *) ref);
+
+			/* Dedup */
+			foreach (lc, attrs)
+			{
+				Form_pg_attribute attr = (Form_pg_attribute) lfirst(lc);
+				if (pg_strcasecmp(colname, NameStr(attr->attname)) == 0)
+				{
+					alreadyExists = true;
+					break;
+				}
+			}
+
+			if (alreadyExists)
+				continue;
+
+			if (pg_strcasecmp(colname, ARRIVAL_TIMESTAMP) == 0)
+					sawArrivalTime = true;
+
+			type = typenameType(pstate, tc->typeName, &typemod);
+
+			attr = (Form_pg_attribute) palloc(sizeof(FormData_pg_attribute));
+			attr->attndims = list_length(tc->typeName->arrayBounds);
+			attr->attnum = attnum++;
+			attr->atttypid = typeTypeId(type);
+			attr->atttypmod = typemod;
+			attr->attcollation = typeTypeCollation(type);
+
+			namestrcpy(&attr->attname, colname);
+			attrs = lappend(attrs, attr);
+
+			ReleaseSysCache((HeapTuple) type);
+		}
+	}
+
+	if (!sawArrivalTime)
+	{
+		Oid oid = LookupTypeNameOid(NULL, makeTypeName("timestamptz"), false);
+		Form_pg_attribute attr = (Form_pg_attribute) palloc(sizeof(FormData_pg_attribute));
+		attr->attnum = attnum++;
+		attr->atttypid = oid;
+		attr->attndims = 1;
+		attr->atttypmod = -1;
+		attr->attcollation = InvalidOid;
+		namestrcpy(&attr->attname, ARRIVAL_TIMESTAMP);
+		attrs = lappend(attrs, attr);
+	}
+
+	attrsArray = (Form_pg_attribute *) palloc(list_length(attrs) * sizeof(Form_pg_attribute));
+	i = 0;
+
+	foreach(lc, attrs)
+	{
+		attrsArray[i] = (Form_pg_attribute) lfirst(lc);
+		rte->ctecoltypes = lappend_oid(rte->ctecoltypes, attrsArray[i]->atttypid);
+		rte->ctecoltypmods = lappend_int(rte->ctecoltypmods, attrsArray[i]->atttypmod);
+		rte->ctecolcollations = lappend_oid(rte->ctecolcollations, attrsArray[i]->attcollation);
+		i++;
+	}
+
+	qsort(attrsArray, list_length(attrs), sizeof(Form_pg_attribute), &compare_attrs);
+
+	tupdesc = CreateTemplateTupleDesc(list_length(attrs), false);
+
+	for (i = 0; i < list_length(attrs); i++)
+	{
+		Form_pg_attribute attr = attrsArray[i];
+		TupleDescInitEntry(tupdesc, attr->attnum, NameStr(attr->attname),
+				attr->atttypid, InvalidOid, attr->attndims);
+	}
+
+	pfree(attrsArray);
+
+	return tupdesc;
+}
+
+
+/*
  * transformContinuousSelectStmt
  */
 void
 transformContSelectStmt(ParseState *pstate, SelectStmt *select)
 {
 	ContAnalyzeContext *context = MakeContAnalyzeContext(pstate, select);
-	ListCell *lc;
-	List *fromClause = NIL;
 
 	collect_rels_and_streams((Node *) select->fromClause, context);
 	collect_types_and_cols((Node *) select, context);
 
-	foreach(lc, select->fromClause)
-	{
-		Node *n = (Node *) lfirst(lc);
-		Node *newnode = replace_stream_rangevar_with_streamdesc(n, context);
-
-		fromClause = lappend(fromClause, newnode);
-	}
-
-	select->fromClause = fromClause;
-}
-
-/*
- * transformStreamEntry
- *
- * Transform a StreamDesc to a RangeTblEntry
- */
-RangeTblEntry *
-transformStreamDesc(ParseState *pstate, StreamDesc *stream)
-{
-	RangeVar *relation = stream->name;
-	RangeTblEntry *rte = makeNode(RangeTblEntry);
-	char *refname = relation->alias ? relation->alias->aliasname : relation->relname;
-
-	rte->rtekind = RTE_STREAM;
-	rte->alias = relation->alias;
-	rte->inFromCl = true;
-	rte->requiredPerms = ACL_SELECT;
-	rte->checkAsUser = InvalidOid;		/* not set-uid by default, either */
-	rte->selectedCols = NULL;
-	rte->modifiedCols = NULL;
-	rte->relname = refname;
-
-	rte->eref = makeAlias(refname, NIL);
-	rte->relkind = RELKIND_STREAM;
-	rte->relid = GetStreamRelId(stream->name);
-	rte->streamdesc = stream;
-
-	if (pstate != NULL)
-		pstate->p_rtable = lappend(pstate->p_rtable, rte);
-
-	return rte;
+	pstate->p_cont_view_context = context;
+	pstate->p_is_continuous_view = true;
 }

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1861,7 +1861,6 @@ typedef struct StreamScanState
 {
 	ScanState	ss;
 	TupleBufferBatchReader *reader;
-	TupleDesc desc;
 	StreamProjectionInfo *pi;
 } StreamScanState;
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -801,18 +801,6 @@ typedef struct RangeTblEntry
 	List	   *ctecolcollations;		/* OID list of column collation OIDs */
 
 	/*
-	 * Fields valid for a stream RTE (else NULL/zero):
-	 */
-
-	/*
-	 * If this RTE represents a stream, this is its schema. We attach it here because
-	 * streams aren't required to be represented as actual relations in the catalog,
-	 * so we use this in some cases instead of looking for nonexsitent relations in
-	 * the catalog.
-	 */
-	StreamDesc *streamdesc;
-
-	/*
 	 * Fields valid in all RTEs:
 	 */
 	Alias	   *alias;			/* user-written alias clause, if any */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -289,7 +289,8 @@ typedef Scan SeqScan;
 typedef struct StreamScan
 {
 	Scan scan;
-	TupleDesc desc;
+	List *colnames;
+	List *targetlist;
 } StreamScan;
 
 /* ----------------

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -80,13 +80,6 @@ typedef struct RangeVar
 	int			location;		/* token location, or -1 if unknown */
 } RangeVar;
 
-typedef struct StreamDesc
-{
-	NodeTag type;
-	RangeVar *name;
-	TupleDesc desc;
-} StreamDesc;
-
 /*
  * IntoClause - target information for SELECT INTO, CREATE TABLE AS, and
  * CREATE MATERIALIZED VIEW

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -79,6 +79,7 @@ typedef Node *(*CoerceParamHook) (ParseState *pstate, Param *param,
 									   Oid targetTypeId, int32 targetTypeMod,
 											  int location);
 
+typedef struct ContAnalyzeContext ContAnalyzeContext;
 
 /*
  * State information used during parse analysis
@@ -165,6 +166,12 @@ struct ParseState
 	ParseParamRefHook p_paramref_hook;
 	CoerceParamHook p_coerce_param_hook;
 	void	   *p_ref_hook_state;		/* common passthrough link for above */
+
+	/* true if the root parse node is continuous */
+	bool		p_is_continuous_view;
+
+	/* context if this is a continuous view */
+	ContAnalyzeContext *p_cont_view_context;
 };
 
 /*

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -33,6 +33,7 @@ extern ContAnalyzeContext *MakeContAnalyzeContext(ParseState *pstate, SelectStmt
 extern void ValidateContQuery(CreateContViewStmt *stmt, const char *sql);
 
 extern void transformContSelectStmt(ParseState *pstate, SelectStmt *select);
-extern RangeTblEntry *transformStreamDesc(ParseState *pstate, StreamDesc *stream);
+
+extern TupleDesc ParserGetStreamDescr(ParseState *pstate, RangeVar *rv, RangeTblEntry *rte);
 
 #endif

--- a/src/test/regress/expected/cont_window.out
+++ b/src/test/regress/expected/cont_window.out
@@ -3,7 +3,7 @@ CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PART
                             Table "public.cqwindow0_mrel0"
  Column |           Type           | Modifiers | Storage  | Stats target | Description 
 --------+--------------------------+-----------+----------+--------------+-------------
- key    | text(0)                  |           | extended |              | 
+ key    | text                     |           | extended |              | 
  sum    | numeric                  |           | main     |              | 
  _1     | bytea                    |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
@@ -15,7 +15,7 @@ Options: fillfactor=50
                 View "public.cqwindow0"
  Column |  Type   | Modifiers | Storage  | Description 
 --------+---------+-----------+----------+-------------
- key    | text(0) |           | extended | 
+ key    | text    |           | extended | 
  sum    | numeric |           | main     | 
 View definition:
  SELECT cqwindow0_mrel0.key,
@@ -62,7 +62,7 @@ CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITIO
                             Table "public.cqwindow1_mrel0"
  Column |           Type           | Modifiers | Storage  | Stats target | Description 
 --------+--------------------------+-----------+----------+--------------+-------------
- key    | text(0)                  |           | extended |              | 
+ key    | text                     |           | extended |              | 
  avg    | numeric                  |           | main     |              | 
  _1     | bigint[]                 |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
@@ -74,7 +74,7 @@ Options: fillfactor=50
                 View "public.cqwindow1"
  Column |  Type   | Modifiers | Storage  | Description 
 --------+---------+-----------+----------+-------------
- key    | text(0) |           | extended | 
+ key    | text    |           | extended | 
  avg    | numeric |           | main     | 
 View definition:
  SELECT cqwindow1_mrel0.key,

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -89,7 +89,7 @@ SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate3';
                 View "public.cqcreate3"
  Column |  Type   | Modifiers | Storage  | Description 
 --------+---------+-----------+----------+-------------
- key    | text(0) |           | extended | 
+ key    | text    |           | extended | 
  count  | bigint  |           | plain    | 
  sum    | numeric |           | main     | 
 View definition:
@@ -102,7 +102,7 @@ View definition:
                     Table "public.cqcreate3_mrel0"
  Column |  Type   | Modifiers | Storage  | Stats target | Description 
 --------+---------+-----------+----------+--------------+-------------
- key    | text(0) |           | extended |              | 
+ key    | text    |           | extended |              | 
  count  | bigint  |           | plain    |              | 
  sum    | numeric |           | main     |              | 
  _0     | bytea   |           | extended |              | 
@@ -135,7 +135,7 @@ View definition:
  count  | bigint  |           | plain    |              | 
  sum    | numeric |           | main     |              | 
  _1     | bytea   |           | extended |              | 
- _0     | text(0) |           | extended |              | 
+ _0     | text    |           | extended |              | 
 Indexes:
     "cqcreate4_mrel0_expr_idx" btree (hash_group(_0))
 Options: fillfactor=50
@@ -155,21 +155,21 @@ SELECT gc FROM pipeline_query WHERE name='cqcreate5';
 (1 row)
 
 \d+ cqcreate5;
-                View "public.cqcreate5"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- key    | text(0) |           | extended | 
+              View "public.cqcreate5"
+ Column | Type | Modifiers | Storage  | Description 
+--------+------+-----------+----------+-------------
+ key    | text |           | extended | 
 View definition:
  SELECT cqcreate5_mrel0.key
    FROM cqcreate5_mrel0
   WHERE cqcreate5_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second);
 
 \d+ cqcreate5_mrel0;
-                              Table "public.cqcreate5_mrel0"
- Column |            Type             | Modifiers | Storage  | Stats target | Description 
---------+-----------------------------+-----------+----------+--------------+-------------
- key    | text(0)                     |           | extended |              | 
- _0     | timestamp(0) with time zone |           | plain    |              | 
+                            Table "public.cqcreate5_mrel0"
+ Column |           Type           | Modifiers | Storage  | Stats target | Description 
+--------+--------------------------+-----------+----------+--------------+-------------
+ key    | text                     |           | extended |              | 
+ _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqcreate5_mrel0__0_idx" btree (_0)
 Options: fillfactor=50
@@ -203,7 +203,7 @@ View definition:
  Column |           Type           | Modifiers | Storage  | Stats target | Description 
 --------+--------------------------+-----------+----------+--------------+-------------
  count  | bigint                   |           | plain    |              | 
- _1     | text(0)                  |           | extended |              | 
+ _1     | text                     |           | extended |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
     "cqcreate6_mrel0_expr_idx" btree (ls_hash_group(_1, _0))
@@ -215,7 +215,7 @@ CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, A
                          View "public.cvavg"
     Column    |       Type       | Modifiers | Storage  | Description 
 --------------+------------------+-----------+----------+-------------
- key          | text(0)          |           | extended | 
+ key          | text             |           | extended | 
  float_avg    | double precision |           | plain    | 
  int_avg      | numeric          |           | main     | 
  internal_avg | interval         |           | plain    | 
@@ -230,7 +230,7 @@ View definition:
                               Table "public.cvavg_mrel0"
     Column    |        Type        | Modifiers | Storage  | Stats target | Description 
 --------------+--------------------+-----------+----------+--------------+-------------
- key          | text(0)            |           | extended |              | 
+ key          | text               |           | extended |              | 
  float_avg    | double precision   |           | plain    |              | 
  _0           | double precision[] |           | extended |              | 
  int_avg      | numeric            |           | main     |              | 
@@ -314,23 +314,23 @@ Options: fillfactor=50
 
 CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text, 1, 2), ',') FROM cont_create_stream2 GROUP BY key;
 \d+ cvtext;
-                   View "public.cvtext"
-   Column   |  Type   | Modifiers | Storage  | Description 
-------------+---------+-----------+----------+-------------
- key        | text(0) |           | extended | 
- string_agg | text    |           | extended | 
+                  View "public.cvtext"
+   Column   | Type | Modifiers | Storage  | Description 
+------------+------+-----------+----------+-------------
+ key        | text |           | extended | 
+ string_agg | text |           | extended | 
 View definition:
  SELECT cvtext_mrel0.key,
     cvtext_mrel0.string_agg
    FROM cvtext_mrel0;
 
 \d+ cvtext_mrel0;
-                       Table "public.cvtext_mrel0"
-   Column   |  Type   | Modifiers | Storage  | Stats target | Description 
-------------+---------+-----------+----------+--------------+-------------
- key        | text(0) |           | extended |              | 
- string_agg | text    |           | extended |              | 
- _0         | bytea   |           | extended |              | 
+                      Table "public.cvtext_mrel0"
+   Column   | Type  | Modifiers | Storage  | Stats target | Description 
+------------+-------+-----------+----------+--------------+-------------
+ key        | text  |           | extended |              | 
+ string_agg | text  |           | extended |              | 
+ _0         | bytea |           | extended |              | 
 Indexes:
     "cvtext_mrel0_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
@@ -359,7 +359,7 @@ CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::in
                     View "public.cqaggexpr2"
  Column |       Type       | Modifiers | Storage  | Description 
 --------+------------------+-----------+----------+-------------
- key    | text(0)          |           | extended | 
+ key    | text             |           | extended | 
  value  | double precision |           | plain    | 
 View definition:
  SELECT cqaggexpr2_mrel0.key,
@@ -370,7 +370,7 @@ View definition:
                          Table "public.cqaggexpr2_mrel0"
  Column |        Type        | Modifiers | Storage  | Stats target | Description 
 --------+--------------------+-----------+----------+--------------+-------------
- key    | text(0)            |           | extended |              | 
+ key    | text               |           | extended |              | 
  _0     | double precision   |           | plain    |              | 
  _2     | double precision[] |           | extended |              | 
  _1     | integer            |           | plain    |              | 
@@ -381,10 +381,10 @@ Options: fillfactor=50
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key;
 \d+ cqaggexpr3;
                View "public.cqaggexpr3"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- key    | text(0) |           | extended | 
- value  | bigint  |           | plain    | 
+ Column |  Type  | Modifiers | Storage  | Description 
+--------+--------+-----------+----------+-------------
+ key    | text   |           | extended | 
+ value  | bigint |           | plain    | 
 View definition:
  SELECT cqaggexpr3_mrel0.key,
     combine(cqaggexpr3_mrel0.2) AS value
@@ -396,7 +396,7 @@ View definition:
                             Table "public.cqaggexpr3_mrel0"
  Column |           Type           | Modifiers | Storage  | Stats target | Description 
 --------+--------------------------+-----------+----------+--------------+-------------
- key    | text(0)                  |           | extended |              | 
+ key    | text                     |           | extended |              | 
  value  | bigint                   |           | plain    |              | 
  _0     | timestamp with time zone |           | plain    |              | 
 Indexes:
@@ -408,7 +408,7 @@ CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS v
                     View "public.cqaggexpr4"
  Column |       Type       | Modifiers | Storage  | Description 
 --------+------------------+-----------+----------+-------------
- key    | text(0)          |           | extended | 
+ key    | text             |           | extended | 
  value  | double precision |           | plain    | 
 View definition:
  SELECT cqaggexpr4_mrel0.key,
@@ -419,7 +419,7 @@ View definition:
                          Table "public.cqaggexpr4_mrel0"
  Column |        Type        | Modifiers | Storage  | Stats target | Description 
 --------+--------------------+-----------+----------+--------------+-------------
- key    | text(0)            |           | extended |              | 
+ key    | text               |           | extended |              | 
  _0     | double precision   |           | plain    |              | 
  _1     | double precision[] |           | extended |              | 
 Indexes:
@@ -431,7 +431,7 @@ CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM 
                 View "public.cqgroupby"
  Column |  Type   | Modifiers | Storage  | Description 
 --------+---------+-----------+----------+-------------
- k0     | text(0) |           | extended | 
+ k0     | text    |           | extended | 
  k1     | integer |           | plain    | 
  count  | bigint  |           | plain    | 
 View definition:
@@ -444,7 +444,7 @@ View definition:
                     Table "public.cqgroupby_mrel0"
  Column |  Type   | Modifiers | Storage  | Stats target | Description 
 --------+---------+-----------+----------+--------------+-------------
- k0     | text(0) |           | extended |              | 
+ k0     | text    |           | extended |              | 
  k1     | integer |           | plain    |              | 
  count  | bigint  |           | plain    |              | 
 Indexes:
@@ -463,7 +463,7 @@ CREATE CONTINUOUS VIEW withff WITH (fillfactor = 42) AS SELECT COUNT(*) FROM str
                  View "public.multigroupindex"
  Column |       Type       | Modifiers | Storage  | Description 
 --------+------------------+-----------+----------+-------------
- a      | text(0)          |           | extended | 
+ a      | text             |           | extended | 
  b      | bigint           |           | plain    | 
  c      | integer          |           | plain    | 
  d      | smallint         |           | plain    | 
@@ -482,7 +482,7 @@ View definition:
                      Table "public.multigroupindex_mrel0"
  Column |       Type       | Modifiers | Storage  | Stats target | Description 
 --------+------------------+-----------+----------+--------------+-------------
- a      | text(0)          |           | extended |              | 
+ a      | text             |           | extended |              | 
  b      | bigint           |           | plain    |              | 
  c      | integer          |           | plain    |              | 
  d      | smallint         |           | plain    |              | 


### PR DESCRIPTION
This rips out the `streamdesc` member of `RangeTblEntry`, which was causing problems because it's not copyable. This has the effect of cleaning a lot of things up and making better use of existing code paths.
