### PR TITLE
Probably a non-issue but it remove a warning :)

### DIFF
--- a/src/backend/pipeline/cqwindow.c
+++ b/src/backend/pipeline/cqwindow.c
@@ -410,7 +410,7 @@ create_group_by_for_time_bucket_field(SelectStmt *workerstmt, SelectStmt *viewst
 		Node *timeNode, bool doesViewAggregate, CQAnalyzeContext *context, AttrNumber *timeAttr)
 {
 	Node *timeCRefWithTC;
-	ResTarget *timeRes;
+	ResTarget *timeRes = NULL;
 
 	context->cols = NIL;
 	FindColumnRefsWithTypeCasts(timeNode, context);
@@ -559,6 +559,7 @@ create_group_by_for_time_bucket_field(SelectStmt *workerstmt, SelectStmt *viewst
 		memcpy(timeCRefWithTC, CreateColumnRefFromResTarget(res), sizeof(ColumnRef));
 	}
 
+	Assert(timeRes != NULL);
 	return timeRes;
 }
 


### PR DESCRIPTION
cqwindow.c:562:2: warning: ‘timeRes’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  return timeRes;
  ^
cqwindow.c:562:2: warning: Undefined or garbage value returned to caller
        return timeRes;
        ^~~~~~~~~~~~~~

If none of the branch are taken then timeRes contain garbage value (non initialized).
I propose to initialize it to NULL and add an Assert, just to be sure :)