### PR TITLE
320 subselect

### DIFF
--- a/src/backend/pipeline/Makefile
+++ b/src/backend/pipeline/Makefile
@@ -15,6 +15,6 @@ include $(top_builddir)/src/Makefile.global
 OBJS = combinerReceiver.o cqanalyze.o cont_plan.o cqwindow.o stream.o \
 			 cqmatrel.o sw_vacuum.o tdigest.o miscutils.o bloom.o hll.o cmsketch.o \
 			 cont_analyze.o cont_scheduler.o cont_worker.o cont_combiner.o \
-			 groupcache.o tuplebuf.o
+			 groupcache.o streamReceiver.o tuplebuf.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/pipeline/combinerReceiver.c
+++ b/src/backend/pipeline/combinerReceiver.c
@@ -65,7 +65,8 @@ combiner_receive(TupleTableSlot *slot, DestReceiver *self)
 			TupleBufferSlot *tbs = lfirst(lc_slot);
 			int i;
 
-			for (i = 0; i < tbs->tuple->num_acks; i++) {
+			for (i = 0; i < tbs->tuple->num_acks; i++)
+			{
 				InsertBatchAck *ack = &tbs->tuple->acks[i];
 				bool found = false;
 

--- a/src/backend/pipeline/cont_worker.c
+++ b/src/backend/pipeline/cont_worker.c
@@ -62,6 +62,11 @@ set_reader(PlanState *planstate, TupleBufferBatchReader *reader)
 		scan->reader = reader;
 		return;
 	}
+	else if (IsA(planstate, SubqueryScanState))
+	{
+		set_reader(((SubqueryScanState *) planstate)->subplan, reader);
+		return;
+	}
 
 	set_reader(planstate->lefttree, reader);
 	set_reader(planstate->righttree, reader);

--- a/src/backend/pipeline/stream.c
+++ b/src/backend/pipeline/stream.c
@@ -27,14 +27,17 @@
 #include "parser/parse_target.h"
 #include "pgstat.h"
 #include "pipeline/stream.h"
+#include "pipeline/streamReceiver.h"
 #include "storage/shm_alloc.h"
 #include "storage/ipc.h"
+#include "tcop/pquery.h"
 #include "utils/builtins.h"
 #include "tcop/tcopprot.h"
 #include "utils/lsyscache.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
+#include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tqual.h"
 #include "utils/typcache.h"
@@ -49,6 +52,50 @@ char *stream_targets = NULL;
 
 static HTAB *prepared_stream_inserts = NULL;
 static bool *cont_queries_active = NULL;
+
+/*
+ * get_desc
+ *
+ * Build a tuple descriptor from a query's target list
+ */
+static TupleDesc
+get_desc(List *colnames, Query *q)
+{
+	ListCell *lc;
+	TupleDesc desc = CreateTemplateTupleDesc(list_length(q->targetList), false);
+	AttrNumber attno = 1;
+	AttrNumber count = 0;
+
+	foreach(lc, q->targetList)
+	{
+		TargetEntry *te = (TargetEntry *) lfirst(lc);
+		if (!te->resjunk)
+			count++;
+	}
+
+	if (!AttributeNumberIsValid(count))
+		elog(ERROR, "could not determine tuple descriptor from target list");
+
+	desc = CreateTemplateTupleDesc(count, false);
+	foreach(lc, q->targetList)
+	{
+		TargetEntry *te = (TargetEntry *) lfirst(lc);
+
+		if (te->resjunk)
+			continue;
+
+		TupleDescInitEntry(desc, attno,
+						   strVal(list_nth(colnames, attno - 1)),
+						   exprType((Node *) te->expr),
+						   -1,
+						   0);
+		TupleDescInitEntryCollation(desc,
+				attno, exprCollation((Node *) te->expr));
+		attno++;
+	}
+
+	return desc;
+}
 
 /*
  * StorePreparedStreamInsert
@@ -210,22 +257,29 @@ InsertIntoStreamPrepared(PreparedStreamInsertStmt *pstmt)
  * Send INSERT-encoded events to the given stream
  */
 int
-InsertIntoStream(InsertStmt *ins, List *values)
+InsertIntoStream(InsertStmt *ins, List *params)
 {
-	ListCell *lc;
 	int numcols = list_length(ins->cols);
 	int i;
 	int count = 0;
-	ParseState *ps = make_parsestate(NULL);
 	List *colnames = NIL;
 	TupleDesc desc = NULL;
-	ExprContext *econtext = CreateStandaloneExprContext();
 	Oid namespace = RangeVarGetCreationNamespace(ins->relation);
 	Bitmapset *targets = GetLocalStreamReaders(namespace, ins->relation->relname);
 	InsertBatchAck acks[1];
 	InsertBatch *batch = NULL;
 	int num_batches = 0;
 	Size size = 0;
+	List *queries;
+	List *plans;
+	PlannedStmt *pstmt;
+	DestReceiver *receiver;
+	Portal portal;
+	Query *query;
+	SelectStmt *stmt;
+
+	Assert(IsA(ins->selectStmt, SelectStmt));
+	stmt = ((SelectStmt *) ins->selectStmt);
 
 	/*
 	 * If it's a typed stream we can get here because technically the relation does exist.
@@ -239,7 +293,7 @@ InsertIntoStream(InsertStmt *ins, List *values)
 
 	if (synchronous_stream_insert)
 	{
-		batch = InsertBatchCreate(targets, list_length(values));
+		batch = InsertBatchCreate(targets, list_length(stmt->valuesLists));
 		num_batches = 1;
 
 		acks[0].batch_id = batch->id;
@@ -274,88 +328,54 @@ InsertIntoStream(InsertStmt *ins, List *values)
 		colnames = lappend(colnames, makeString(res->name));
 	}
 
-	desc = GetStreamTupleDesc(namespace, ins->relation->relname, colnames);
-	if (desc == NULL)
-		elog(ERROR, "could not determine descriptor for stream %s", ins->relation->relname);
+	/*
+	 * If we're doing a prepared insert on this path, then params is just an eval'd tuple of
+	 * values and the simplest thing to do is to just use it as the actual values list.
+	 * InsertIntoStreamPrepared handles more complex prepared inserts.
+	 */
+	if (params)
+		stmt->valuesLists = params;
 
-	/* append each VALUES tuple to the stream buffer */
-	foreach (lc, values)
-	{
-		List *raw = (List *) lfirst(lc);
-		List *exprlist = transformExpressionList(ps, raw, EXPR_KIND_VALUES);
-		List *exprstatelist;
-		ListCell *l;
-		Datum *values;
-		bool *nulls;
-		int col = 0;
-		int attindex = 0;
-		int evindex = 0;
-		List *filteredvals = NIL;
-		List *filteredcols = NIL;
-		StreamTuple *tuple;
+	/*
+	 * Plan and execute the query being used to generate rows (usually this will be a VALUES list)
+	 */
+	queries = pg_analyze_and_rewrite(ins->selectStmt, "INSERT", NULL, 0);
+	Assert(list_length(queries) == 1);
+	query = linitial(queries);
 
-		assign_expr_collations(NULL, (Node *) exprlist);
+	plans = pg_plan_queries(queries, 0, NULL);
+	Assert(list_length(plans) == 1);
 
-		/*
-		 * Extract all fields from the current tuple that are actually being
-		 * read by something.
-		 */
-		while (attindex < desc->natts && evindex < list_length(exprlist))
-		{
-			Value *colname = (Value *) list_nth(colnames, evindex);
-			Node *n = (Node *) list_nth(exprlist, evindex);
+	pstmt = linitial(plans);
 
-			if (pg_strcasecmp(strVal(colname), NameStr(desc->attrs[attindex]->attname)) == 0)
-			{
-				/* coerce column to common supertype */
-				Node *c = coerce_to_specific_type(NULL, n, desc->attrs[attindex]->atttypid, "VALUES");
+	receiver = CreateDestReceiver(DestStream);
+	desc = get_desc(colnames, query);
+	SetStreamDestReceiverParams(receiver, targets, desc, num_batches, acks);
 
-				filteredvals = lappend(filteredvals, c);
-				filteredcols = lappend(filteredcols, strVal(colname));
-				attindex++;
-			}
-			evindex++;
-		}
+	portal = CreatePortal("__insert__", true, true);
+	portal->visible = false;
 
-		/*
-		 * If we haven't read any fields then we need to add the last one
-		 * available because a COUNT(*) might need it (annoying). We arbitrarily
-		 * use the first value in the INSERT tuple in this case.
-		 */
-		if (!filteredvals)
-		{
-			filteredvals = lappend(filteredvals, linitial(exprlist));
-			filteredcols = lappend(filteredcols, strVal(linitial(colnames)));
-		}
+	PortalDefineQuery(portal,
+					  NULL,
+					  ins->relation->relname,
+					  "INSERT",
+					  list_make1(pstmt),
+					  NULL);
 
-		exprstatelist = (List *) ExecInitExpr((Expr *) filteredvals, NULL);
+	PortalStart(portal, NULL, 0, InvalidSnapshot);
 
-		values = palloc0(list_length(exprstatelist) * sizeof(Datum));
-		nulls = palloc0(list_length(exprstatelist) * sizeof(bool));
+	(void) PortalRun(portal,
+					 FETCH_ALL,
+					 true,
+					 receiver,
+					 receiver,
+					 NULL);
 
-		/*
-		 * Eval expressions to create a tuple of constants
-		 */
-		col = 0;
-		foreach(l, exprstatelist)
-		{
-			ExprState  *estate = (ExprState *) lfirst(l);
+	count = ((StreamReceiver *) receiver)->count;
+	size = ((StreamReceiver *) receiver)->bytes;
+	(*receiver->rDestroy) (receiver);
 
-			values[col] = ExecEvalExpr(estate, econtext, &nulls[col], NULL);
-			col++;
-		}
-
-		/*
-		 * Now write the tuple of constants to the TupleBuffer
-		 */
-		tuple = MakeStreamTuple(heap_form_tuple(desc, values, nulls), desc, num_batches, acks);
-		TupleBufferInsert(WorkerTupleBuffer, tuple, targets);
-
-		count++;
-		size += tuple->heaptup->t_len + HEAPTUPLESIZE;
-	}
-
-	FreeExprContext(econtext, false);
+	PortalDrop(portal, false);
 
 	stream_stat_report(namespace, ins->relation->relname, count, 1, size);
 

--- a/src/backend/pipeline/streamReceiver.c
+++ b/src/backend/pipeline/streamReceiver.c
@@ -1,0 +1,76 @@
+/*-------------------------------------------------------------------------
+ *
+ * streamReceiver.c
+ *	  An implementation of DestReceiver that that allows sends output
+ *	  tuples to a tuple buffer
+ *
+ * IDENTIFICATION
+ *	  src/backend/pipeline/streamReceiver.c
+ */
+#include "pipeline/stream.h"
+#include "pipeline/streamReceiver.h"
+#include "pipeline/tuplebuf.h"
+
+static void
+stream_shutdown(DestReceiver *self)
+{
+
+}
+
+static void
+stream_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
+{
+
+}
+
+static void
+stream_receive(TupleTableSlot *slot, DestReceiver *self)
+{
+	StreamReceiver *stream = (StreamReceiver *) self;
+	MemoryContext old = MemoryContextSwitchTo(stream->context);
+	HeapTuple tup = ExecMaterializeSlot(slot);
+	StreamTuple *tuple = MakeStreamTuple(tup, stream->desc, stream->nbatches, stream->acks);
+
+	if (TupleBufferInsert(WorkerTupleBuffer, tuple, stream->targets))
+	{
+		stream->count++;
+		stream->bytes += tuple->heaptup->t_len + HEAPTUPLESIZE;
+	}
+
+	MemoryContextSwitchTo(old);
+}
+
+static void
+stream_destroy(DestReceiver *self)
+{
+	StreamReceiver *stream = (StreamReceiver *) self;
+	pfree(stream);
+}
+
+DestReceiver *
+CreateStreamDestReceiver(void)
+{
+	StreamReceiver *self = (StreamReceiver *) palloc0(sizeof(StreamReceiver));
+
+	self->pub.receiveSlot = stream_receive; /* might get changed later */
+	self->pub.rStartup = stream_startup;
+	self->pub.rShutdown = stream_shutdown;
+	self->pub.rDestroy = stream_destroy;
+	self->pub.mydest = DestCombiner;
+	self->count = 0;
+
+	return (DestReceiver *) self;
+}
+
+void
+SetStreamDestReceiverParams(DestReceiver *self, Bitmapset *targets, TupleDesc desc,
+		int nbatches, InsertBatchAck *acks)
+{
+	StreamReceiver *stream = (StreamReceiver *) self;
+
+	stream->desc = desc;
+	stream->targets = targets;
+	stream->nbatches = nbatches;
+	stream->acks = acks;
+	stream->context = CurrentMemoryContext;
+}

--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -39,6 +39,7 @@
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
 #include "pipeline/combinerReceiver.h"
+#include "pipeline/streamReceiver.h"
 #include "utils/portal.h"
 
 
@@ -137,6 +138,9 @@ CreateDestReceiver(CommandDest dest)
 
 		case DestCombiner:
 			return CreateCombinerDestReceiver();
+
+		case DestStream:
+			return CreateStreamDestReceiver();
 	}
 
 	/* should never get here */
@@ -172,6 +176,7 @@ EndCommand(const char *commandTag, CommandDest dest)
 		case DestTupleTable:
 		case DestTransientRel:
 		case DestCombiner:
+		case DestStream:
 			break;
 	}
 }
@@ -216,6 +221,7 @@ NullCommand(CommandDest dest)
 		case DestTupleTable:
 		case DestTransientRel:
 		case DestCombiner:
+		case DestStream:
 			break;
 	}
 }
@@ -262,6 +268,7 @@ ReadyForQuery(CommandDest dest)
 		case DestTupleTable:
 		case DestTransientRel:
 		case DestCombiner:
+		case DestStream:
 			break;
 	}
 }

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -850,7 +850,7 @@ pg_plan_queries(List *querytrees, int cursorOptions, ParamListInfo boundParams)
 }
 
 void
-exec_stream_inserts(InsertStmt *ins, PreparedStreamInsertStmt *pstmt, List *values)
+exec_stream_inserts(InsertStmt *ins, PreparedStreamInsertStmt *pstmt, List *params)
 {
 	CommandDest dest = whereToSendOutput;
 	MemoryContext oldcontext;
@@ -868,9 +868,7 @@ exec_stream_inserts(InsertStmt *ins, PreparedStreamInsertStmt *pstmt, List *valu
 	}
 	else
 	{
-		List *vals = values ? values : ((SelectStmt *) ins->selectStmt)->valuesLists;
-
-		count = InsertIntoStream(ins, vals);
+		count = InsertIntoStream(ins, params);
 	}
 	PopActiveSnapshot();
 

--- a/src/include/pipeline/combinerReceiver.h
+++ b/src/include/pipeline/combinerReceiver.h
@@ -1,14 +1,13 @@
 /*-------------------------------------------------------------------------
  *
- * combinerReceiver.c
+ * combinerReceiver.h
  *	  An implementation of DestReceiver that that allows combiners to receive
  *	  tuples from worker processes.
  *
  * IDENTIFICATION
- *	  src/backend/pipeline/combinerReceiver.c
+ *	  src/include/pipeline/combinerReceiver.h
  *
  */
-
 #ifndef COMBINER_RECEIVER_H
 #define COMBINER_RECEIVER_H
 

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -30,7 +30,7 @@ extern bool collect_rels_and_streams(Node *node, ContAnalyzeContext *context);
 extern bool collect_types_and_cols(Node *node, ContAnalyzeContext *context);
 
 extern ContAnalyzeContext *MakeContAnalyzeContext(ParseState *pstate, SelectStmt *select);
-extern void ValidateContQuery(CreateContViewStmt *stmt, const char *sql);
+extern void ValidateContQuery(RangeVar *name, Node *node, const char *sql);
 
 extern void transformContSelectStmt(ParseState *pstate, SelectStmt *select);
 extern TupleDesc parserGetStreamDescr(ParseState *pstate, RangeVar *rv, RangeTblEntry *rte);

--- a/src/include/pipeline/cqanalyze.h
+++ b/src/include/pipeline/cqanalyze.h
@@ -67,4 +67,6 @@ Query *RewriteContinuousViewSelect(Query *query, Query *rule, Relation cv, int r
 bool CollectUserCombines(Node *node, CQAnalyzeContext *context);
 bool SelectsFromStreamOnly(SelectStmt *stmt);
 
+bool MakeSelectsContinuous(Node *node, CQAnalyzeContext *context);
+
 #endif

--- a/src/include/pipeline/stream.h
+++ b/src/include/pipeline/stream.h
@@ -51,7 +51,7 @@ extern void AddPreparedStreamInsert(PreparedStreamInsertStmt *stmt, ParamListInf
 extern PreparedStreamInsertStmt *FetchPreparedStreamInsert(const char *name);
 extern void DropPreparedStreamInsert(const char *name);
 extern int InsertIntoStreamPrepared(PreparedStreamInsertStmt *pstmt);
-extern int InsertIntoStream(InsertStmt *ins, List *values);
+extern int InsertIntoStream(InsertStmt *ins, List *params);
 extern uint64 CopyIntoStream(Relation stream, TupleDesc desc, HeapTuple *tuples, int ntuples);
 
 /* Represents a single batch of inserts made into a stream. */

--- a/src/include/pipeline/streamReceiver.h
+++ b/src/include/pipeline/streamReceiver.h
@@ -1,0 +1,35 @@
+/*-------------------------------------------------------------------------
+ *
+ * streamReceiver.h
+ *	  An implementation of DestReceiver that that allows sends output
+ *	  tuples to a tuple buffer
+ *
+ * IDENTIFICATION
+ *	  src/include/pipeline/streamReceiver.h
+ *
+ */
+
+#ifndef STREAM_RECEIVER_H
+#define STREAM_RECEIVER_H
+
+#include "postgres.h"
+
+#include "tcop/dest.h"
+
+typedef struct StreamReceiver
+{
+	DestReceiver pub;
+	InsertBatchAck *acks;
+	int nbatches;
+	Bitmapset *targets;
+	long count;
+	TupleDesc desc;
+	MemoryContext context;
+	Size bytes;
+} StreamReceiver;
+
+extern DestReceiver *CreateStreamDestReceiver(void);
+extern void SetStreamDestReceiverParams(DestReceiver *self, Bitmapset *targets,
+		TupleDesc desc, int nbatches, InsertBatchAck *acks);
+
+#endif

--- a/src/include/tcop/dest.h
+++ b/src/include/tcop/dest.h
@@ -97,6 +97,7 @@ typedef enum
 	DestTupleTable,					/* results sent to a TupleHashTable */
 	DestTransientRel,			/* results sent to transient relation */
 	DestCombiner,	/* results are sent to a CQ combiner process */
+	DestStream, /* results are sent to a stream */
 } CommandDest;
 
 /* ----------------

--- a/src/test/py/test_pipeline_stats.py
+++ b/src/test/py/test_pipeline_stats.py
@@ -65,7 +65,7 @@ def test_stream_stats(pipeline, clean_db):
 
   assert result['input_rows'] == 1
   assert result['input_batches'] == 1
-  assert result['input_bytes'] == 48
+  assert result['input_bytes'] == 52
 
   pipeline.insert('test_stream_stats_stream', ('x', ), [(1, )] * 100)
   time.sleep(0.5)
@@ -73,4 +73,4 @@ def test_stream_stats(pipeline, clean_db):
   result = pipeline.execute("SELECT * FROM pipeline_stream_stats WHERE name='test_stream_stats_stream'").first()
   assert result['input_rows'] == 101
   assert result['input_batches'] == 2
-  assert result['input_bytes'] == 4848
+  assert result['input_bytes'] == 5252

--- a/src/test/regress/expected/cont_subselect.out
+++ b/src/test/regress/expected/cont_subselect.out
@@ -1,0 +1,185 @@
+CREATE SCHEMA test_cont_subselect;
+SET search_path TO test_cont_subselect,public;
+-- Disallowed subselects
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM (SELECT COUNT(*) FROM stream) _;
+ERROR:  subqueries in continuous views cannot contain aggregates
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT COUNT(*) OVER (PARTITION BY key::text) FROM stream) _;
+ERROR:  subqueries in continuous views cannot contain window functions
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT x::integer, y::integer FROM stream GROUP BY x, y) _;
+ERROR:  subqueries in continuous views cannot contain GROUP BY clauses
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT COUNT(*) FROM stream HAVING COUNT(*) = 1) _;
+ERROR:  subqueries in continuous views cannot contain aggregates
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT x::integer FROM stream ORDER BY x) _;
+ERROR:  subqueries in continuous views cannot contain ORDER BY clauses
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT DISTINCT x::integer FROM stream) _;
+ERROR:  subqueries in continuous views cannot contain DISTINCT clauses
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT x::integer FROM stream LIMIT 10 OFFSET 2) _;
+ERROR:  subqueries in continuous views cannot contain LIMIT clauses
+-- Simple stuff
+CREATE CONTINUOUS VIEW v0 AS SELECT COUNT(*) FROM
+	(SELECT x::integer FROM stream WHERE x < 0) _;
+INSERT INTO stream (x) (SELECT generate_series(-100, 999));
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM v0;
+ count 
+-------
+   100
+(1 row)
+
+CREATE CONTINUOUS VIEW v1 AS SELECT x, sum(y) FROM
+	(SELECT x::integer, y::integer FROM stream) _ GROUP by x;
+INSERT INTO stream (x, y) (SELECT x % 10, -x AS y FROM generate_series(1, 1000) AS x);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM v1 ORDER BY x;
+ x |  sum   
+---+--------
+ 0 | -50500
+ 1 | -49600
+ 2 | -49700
+ 3 | -49800
+ 4 | -49900
+ 5 | -50000
+ 6 | -50100
+ 7 | -50200
+ 8 | -50300
+ 9 | -50400
+(10 rows)
+
+-- JSON unrolling
+CREATE CONTINUOUS VIEW v2 AS SELECT (element->>'k')::integer AS value FROM
+	(SELECT json_array_elements(data::json) AS element FROM stream) _;
+INSERT INTO stream (data) (SELECT '[{"k": 1}, {"k": 1}, {"k": 1}]'::json FROM generate_series(1, 1000));
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT sum(value) FROM v2;
+ sum  
+------
+ 3000
+(1 row)
+
+-- Column renames between subquery levels
+CREATE CONTINUOUS VIEW v3 AS SELECT a0, c0, b0 FROM
+	(SELECT b1 AS b0, a1 AS a0, c1 AS c0 FROM
+		(SELECT c2 AS c1, b2 AS b1, a2 AS a1 FROM 
+			(SELECT a2::text, b2::text, c2::text FROM stream) s0) s1) s2;
+INSERT INTO stream (a2, b2, c2) (SELECT x AS a2, x AS b2, x AS c2 FROM generate_series(1, 1000) AS x);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT COUNT(DISTINCT(a0, b0, c0)) FROM v3;
+ count 
+-------
+  1000
+(1 row)
+
+-- References to function calls in inner query
+CREATE CONTINUOUS VIEW v4 AS SELECT day, upper FROM
+	(SELECT day(arrival_timestamp), upper(s::text) FROM stream) _;
+INSERT INTO stream (s) (SELECT s::text FROM generate_series(1, 1000) AS s);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT COUNT(DISTINCT(day, upper)) FROM v4;
+ count 
+-------
+  1000
+(1 row)
+
+-- Deep nesting
+CREATE CONTINUOUS VIEW v5 AS SELECT x, COUNT(*) FROM
+	(SELECT x FROM
+		(SELECT x FROM
+			(SELECT x FROM
+				(SELECT x FROM
+					(SELECT x FROM
+						(SELECT x FROM
+							(SELECT x FROM
+								(SELECT x FROM
+									(SELECT x FROM
+										(SELECT x::integer FROM stream) s0) s1) s2) s3) s4) s5) s6) s7) s8) s9
+	GROUP BY x;
+INSERT INTO stream (x) (SELECT x % 10 FROM generate_series(1, 1000) AS x);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM v5 ORDER BY x;
+ x | count 
+---+-------
+ 0 |   100
+ 1 |   100
+ 2 |   100
+ 3 |   100
+ 4 |   100
+ 5 |   100
+ 6 |   100
+ 7 |   100
+ 8 |   100
+ 9 |   100
+(10 rows)
+
+DROP SCHEMA test_cont_subselect CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to view v0
+drop cascades to view v1
+drop cascades to view v2
+drop cascades to view v3
+drop cascades to view v4
+drop cascades to view v5
+-- Stream-table joins in subselects
+CREATE TABLE test_cont_sub_t0 (x integer, y integer);
+INSERT INTO test_cont_sub_t0 (x, y) VALUES (0, 0);
+INSERT INTO test_cont_sub_t0 (x, y) VALUES (1, 1);
+INSERT INTO test_cont_sub_t0 (x, y) VALUES (2, 2);
+CREATE STREAM test_cont_sub_s0 (x integer, y integer);
+CREATE CONTINUOUS VIEW test_cont_sub_v6 AS SELECT COUNT(*) FROM
+	(SELECT s0.x, s0.y, t0.y FROM test_cont_sub_s0 s0 JOIN test_cont_sub_t0 t0 ON s0.x = t0.x) _;
+NOTICE:  consider creating an index on t0.x for improved stream-table join performance
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (0, 0);
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (0, 0);
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (1, 1);
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (1, 1);
+INSERT INTO test_cont_sub_s0 (x, y) (SELECT x, x AS y FROM generate_series(1, 100) AS x);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM test_cont_sub_v6;
+ count 
+-------
+     6
+(1 row)
+
+DROP CONTINUOUS VIEW test_cont_sub_v6;
+DROP TABLE test_cont_sub_t0;
+DROP STREAM test_cont_sub_s0;

--- a/src/test/regress/expected/stream_insert_subselect.out
+++ b/src/test/regress/expected/stream_insert_subselect.out
@@ -1,0 +1,108 @@
+CREATE SCHEMA test_stream_insert_subselect;
+SET search_path TO test_stream_insert_subselect,public;
+CREATE TABLE t (x integer);
+INSERT INTO t (SELECT generate_series(1, 100));
+CREATE CONTINUOUS VIEW v0 AS SELECT x::integer FROM stream;
+INSERT INTO stream (x) (SELECT * FROM t);
+INSERT INTO stream (x) (SELECT * FROM (SELECT x AS y FROM t) s0);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT COUNT(DISTINCT x) FROM v0;
+ count 
+-------
+   100
+(1 row)
+
+CREATE CONTINUOUS VIEW v1 AS SELECT x::integer, COUNT(*) FROM stream GROUP BY x;
+INSERT INTO stream (x) (SELECT generate_series(1, 1000));
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT COUNT(DISTINCT x) FROM v1;
+ count 
+-------
+  1000
+(1 row)
+
+-- It's not possible to SELECT from another stream in a stream INSERT
+CREATE STREAM s0 (x integer);
+INSERT INTO stream (x) (SELECT x FROM s0);
+ERROR:  "s0" is a stream
+HINT:  Streams can only be read by a continuous view's FROM clause.
+CREATE CONTINUOUS VIEW v2 AS SELECT x::integer FROM stream;
+INSERT INTO stream (x) (SELECT generate_series(1, 1000) AS x ORDER BY random());
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT COUNT(DISTINCT x) FROM v2;
+ count 
+-------
+  1000
+(1 row)
+
+CREATE CONTINUOUS VIEW v3 AS SELECT x::integer FROM stream;
+INSERT INTO stream (x) (SELECT * FROM t WHERE x IN (SELECT generate_series(1, 20)));
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM v3 ORDER BY x;
+ x  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(20 rows)
+
+CREATE CONTINUOUS VIEW v4 AS SELECT COUNT(*) FROM stream;
+INSERT INTO stream (price, t) SELECT 10 + random() AS price, current_timestamp - interval '1 minute' * random() AS t FROM generate_series(1, 1000);
+SELECT pg_sleep(0.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM v4;
+ count 
+-------
+  1000
+(1 row)
+
+DROP SCHEMA test_stream_insert_subselect CASCADE;
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to table t
+drop cascades to view v0
+drop cascades to view v1
+drop cascades to type s0
+drop cascades to view v2
+drop cascades to view v3
+drop cascades to view v4

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -148,12 +148,12 @@ test: cont_hs_agg cont_sw_hs_agg cont_distinct cont_hll_agg cont_os_agg cont_sw_
 # ----------
 # Another group of parallel tests
 # ----------
-test: stream_table_join user_combine cont_limit cont_alter stream_targets hash_group
+test: stream_table_join user_combine cont_limit cont_alter stream_targets hash_group stream_insert_subselect
 
 # ----------
 # Another group of parallel tests
 # ----------
-test: stream_exprs schema_inference prepared_stream_insert cont_view_namespace cont_view_tablespace typed_streams
+test: stream_exprs schema_inference prepared_stream_insert cont_view_namespace cont_view_tablespace typed_streams cont_subselect
 
 # These are run in serial because they each activate many CVs.
 # If they are run in parallel the CPU can potentially get starved.

--- a/src/test/regress/sql/cont_subselect.sql
+++ b/src/test/regress/sql/cont_subselect.sql
@@ -1,0 +1,107 @@
+CREATE SCHEMA test_cont_subselect;
+SET search_path TO test_cont_subselect,public;
+
+-- Disallowed subselects
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM (SELECT COUNT(*) FROM stream) _;
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT COUNT(*) OVER (PARTITION BY key::text) FROM stream) _;
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT x::integer, y::integer FROM stream GROUP BY x, y) _;
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT COUNT(*) FROM stream HAVING COUNT(*) = 1) _;
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT x::integer FROM stream ORDER BY x) _;
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT DISTINCT x::integer FROM stream) _;
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x FROM
+	(SELECT x::integer FROM stream LIMIT 10 OFFSET 2) _;
+
+-- Simple stuff
+CREATE CONTINUOUS VIEW v0 AS SELECT COUNT(*) FROM
+	(SELECT x::integer FROM stream WHERE x < 0) _;
+INSERT INTO stream (x) (SELECT generate_series(-100, 999));
+
+SELECT pg_sleep(0.2);
+SELECT * FROM v0;
+
+CREATE CONTINUOUS VIEW v1 AS SELECT x, sum(y) FROM
+	(SELECT x::integer, y::integer FROM stream) _ GROUP by x;
+INSERT INTO stream (x, y) (SELECT x % 10, -x AS y FROM generate_series(1, 1000) AS x);
+
+SELECT pg_sleep(0.2);
+SELECT * FROM v1 ORDER BY x;
+
+-- JSON unrolling
+CREATE CONTINUOUS VIEW v2 AS SELECT (element->>'k')::integer AS value FROM
+	(SELECT json_array_elements(data::json) AS element FROM stream) _;
+INSERT INTO stream (data) (SELECT '[{"k": 1}, {"k": 1}, {"k": 1}]'::json FROM generate_series(1, 1000));
+
+SELECT pg_sleep(0.2);
+SELECT sum(value) FROM v2;
+
+-- Column renames between subquery levels
+CREATE CONTINUOUS VIEW v3 AS SELECT a0, c0, b0 FROM
+	(SELECT b1 AS b0, a1 AS a0, c1 AS c0 FROM
+		(SELECT c2 AS c1, b2 AS b1, a2 AS a1 FROM 
+			(SELECT a2::text, b2::text, c2::text FROM stream) s0) s1) s2;
+INSERT INTO stream (a2, b2, c2) (SELECT x AS a2, x AS b2, x AS c2 FROM generate_series(1, 1000) AS x);
+
+SELECT pg_sleep(0.2);
+SELECT COUNT(DISTINCT(a0, b0, c0)) FROM v3;
+
+-- References to function calls in inner query
+CREATE CONTINUOUS VIEW v4 AS SELECT day, upper FROM
+	(SELECT day(arrival_timestamp), upper(s::text) FROM stream) _;
+INSERT INTO stream (s) (SELECT s::text FROM generate_series(1, 1000) AS s);
+
+SELECT pg_sleep(0.2);
+SELECT COUNT(DISTINCT(day, upper)) FROM v4;
+
+-- Deep nesting
+CREATE CONTINUOUS VIEW v5 AS SELECT x, COUNT(*) FROM
+	(SELECT x FROM
+		(SELECT x FROM
+			(SELECT x FROM
+				(SELECT x FROM
+					(SELECT x FROM
+						(SELECT x FROM
+							(SELECT x FROM
+								(SELECT x FROM
+									(SELECT x FROM
+										(SELECT x::integer FROM stream) s0) s1) s2) s3) s4) s5) s6) s7) s8) s9
+	GROUP BY x;
+INSERT INTO stream (x) (SELECT x % 10 FROM generate_series(1, 1000) AS x);
+
+SELECT pg_sleep(0.2);
+SELECT * FROM v5 ORDER BY x;
+
+DROP SCHEMA test_cont_subselect CASCADE;
+
+-- Stream-table joins in subselects
+CREATE TABLE test_cont_sub_t0 (x integer, y integer);
+INSERT INTO test_cont_sub_t0 (x, y) VALUES (0, 0);
+INSERT INTO test_cont_sub_t0 (x, y) VALUES (1, 1);
+INSERT INTO test_cont_sub_t0 (x, y) VALUES (2, 2);
+
+CREATE STREAM test_cont_sub_s0 (x integer, y integer);
+CREATE CONTINUOUS VIEW test_cont_sub_v6 AS SELECT COUNT(*) FROM
+	(SELECT s0.x, s0.y, t0.y FROM test_cont_sub_s0 s0 JOIN test_cont_sub_t0 t0 ON s0.x = t0.x) _;
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (0, 0);
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (0, 0);
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (1, 1);
+INSERT INTO test_cont_sub_s0 (x, y) VALUES (1, 1);
+INSERT INTO test_cont_sub_s0 (x, y) (SELECT x, x AS y FROM generate_series(1, 100) AS x);
+
+SELECT pg_sleep(0.2);
+SELECT * FROM test_cont_sub_v6;
+
+DROP CONTINUOUS VIEW test_cont_sub_v6;
+DROP TABLE test_cont_sub_t0;
+DROP STREAM test_cont_sub_s0;
+

--- a/src/test/regress/sql/stream_insert_subselect.sql
+++ b/src/test/regress/sql/stream_insert_subselect.sql
@@ -1,0 +1,43 @@
+CREATE SCHEMA test_stream_insert_subselect;
+SET search_path TO test_stream_insert_subselect,public;
+
+CREATE TABLE t (x integer);
+INSERT INTO t (SELECT generate_series(1, 100));
+
+CREATE CONTINUOUS VIEW v0 AS SELECT x::integer FROM stream;
+
+INSERT INTO stream (x) (SELECT * FROM t);
+INSERT INTO stream (x) (SELECT * FROM (SELECT x AS y FROM t) s0);
+
+SELECT pg_sleep(0.2);
+SELECT COUNT(DISTINCT x) FROM v0;
+
+CREATE CONTINUOUS VIEW v1 AS SELECT x::integer, COUNT(*) FROM stream GROUP BY x;
+INSERT INTO stream (x) (SELECT generate_series(1, 1000));
+
+SELECT pg_sleep(0.2);
+SELECT COUNT(DISTINCT x) FROM v1;
+
+-- It's not possible to SELECT from another stream in a stream INSERT
+CREATE STREAM s0 (x integer);
+INSERT INTO stream (x) (SELECT x FROM s0);
+
+CREATE CONTINUOUS VIEW v2 AS SELECT x::integer FROM stream;
+INSERT INTO stream (x) (SELECT generate_series(1, 1000) AS x ORDER BY random());
+
+SELECT pg_sleep(0.2);
+SELECT COUNT(DISTINCT x) FROM v2;
+
+CREATE CONTINUOUS VIEW v3 AS SELECT x::integer FROM stream;
+INSERT INTO stream (x) (SELECT * FROM t WHERE x IN (SELECT generate_series(1, 20)));
+
+SELECT pg_sleep(0.2);
+SELECT * FROM v3 ORDER BY x;
+
+CREATE CONTINUOUS VIEW v4 AS SELECT COUNT(*) FROM stream;
+INSERT INTO stream (price, t) SELECT 10 + random() AS price, current_timestamp - interval '1 minute' * random() AS t FROM generate_series(1, 1000);
+
+SELECT pg_sleep(0.2);
+SELECT * FROM v4;
+
+DROP SCHEMA test_stream_insert_subselect CASCADE;


### PR DESCRIPTION
This adds support for subselects in both continuous views as well as stream insertions. So now we can do things like:

```
CREATE CONTINUOUS VIEW v AS SELECT x FROM (SELECT x::integer FROM stream WHERE x > 10);
CREATE CONTINUOUS VIEW unroll AS SELECT element->>'k' AS value FROM
    (SELECT json_array_elements(data::json) AS element FROM stream) _;
INSERT INTO stream (x) (SELECT * from some_table);
INSERT INTO stream (x) (SELECT x FROM generate_series(1, 100000) AS x);
```

This is especially powerful for testing, as we can now quite easily insert large numbers of events in sql tests.

Surprisingly, using the planner with an actual `Query` to perform stream inserts actually gives us a definite performance boost. I'm guessing we were previously doing more evals and coercions. Here are some numbers on `-O0`:

**master**:
- 100k-groups-by-second: 10000000 events emitted in 229.705 s (43.5k eps)
- 100k-groups-by-minute: 10000000 events emitted in 82.896 s (120.6k eps)
- 100k-groups (batchsize=10000 concurrency=1 count=10M): 10000000 events emitted in 172.482 s (57.9k eps)

**this branch**
- 100k-groups-by-second: 10000000 events emitted in 187.836 s (53.2k eps) **+22%**
- 100k-groups-by-minute: 10000000 events emitted in 44.837 s (223.0k eps) **+86%**
- 100k-groups (batchsize=10000 concurrency=1 count=10M): 10000000 events emitted in 142.953 s (69.9k eps) **+17%**

You can see that we got a pretty big boost with the `100k-groups-by-minute` workload. I'm guessing it's because of the low cardinality grouping used in that workload, the `INSERT` path is actually a bottleneck. Anyways, pretty sweet!
