### PR TITLE
Custom data types improvements and bug fixes

### DIFF
--- a/src/backend/pipeline/bloom.c
+++ b/src/backend/pipeline/bloom.c
@@ -43,6 +43,8 @@ BloomFilterCreateWithMAndK(uint32_t m, uint16_t k)
 	bf->k = k;
 	bf->blen = blen;
 
+	SET_VARSIZE(bf, BloomFilterSize(bf));
+
 	return bf;
 }
 

--- a/src/backend/pipeline/cmsketch.c
+++ b/src/backend/pipeline/cmsketch.c
@@ -30,6 +30,9 @@ CountMinSketchCreateWithDAndW(uint32_t d, uint32_t w)
 	CountMinSketch *cms = palloc0(sizeof(CountMinSketch) + (sizeof(uint32_t) * d * w));
 	cms->d = d;
 	cms->w = w;
+
+	SET_VARSIZE(cms, CountMinSketchSize(cms));
+
 	return cms;
 }
 

--- a/src/backend/utils/adt/orderedsetaggs.c
+++ b/src/backend/utils/adt/orderedsetaggs.c
@@ -1797,7 +1797,7 @@ cqosastatesend(PG_FUNCTION_ARGS)
 	TDigestCompress(t);
 
 	nbytes = (sizeof(CQOSAAggState) + sizeof(float8) * state->num_percentiles + sizeof(bool) * state->num_percentiles +
-			sizeof(TDigest) + sizeof(Centroid) * t->num_centroids);
+			TDigestSize(t));
 
 	result = (bytea *) palloc0(nbytes + VARHDRSZ);
 	SET_VARSIZE(result, nbytes + VARHDRSZ);
@@ -1811,9 +1811,7 @@ cqosastatesend(PG_FUNCTION_ARGS)
 	memcpy(pos, state->nulls, sizeof(bool) * state->num_percentiles);
 	pos += sizeof(bool) * state->num_percentiles;
 
-	memcpy(pos, t, sizeof(TDigest));
-	pos += sizeof(TDigest);
-	memcpy(pos, t->centroids, sizeof(Centroid) * t->num_centroids);
+	memcpy(pos, t, TDigestSize(t));
 
 	PG_RETURN_BYTEA_P(result);
 }
@@ -1827,25 +1825,21 @@ cqosastaterecv(PG_FUNCTION_ARGS)
 	bytea *bytes = (bytea *) PG_GETARG_BYTEA_P(0);
 	char *pos = VARDATA(bytes);
 	CQOSAAggState *state = palloc(sizeof(CQOSAAggState));
-	TDigest *t = palloc(sizeof(TDigest));
+	TDigest *t;
 
 	memcpy(state, pos, sizeof(CQOSAAggState));
 	pos += sizeof(CQOSAAggState);
 
-	state->percentiles = palloc0(sizeof(float8) * state->num_percentiles);
+	state->percentiles = palloc(sizeof(float8) * state->num_percentiles);
 	memcpy(state->percentiles, pos, sizeof(float8) * state->num_percentiles);
 	pos += sizeof(float8) * state->num_percentiles;
-	state->nulls = palloc0(sizeof(bool) * state->num_percentiles);
+	state->nulls = palloc(sizeof(bool) * state->num_percentiles);
 	memcpy(state->nulls, pos, sizeof(bool) * state->num_percentiles);
 	pos += sizeof(bool) * state->num_percentiles;
 
-	state->tdigest = t;
-	memcpy(t, pos, sizeof(TDigest));
-
-	pos += sizeof(TDigest);
-	t->centroids = palloc0(sizeof(Centroid) * t->size);
-	memcpy(t->centroids, pos, sizeof(Centroid) * t->num_centroids);
-
+	t = (TDigest *) pos;
+	state->tdigest = palloc(TDigestSize(t));
+	memcpy(state->tdigest, t, TDigestSize(t));
 
 	PG_RETURN_POINTER(state);
 }

--- a/src/include/catalog/pg_aggregate.h
+++ b/src/include/catalog/pg_aggregate.h
@@ -333,9 +333,9 @@ DATA(insert ( 4333	n 0 bloom_union_agg_trans	-	-				-				-				f f 0	5030	0	0		0	
 DATA(insert ( 4335	n 0 bloom_intersection_agg_trans	-	-		-				-				f f 0	5030	0	0		0	_null_ _null_ ));
 
 /* t-digest aggregates */
-DATA(insert ( 4339	n 0 tdigest_agg_trans		tdigest_send	-				-				-				f f 0	5034	0	0		0	_null_ _null_ ));
-DATA(insert ( 4340	n 0 tdigest_agg_transp		tdigest_send	-				-				-				f f 0	5034	0	0		0	_null_ _null_ ));
-DATA(insert ( 4343	n 0 tdigest_merge_agg_trans	tdigest_send	-				-				-				f f 0	5034	0	0		0	_null_ _null_ ));
+DATA(insert ( 4339	n 0 tdigest_agg_trans		tdigest_compress	-				-				-				f f 0	5034	0	0		0	_null_ _null_ ));
+DATA(insert ( 4340	n 0 tdigest_agg_transp		tdigest_compress	-				-				-				f f 0	5034	0	0		0	_null_ _null_ ));
+DATA(insert ( 4343	n 0 tdigest_merge_agg_trans	tdigest_compress	-				-				-				f f 0	5034	0	0		0	_null_ _null_ ));
 
 /* count-min sketch aggregates */
 DATA(insert ( 4348	n 0 cmsketch_agg_trans			-	-				-				-				f f 0	5038	0	0		0	_null_ _null_ ));

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5088,25 +5088,17 @@ DESCR("aggregate combination function");
 DATA(insert OID = 5027 ( cq_percentile_cont_float8_final	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 701 "2281 701" _null_ _null_ _null_ _null_ cq_percentile_cont_float8_final _null_ _null_ _null_ ));
 DESCR("aggregate final function");
 
-DATA(insert OID = 5028 (hll_out PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2275 "3998" _null_ _null_ _null_ _null_ hll_out _null_ _null_ _null_ ));
-DESCR("hyperloglog out function");
-DATA(insert OID = 5029 (hll_in  PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 3998 "2275" _null_ _null_ _null_ _null_ hll_in  _null_ _null_ _null_ ));
-DESCR("hyperloglog in function");
+DATA(insert OID = 5028 (hll_print PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 25 "3998" _null_ _null_ _null_ _null_ hll_print _null_ _null_ _null_ ));
+DESCR("hyperloglog print function");
 
-DATA(insert OID = 5032 (bloom_out PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2275 "5030" _null_ _null_ _null_ _null_ bloom_out _null_ _null_ _null_ ));
-DESCR("bloom filter out function");
-DATA(insert OID = 5033 (bloom_in  PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 5030 "2275" _null_ _null_ _null_ _null_ bloom_in  _null_ _null_ _null_ ));
-DESCR("bloom filter in function");
+DATA(insert OID = 5032 (bloom_print PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 25 "5030" _null_ _null_ _null_ _null_ bloom_print _null_ _null_ _null_ ));
+DESCR("bloom filter print function");
 
-DATA(insert OID = 5036 (tdigest_out PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2275 "5034" _null_ _null_ _null_ _null_ tdigest_out _null_ _null_ _null_ ));
-DESCR("t-digest out function");
-DATA(insert OID = 5037 (tdigest_in  PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 5034 "2275" _null_ _null_ _null_ _null_ tdigest_in  _null_ _null_ _null_ ));
-DESCR("t-digest in function");
+DATA(insert OID = 5036 (tdigest_print PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 25 "5034" _null_ _null_ _null_ _null_ tdigest_print _null_ _null_ _null_ ));
+DESCR("t-digest print function");
 
-DATA(insert OID = 5040 (cmsketch_out PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 2275 "5038" _null_ _null_ _null_ _null_ cmsketch_out _null_ _null_ _null_ ));
-DESCR("count-min sketch out function");
-DATA(insert OID = 5041 (cmsketch_in  PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 5038 "2275" _null_ _null_ _null_ _null_ cmsketch_in  _null_ _null_ _null_ ));
-DESCR("count-min sketch in function");
+DATA(insert OID = 5040 (cmsketch_print PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 25 "5038" _null_ _null_ _null_ _null_ cmsketch_print _null_ _null_ _null_ ));
+DESCR("count-min sketch print function");
 
 /* PipelineDB combiner stuff, heavily inspired by Postgres-XC coordinator aggregation */
 DATA(insert OID = 4301 ( float8_combine	PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 1022 "1022 1022" _null_ _null_ _null_ _null_ float8_combine _null_ _null_ _null_ ));
@@ -5190,7 +5182,7 @@ DATA(insert OID = 4329 ( bloom_agg	PGNSP PGUID 12 1 0 0 0 t f f f f f i 1 0 5030
 DESCR("bloom filter aggregate");
 
 /* bloom filter aggregate with user-supplied p and n */
-DATA(insert OID = 4330 ( bloom_agg	PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 5030 "2283 701 20" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ ));
+DATA(insert OID = 4330 ( bloom_agg	PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 5030 "2283 701 20" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ ));
 DESCR("bloom filter aggregate");
 
 /* bloom filter aggregate transition function */
@@ -5198,7 +5190,7 @@ DATA(insert OID = 4331 ( bloom_agg_trans	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 
 DESCR("bloom filter aggregate");
 
 /* bloom filter aggregate with p and n transition function */
-DATA(insert OID = 4332 ( bloom_agg_transp	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 5030 "5030 2283 701 20" _null_ _null_ _null_ _null_ bloom_agg_transp _null_ _null_ _null_ ));
+DATA(insert OID = 4332 ( bloom_agg_transp	PGNSP PGUID 12 1 0 0 0 f f f f f f i 4 0 5030 "5030 2283 701 20" _null_ _null_ _null_ _null_ bloom_agg_transp _null_ _null_ _null_ ));
 DESCR("bloom filter aggregate");
 
 /* bloom filter union aggregate */
@@ -5223,6 +5215,8 @@ DESCR("bloom filter cardinality");
 
 /* bloom filter contains function */
 DATA(insert OID = 4338 ( bloom_contains	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 16 "5030 2283" _null_ _null_ _null_ _null_ bloom_contains _null_ _null_ _null_ ));
+DESCR("bloom filter contains item?");
+DATA(insert OID = 4385 ( bloom_contains	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 16 "5030 25" _null_ _null_ _null_ _null_ bloom_contains _null_ _null_ _null_ ));
 DESCR("bloom filter contains item?");
 
 /* t-digest aggregate */
@@ -5257,16 +5251,16 @@ DESCR("t-digest cdf");
 DATA(insert OID = 4346 ( tdigest_quantile	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 701 "5034 701" _null_ _null_ _null_ _null_ tdigest_quantile _null_ _null_ _null_ ));
 DESCR("t-digest quantile");
 
-/* t-digest serialize */
-DATA(insert OID = 4347 (tdigest_send PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 17 "5034" _null_ _null_ _null_ _null_ tdigest_send _null_ _null_ _null_ ));
-DESCR("t-digest serialize");
+/* t-digest compress */
+DATA(insert OID = 4347 (tdigest_compress PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 5034 "5034" _null_ _null_ _null_ _null_ tdigest_compress _null_ _null_ _null_ ));
+DESCR("t-digest compress");
 
 /* count-min sketch aggregate */
 DATA(insert OID = 4348 ( cmsketch_agg	PGNSP PGUID 12 1 0 0 0 t f f f f f i 1 0 5038 "2283" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ ));
 DESCR("count-min sketch aggregate");
 
 /* count-min sketch aggregate with user-supplied eps and p */
-DATA(insert OID = 4349 ( cmsketch_agg	PGNSP PGUID 12 1 0 0 0 t f f f f f i 2 0 5038 "2283 701 701" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ ));
+DATA(insert OID = 4349 ( cmsketch_agg	PGNSP PGUID 12 1 0 0 0 t f f f f f i 3 0 5038 "2283 701 701" _null_ _null_ _null_ _null_ aggregate_dummy _null_ _null_ _null_ ));
 DESCR("count-min sketch aggregate");
 
 /* count-min sketch aggregate transition function */
@@ -5274,7 +5268,7 @@ DATA(insert OID = 4350 ( cmsketch_agg_trans	PGNSP PGUID 12 1 0 0 0 f f f f f f i
 DESCR("count-min sketch aggregate");
 
 /* count-min sketch aggregate with eps and p transition function */
-DATA(insert OID = 4351 ( cmsketch_agg_transp	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 5038 "5038 2283 701 701" _null_ _null_ _null_ _null_ cmsketch_agg_transp _null_ _null_ _null_ ));
+DATA(insert OID = 4351 ( cmsketch_agg_transp	PGNSP PGUID 12 1 0 0 0 f f f f f f i 4 0 5038 "5038 2283 701 701" _null_ _null_ _null_ _null_ cmsketch_agg_transp _null_ _null_ _null_ ));
 DESCR("count-min sketch aggregate");
 
 /* count-min sketch merge aggregate */
@@ -5287,6 +5281,8 @@ DESCR("count-min sketch merge aggregate");
 
 /* count-min sketch count function */
 DATA(insert OID = 4354 ( cmsketch_count	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 23 "5038 2283" _null_ _null_ _null_ _null_ cmsketch_count _null_ _null_ _null_ ));
+DESCR("count-min sketch estimate count");
+DATA(insert OID = 4386 ( cmsketch_count	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 23 "5038 25" _null_ _null_ _null_ _null_ cmsketch_count _null_ _null_ _null_ ));
 DESCR("count-min sketch estimate count");
 
 DATA(insert OID = 4355 ( cq_proc_stat_get PGNSP PGUID 12 1 1000 0 0 f f f f t t s 0 0 2249 "" "{25,23,1184,20,20,20,20,20,20,20,20}" "{o,o,o,o,o,o,o,o,o,o,o}" "{type,pid,start_time,input_rows,output_rows,updates,input_bytes,output_bytes,updated_bytes,executions,errors}" _null_ cq_proc_stat_get _null_ _null_ _null_ ));
@@ -5306,6 +5302,8 @@ DESCR("hyperloglog empty");
 /* hyperloglog add */
 DATA(insert OID = 4359 ( hll_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 3998 "3998 2283" _null_ _null_ _null_ _null_ hll_add _null_ _null_ _null_ ));
 DESCR("hyperloglog add");
+DATA(insert OID = 4384 ( hll_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 3998 "3998 25" _null_ _null_ _null_ _null_ hll_add _null_ _null_ _null_ ));
+DESCR("hyperloglog add");
 
 /* bloom filter empty */
 DATA(insert OID = 4360 ( bloom_empty	PGNSP PGUID 12 1 0 0 0 f f f f f f i 0 0 5030 "" _null_ _null_ _null_ _null_ bloom_empty _null_ _null_ _null_ ));
@@ -5317,6 +5315,8 @@ DESCR("bloom filter empty");
 
 /* bloom filter add */
 DATA(insert OID = 4362 ( bloom_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 5030 "5030 2283" _null_ _null_ _null_ _null_ bloom_add _null_ _null_ _null_ ));
+DESCR("bloom filter add");
+DATA(insert OID = 4382 ( bloom_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 5030 "5030 25" _null_ _null_ _null_ _null_ bloom_add _null_ _null_ _null_ ));
 DESCR("bloom filter add");
 
 /* t-digest empty */
@@ -5341,6 +5341,8 @@ DESCR("count-min sketch empty");
 
 /* count-min sketch add */
 DATA(insert OID = 4377 ( cmsketch_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 5038 "5038 2283" _null_ _null_ _null_ _null_ cmsketch_add _null_ _null_ _null_ ));
+DESCR("count-min sketch add");
+DATA(insert OID = 4383 ( cmsketch_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 2 0 5038 "5038 25" _null_ _null_ _null_ _null_ cmsketch_add _null_ _null_ _null_ ));
 DESCR("count-min sketch add");
 
 /* date truncation convenience functions */
@@ -5378,6 +5380,16 @@ DESCR("get continuous queries");
 
 DATA(insert OID = 4379 ( pipeline_streams PGNSP PGUID 12 1 1000 0 0 f f f f t t s 0 0 2249 "" "{25,25,16,1028,17}" "{o,o,o,o,o}" "{schema,name,inferred,queries,desc}" _null_ pipeline_streams _null_ _null_ _null_ ));
 DESCR("get streams");
+
+/* t-digest add n */
+DATA(insert OID = 4380 ( tdigest_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 5034 "5034 701 23" _null_ _null_ _null_ _null_ tdigest_addn _null_ _null_ _null_ ));
+DESCR("t-digest add");
+
+/* count-min sketch add n */
+DATA(insert OID = 4381 ( cmsketch_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 5038 "5038 2283 23" _null_ _null_ _null_ _null_ cmsketch_addn _null_ _null_ _null_ ));
+DESCR("count-min sketch add");
+DATA(insert OID = 4387 ( cmsketch_add	PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 5038 "5038 25 23" _null_ _null_ _null_ _null_ cmsketch_addn _null_ _null_ _null_ ));
+DESCR("count-min sketch add");
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -639,25 +639,25 @@ DESCR("range of bigints");
 DATA(insert OID = 3927 ( _int8range		PGNSP PGUID  -1 f b A f t \054 0 3926 0 array_in array_out array_recv array_send - - array_typanalyze d x f 0 -1 0 0 _null_ _null_ _null_ ));
 
 /* hyperloglog */
-DATA(insert OID = 3998 ( hll	PGNSP PGUID	-1 f b U f t \054 0	 0 5000 hll_in   hll_out   - - - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 3998 ( hll	PGNSP PGUID	-1 f b U f t \054 0	 0 5000 byteain   byteaout   bytearecv byteasend - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("hyperloglog");
 DATA(insert OID = 5000 ( _hll	PGNSP PGUID -1 f b A f t \054 0  3998 0 array_in array_out array_recv array_send - - array_typanalyze i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("hyperloglog array");
 
 /* bloom filter */
-DATA(insert OID = 5030 ( bloom	PGNSP PGUID	-1 f b U f t \054 0	 0 5031 bloom_in	bloom_out   - - - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 5030 ( bloom	PGNSP PGUID	-1 f b U f t \054 0	 0 5031 byteain	byteaout   bytearecv byteasend - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("bloom filter");
 DATA(insert OID = 5031 ( _bloom	PGNSP PGUID -1 f b A f t \054 0  5030 0 array_in	array_out array_recv array_send - - array_typanalyze i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("bloom filter array");
 
 /* t-digest */
-DATA(insert OID = 5034 ( tdigest	PGNSP PGUID	-1 f b U f t \054 0	 0 5035 tdigest_in	tdigest_out   - - - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 5034 ( tdigest	PGNSP PGUID	-1 f b U f t \054 0	 0 5035 byteain	byteaout   bytearecv byteasend - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("t-digest");
 DATA(insert OID = 5035 ( _tdigest	PGNSP PGUID -1 f b A f t \054 0  5034 0 array_in	array_out array_recv array_send - - array_typanalyze i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("t-digest array");
 
 /* count-min sketch */
-DATA(insert OID = 5038 ( cmsketch	PGNSP PGUID	-1 f b U f t \054 0	 0 5039 cmsketch_in	cmsketch_out   - - - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 5038 ( cmsketch	PGNSP PGUID	-1 f b U f t \054 0	 0 5039 byteain	byteaout   bytearecv byteasend - - - i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("count-min sketch");
 DATA(insert OID = 5039 ( _cmsketch	PGNSP PGUID -1 f b A f t \054 0  5038 0 array_in	array_out array_recv array_send - - array_typanalyze i x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("count-min sketch array");

--- a/src/include/catalog/pipeline_combine.h
+++ b/src/include/catalog/pipeline_combine.h
@@ -187,8 +187,8 @@ DATA(insert (0 bloom_agg_trans  0 0 bloom_union_agg_trans 5030));
 DATA(insert (0 bloom_agg_transp 0 0 bloom_union_agg_trans 5030));
 
 /* tdigest_agg */
-DATA(insert (tdigest_send tdigest_agg_trans  tdigest_send 0 tdigest_merge_agg_trans 5034));
-DATA(insert (tdigest_send tdigest_agg_transp tdigest_send 0 tdigest_merge_agg_trans 5034));
+DATA(insert (tdigest_compress tdigest_agg_trans  tdigest_compress 0 tdigest_merge_agg_trans 5034));
+DATA(insert (tdigest_compress tdigest_agg_transp tdigest_compress 0 tdigest_merge_agg_trans 5034));
 
 /* cmsketch_agg */
 DATA(insert (0 cmsketch_agg_trans  0 0 cmsketch_merge_agg_trans 5038));

--- a/src/include/pipeline/tdigest.h
+++ b/src/include/pipeline/tdigest.h
@@ -22,18 +22,19 @@ typedef struct Centroid
 } Centroid;
 
 typedef struct TDigest {
+	uint32	vl_len_;
+
 	float8 compression;
 	uint32 threshold;
 	uint32 size;
-
-	uint32 num_centroids;
-	Centroid *centroids;
 
 	uint64 total_weight;
 	float8 min;
 	float8 max;
 
 	List *unmerged_centroids;
+	uint32 num_centroids;
+	Centroid centroids[1];
 } TDigest;
 
 extern TDigest *TDigestCreate(void);
@@ -47,5 +48,7 @@ extern void TDigestMerge(TDigest *t1, TDigest *t2);
 
 extern float8 TDigestCDF(TDigest *t, float8 x);
 extern float8 TDigestQuantile(TDigest *t, float8 q);
+
+extern Size TDigestSize(TDigest *t);
 
 #endif

--- a/src/include/utils/bloomfuncs.h
+++ b/src/include/utils/bloomfuncs.h
@@ -14,8 +14,7 @@
 #include "postgres.h"
 #include "fmgr.h"
 
-extern Datum bloom_in(PG_FUNCTION_ARGS);
-extern Datum bloom_out(PG_FUNCTION_ARGS);
+extern Datum bloom_print(PG_FUNCTION_ARGS);
 extern Datum bloom_agg_trans(PG_FUNCTION_ARGS);
 extern Datum bloom_agg_transp(PG_FUNCTION_ARGS);
 extern Datum bloom_union_agg_trans(PG_FUNCTION_ARGS);

--- a/src/include/utils/cmsketchfuncs.h
+++ b/src/include/utils/cmsketchfuncs.h
@@ -14,8 +14,7 @@
 #include "postgres.h"
 #include "fmgr.h"
 
-extern Datum cmsketch_in(PG_FUNCTION_ARGS);
-extern Datum cmsketch_out(PG_FUNCTION_ARGS);
+extern Datum cmsketch_print(PG_FUNCTION_ARGS);
 extern Datum cmsketch_agg_trans(PG_FUNCTION_ARGS);
 extern Datum cmsketch_agg_transp(PG_FUNCTION_ARGS);
 extern Datum cmsketch_merge_agg_trans(PG_FUNCTION_ARGS);
@@ -23,5 +22,6 @@ extern Datum cmsketch_count(PG_FUNCTION_ARGS);
 extern Datum cmsketch_empty(PG_FUNCTION_ARGS);
 extern Datum cmsketch_emptyp(PG_FUNCTION_ARGS);
 extern Datum cmsketch_add(PG_FUNCTION_ARGS);
+extern Datum cmsketch_addn(PG_FUNCTION_ARGS);
 
 #endif

--- a/src/include/utils/hllfuncs.h
+++ b/src/include/utils/hllfuncs.h
@@ -12,8 +12,7 @@
 #include "postgres.h"
 #include "fmgr.h"
 
-extern Datum hll_in(PG_FUNCTION_ARGS);
-extern Datum hll_out(PG_FUNCTION_ARGS);
+extern Datum hll_print(PG_FUNCTION_ARGS);
 extern Datum hll_agg_trans(PG_FUNCTION_ARGS);
 extern Datum hll_agg_transp(PG_FUNCTION_ARGS);
 extern Datum hll_union_agg_trans(PG_FUNCTION_ARGS);

--- a/src/include/utils/tdigestfuncs.h
+++ b/src/include/utils/tdigestfuncs.h
@@ -14,9 +14,8 @@
 #include "postgres.h"
 #include "fmgr.h"
 
-extern Datum tdigest_send(PG_FUNCTION_ARGS);
-extern Datum tdigest_in(PG_FUNCTION_ARGS);
-extern Datum tdigest_out(PG_FUNCTION_ARGS);
+extern Datum tdigest_compress(PG_FUNCTION_ARGS);
+extern Datum tdigest_print(PG_FUNCTION_ARGS);
 extern Datum tdigest_agg_trans(PG_FUNCTION_ARGS);
 extern Datum tdigest_agg_transp(PG_FUNCTION_ARGS);
 extern Datum tdigest_merge_agg_trans(PG_FUNCTION_ARGS);
@@ -25,5 +24,6 @@ extern Datum tdigest_quantile(PG_FUNCTION_ARGS);
 extern Datum tdigest_empty(PG_FUNCTION_ARGS);
 extern Datum tdigest_emptyp(PG_FUNCTION_ARGS);
 extern Datum tdigest_add(PG_FUNCTION_ARGS);
+extern Datum tdigest_addn(PG_FUNCTION_ARGS);
 
 #endif

--- a/src/test/regress/expected/cont_complex_types.out
+++ b/src/test/regress/expected/cont_complex_types.out
@@ -123,13 +123,13 @@ SELECT bloom_cardinality(bloom_agg) FROM test_cont_complex4;
                  2
 (1 row)
 
-SELECT bloom_contains(bloom_agg, 'hello'::text) FROM test_cont_complex4;
+SELECT bloom_contains(bloom_agg, 'hello') FROM test_cont_complex4;
  bloom_contains 
 ----------------
  t
 (1 row)
 
-SELECT bloom_contains(bloom_agg, 'world'::text) FROM test_cont_complex4;
+SELECT bloom_contains(bloom_agg, 'world') FROM test_cont_complex4;
  bloom_contains 
 ----------------
  t

--- a/src/test/regress/expected/cont_hll_agg.out
+++ b/src/test/regress/expected/cont_hll_agg.out
@@ -1,7 +1,7 @@
 CREATE CONTINUOUS VIEW test_hll_agg0 AS SELECT k::text, hll_agg(x::integer) FROM test_hll_agg_stream GROUP BY k;
 CREATE CONTINUOUS VIEW test_hll_agg1 AS SELECT k::text, hll_cardinality(hll_agg(x::integer)) + hll_cardinality(hll_agg(y::text)) FROM test_hll_agg_stream GROUP BY k;
 CREATE CONTINUOUS VIEW test_hll_agg2 AS SELECT k::text, hll_cardinality(hll_agg(x::integer)) + hll_cardinality(hll_agg(substring(y::text, 1, 1))) FROM test_hll_agg_stream GROUP BY k;
-CREATE CONTINUOUS VIEW test_sw_hll_agg0 AS SELECT k::text, hll_agg(x::integer) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY k;
+CREATE CONTINUOUS VIEW test_sw_hll_agg0 AS SELECT k::text, hll_print(hll_agg(x::integer)) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY k;
 CREATE CONTINUOUS VIEW test_sw_hll_agg1 AS SELECT k::text, hll_cardinality(hll_agg(x::integer)) + hll_cardinality(hll_agg(y::text)) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour')  GROUP BY k;
 CREATE CONTINUOUS VIEW test_sw_hll_agg2 AS SELECT k::text, hll_cardinality(hll_agg(x::integer)) + hll_cardinality(hll_agg(substring(y::text, 1, 1))) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour')  GROUP BY k;
 INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('0', 0, '0');
@@ -105,8 +105,8 @@ INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('7', 97, '9700');
 INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('8', 98, '9800');
 INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('9', 99, '9900');
 INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('0', 0, '0'), ('1', 1, '100'), ('2', 2, '200'), ('3', 3, '300'), ('4', 4, '400'), ('5', 5, '500'), ('6', 6, '600'), ('7', 7, '700'), ('8', 8, '800'), ('9', 9, '900'), ('0', 10, '1000'), ('1', 11, '1100'), ('2', 12, '1200'), ('3', 13, '1300'), ('4', 14, '1400'), ('5', 15, '1500'), ('6', 16, '1600'), ('7', 17, '1700'), ('8', 18, '1800'), ('9', 19, '1900'), ('0', 20, '2000'), ('1', 21, '2100'), ('2', 22, '2200'), ('3', 23, '2300'), ('4', 24, '2400'), ('5', 25, '2500'), ('6', 26, '2600'), ('7', 27, '2700'), ('8', 28, '2800'), ('9', 29, '2900'), ('0', 30, '3000'), ('1', 31, '3100'), ('2', 32, '3200'), ('3', 33, '3300'), ('4', 34, '3400'), ('5', 35, '3500'), ('6', 36, '3600'), ('7', 37, '3700'), ('8', 38, '3800'), ('9', 39, '3900'), ('0', 40, '4000'), ('1', 41, '4100'), ('2', 42, '4200'), ('3', 43, '4300'), ('4', 44, '4400'), ('5', 45, '4500'), ('6', 46, '4600'), ('7', 47, '4700'), ('8', 48, '4800'), ('9', 49, '4900'), ('0', 50, '5000'), ('1', 51, '5100'), ('2', 52, '5200'), ('3', 53, '5300'), ('4', 54, '5400'), ('5', 55, '5500'), ('6', 56, '5600'), ('7', 57, '5700'), ('8', 58, '5800'), ('9', 59, '5900'), ('0', 60, '6000'), ('1', 61, '6100'), ('2', 62, '6200'), ('3', 63, '6300'), ('4', 64, '6400'), ('5', 65, '6500'), ('6', 66, '6600'), ('7', 67, '6700'), ('8', 68, '6800'), ('9', 69, '6900'), ('0', 70, '7000'), ('1', 71, '7100'), ('2', 72, '7200'), ('3', 73, '7300'), ('4', 74, '7400'), ('5', 75, '7500'), ('6', 76, '7600'), ('7', 77, '7700'), ('8', 78, '7800'), ('9', 79, '7900'), ('0', 80, '8000'), ('1', 81, '8100'), ('2', 82, '8200'), ('3', 83, '8300'), ('4', 84, '8400'), ('5', 85, '8500'), ('6', 86, '8600'), ('7', 87, '8700'), ('8', 88, '8800'), ('9', 89, '8900'), ('0', 90, '9000'), ('1', 91, '9100'), ('2', 92, '9200'), ('3', 93, '9300'), ('4', 94, '9400'), ('5', 95, '9500'), ('6', 96, '9600'), ('7', 97, '9700'), ('8', 98, '9800'), ('9', 99, '9900');
-SELECT * FROM test_hll_agg0 ORDER BY k;
- k |                  hll_agg                  
+SELECT k, hll_print(hll_agg) FROM test_hll_agg0 ORDER BY k;
+ k |                 hll_print                 
 ---+-------------------------------------------
  0 | { p = 14, cardinality = 10, size = 12kB }
  1 | { p = 14, cardinality = 10, size = 12kB }
@@ -151,7 +151,7 @@ SELECT * FROM test_hll_agg2 ORDER BY k;
 (10 rows)
 
 SELECT * FROM test_sw_hll_agg0 ORDER BY k;
- k |                  hll_agg                  
+ k |                 hll_print                 
 ---+-------------------------------------------
  0 | { p = 14, cardinality = 10, size = 12kB }
  1 | { p = 14, cardinality = 10, size = 12kB }
@@ -195,8 +195,8 @@ SELECT * FROM test_sw_hll_agg2 ORDER BY k;
  9 |       19
 (10 rows)
 
-SELECT combine(hll_agg) FROM test_hll_agg0;
-                  combine                   
+SELECT hll_print(combine(hll_agg)) FROM test_hll_agg0;
+                 hll_print                  
 --------------------------------------------
  { p = 14, cardinality = 100, size = 12kB }
 (1 row)

--- a/src/test/regress/expected/custom_data_types.out
+++ b/src/test/regress/expected/custom_data_types.out
@@ -1,0 +1,132 @@
+CREATE TABLE custom_dt_hll (x text, y hll);
+INSERT INTO custom_dt_hll VALUES ('a', hll_empty()), ('b', hll_empty(5)), ('c', NULL);
+SELECT hll_print(y) FROM custom_dt_hll;
+                hll_print                
+-----------------------------------------
+ { p = 14, cardinality = 0, size = 0kB }
+ { p = 5, cardinality = 0, size = 0kB }
+ 
+(3 rows)
+
+UPDATE custom_dt_hll SET y = hll_add(y, 'hello');
+UPDATE custom_dt_hll SET y = hll_add(y, 'world');
+SELECT hll_print(y) FROM custom_dt_hll;
+                hll_print                
+-----------------------------------------
+ { p = 14, cardinality = 2, size = 0kB }
+ { p = 5, cardinality = 2, size = 0kB }
+ { p = 14, cardinality = 2, size = 0kB }
+(3 rows)
+
+SELECT hll_print(hll_agg(x)) FROM custom_dt_hll;
+                hll_print                
+-----------------------------------------
+ { p = 14, cardinality = 3, size = 0kB }
+(1 row)
+
+SELECT hll_print(hll_agg(x, 10)) FROM custom_dt_hll;
+                hll_print                
+-----------------------------------------
+ { p = 10, cardinality = 3, size = 0kB }
+(1 row)
+
+DROP TABLE custom_dt_hll;
+CREATE TABLE custom_dt_bloom (x text, y bloom);
+INSERT INTO custom_dt_bloom VALUES ('a', bloom_empty()), ('b', bloom_empty(0.05, 1000)), ('c', NULL);
+SELECT bloom_print(y) FROM custom_dt_bloom;
+                          bloom_print                          
+---------------------------------------------------------------
+ { k = 6, m = 266808, fill = 0.000000, card = 0, size = 32kB }
+ { k = 4, m = 6235, fill = 0.000000, card = 0, size = 0kB }
+ 
+(3 rows)
+
+UPDATE custom_dt_bloom SET y = bloom_add(y, 'hello');
+UPDATE custom_dt_bloom SET y = bloom_add(y, 'world');
+SELECT bloom_print(y) FROM custom_dt_bloom;
+                          bloom_print                          
+---------------------------------------------------------------
+ { k = 6, m = 266808, fill = 0.000360, card = 2, size = 32kB }
+ { k = 4, m = 6235, fill = 0.010204, card = 2, size = 0kB }
+ { k = 6, m = 266808, fill = 0.000360, card = 2, size = 32kB }
+(3 rows)
+
+SELECT bloom_print(bloom_agg(x)) FROM custom_dt_bloom;
+                          bloom_print                          
+---------------------------------------------------------------
+ { k = 6, m = 266808, fill = 0.000540, card = 3, size = 32kB }
+(1 row)
+
+SELECT bloom_print(bloom_agg(x, 0.05, 1000)) FROM custom_dt_bloom;
+                        bloom_print                         
+------------------------------------------------------------
+ { k = 4, m = 6235, fill = 0.015306, card = 3, size = 0kB }
+(1 row)
+
+DROP TABLE custom_dt_bloom;
+CREATE TABLE custom_dt_cmsketch (x text, y cmsketch);
+INSERT INTO custom_dt_cmsketch VALUES ('a', cmsketch_empty()), ('b', cmsketch_empty(0.05, 0.80)), ('c', NULL);
+SELECT cmsketch_print(y) FROM custom_dt_cmsketch;
+               cmsketch_print                
+---------------------------------------------
+ { d = 6, w = 1360, count = 0, size = 31kB }
+ { d = 2, w = 55, count = 0, size = 0kB }
+ 
+(3 rows)
+
+UPDATE custom_dt_cmsketch SET y = cmsketch_add(y, 'hello');
+UPDATE custom_dt_cmsketch SET y = cmsketch_add(y, 'world', 5);
+SELECT cmsketch_print(y) FROM custom_dt_cmsketch;
+               cmsketch_print                
+---------------------------------------------
+ { d = 6, w = 1360, count = 6, size = 31kB }
+ { d = 2, w = 55, count = 6, size = 0kB }
+ { d = 6, w = 1360, count = 6, size = 31kB }
+(3 rows)
+
+SELECT cmsketch_print(cmsketch_agg(x)) FROM custom_dt_cmsketch;
+               cmsketch_print                
+---------------------------------------------
+ { d = 6, w = 1360, count = 3, size = 31kB }
+(1 row)
+
+SELECT cmsketch_print(cmsketch_agg(x, 0.05, 0.80)) FROM custom_dt_cmsketch;
+              cmsketch_print              
+------------------------------------------
+ { d = 2, w = 55, count = 3, size = 0kB }
+(1 row)
+
+DROP TABLE custom_dt_cmsketch;
+CREATE TABLE custom_dt_tdigest (x text, y tdigest);
+INSERT INTO custom_dt_tdigest VALUES ('a', tdigest_empty()), ('b', tdigest_empty(25)), ('c', NULL);
+SELECT tdigest_print(y) FROM custom_dt_tdigest;
+            tdigest_print             
+--------------------------------------
+ { count = 0, k = 200, centroids: 0 }
+ { count = 0, k = 25, centroids: 0 }
+ 
+(3 rows)
+
+UPDATE custom_dt_tdigest SET y = tdigest_add(y, 10);
+UPDATE custom_dt_tdigest SET y = tdigest_add(y, 20, 2);
+SELECT tdigest_print(y) FROM custom_dt_tdigest;
+            tdigest_print             
+--------------------------------------
+ { count = 3, k = 200, centroids: 2 }
+ { count = 3, k = 25, centroids: 2 }
+ { count = 3, k = 200, centroids: 2 }
+(3 rows)
+
+SELECT tdigest_print(tdigest_agg(x)) FROM custom_dt_tdigest;
+            tdigest_print             
+--------------------------------------
+ { count = 3, k = 200, centroids: 3 }
+(1 row)
+
+SELECT tdigest_print(tdigest_agg(x, 25)) FROM custom_dt_tdigest;
+            tdigest_print            
+-------------------------------------
+ { count = 3, k = 25, centroids: 3 }
+(1 row)
+
+DROP TABLE custom_dt_tdigest;

--- a/src/test/regress/expected/type_sanity.out
+++ b/src/test/regress/expected/type_sanity.out
@@ -136,10 +136,14 @@ WHERE p1.typinput = p2.oid AND p1.typtype in ('b', 'p') AND NOT
     (p1.typelem != 0 AND p1.typlen < 0) AND NOT
     (p2.prorettype = p1.oid AND NOT p2.proretset)
 ORDER BY 1;
- oid  |  typname  | oid | proname 
-------+-----------+-----+---------
- 1790 | refcursor |  46 | textin
-(1 row)
+ oid  |  typname  | oid  | proname 
+------+-----------+------+---------
+ 1790 | refcursor |   46 | textin
+ 3998 | hll       | 1244 | byteain
+ 5030 | bloom     | 1244 | byteain
+ 5034 | tdigest   | 1244 | byteain
+ 5038 | cmsketch  | 1244 | byteain
+(5 rows)
 
 -- Varlena array types will point to array_in
 -- Exception as of 8.1: int2vector and oidvector have their own I/O routines
@@ -179,10 +183,14 @@ WHERE p1.typoutput = p2.oid AND p1.typtype in ('b', 'p') AND NOT
       (p2.oid = 'array_out'::regproc AND
        p1.typelem != 0 AND p1.typlen = -1)))
 ORDER BY 1;
- oid  |  typname  | oid | proname 
-------+-----------+-----+---------
+ oid  |  typname  | oid | proname  
+------+-----------+-----+----------
  1790 | refcursor |  47 | textout
-(1 row)
+ 3998 | hll       |  31 | byteaout
+ 5030 | bloom     |  31 | byteaout
+ 5034 | tdigest   |  31 | byteaout
+ 5038 | cmsketch  |  31 | byteaout
+(5 rows)
 
 SELECT p1.oid, p1.typname, p2.oid, p2.proname
 FROM pg_type AS p1, pg_proc AS p2
@@ -234,10 +242,14 @@ WHERE p1.typreceive = p2.oid AND p1.typtype in ('b', 'p') AND NOT
     (p1.typelem != 0 AND p1.typlen < 0) AND NOT
     (p2.prorettype = p1.oid AND NOT p2.proretset)
 ORDER BY 1;
- oid  |  typname  | oid  | proname  
-------+-----------+------+----------
+ oid  |  typname  | oid  |  proname  
+------+-----------+------+-----------
  1790 | refcursor | 2414 | textrecv
-(1 row)
+ 3998 | hll       | 2412 | bytearecv
+ 5030 | bloom     | 2412 | bytearecv
+ 5034 | tdigest   | 2412 | bytearecv
+ 5038 | cmsketch  | 2412 | bytearecv
+(5 rows)
 
 -- Varlena array types will point to array_recv
 -- Exception as of 8.1: int2vector and oidvector have their own I/O routines
@@ -286,10 +298,14 @@ WHERE p1.typsend = p2.oid AND p1.typtype in ('b', 'p') AND NOT
       (p2.oid = 'array_send'::regproc AND
        p1.typelem != 0 AND p1.typlen = -1)))
 ORDER BY 1;
- oid  |  typname  | oid  | proname  
-------+-----------+------+----------
+ oid  |  typname  | oid  |  proname  
+------+-----------+------+-----------
  1790 | refcursor | 2415 | textsend
-(1 row)
+ 3998 | hll       | 2413 | byteasend
+ 5030 | bloom     | 2413 | byteasend
+ 5034 | tdigest   | 2413 | byteasend
+ 5038 | cmsketch  | 2413 | byteasend
+(5 rows)
 
 SELECT p1.oid, p1.typname, p2.oid, p2.proname
 FROM pg_type AS p1, pg_proc AS p2

--- a/src/test/regress/sql/cont_complex_types.sql
+++ b/src/test/regress/sql/cont_complex_types.sql
@@ -59,8 +59,8 @@ INSERT INTO cont_complex_stream (z) VALUES ('hello'), ('world');
 
 SELECT bloom_cardinality(bloom_agg) FROM test_cont_complex4;
 
-SELECT bloom_contains(bloom_agg, 'hello'::text) FROM test_cont_complex4;
-SELECT bloom_contains(bloom_agg, 'world'::text) FROM test_cont_complex4;
+SELECT bloom_contains(bloom_agg, 'hello') FROM test_cont_complex4;
+SELECT bloom_contains(bloom_agg, 'world') FROM test_cont_complex4;
 
 DROP CONTINUOUS VIEW test_cont_complex1;
 DROP CONTINUOUS VIEW test_cont_complex2;

--- a/src/test/regress/sql/cont_hll_agg.sql
+++ b/src/test/regress/sql/cont_hll_agg.sql
@@ -3,7 +3,7 @@ CREATE CONTINUOUS VIEW test_hll_agg1 AS SELECT k::text, hll_cardinality(hll_agg(
 
 CREATE CONTINUOUS VIEW test_hll_agg2 AS SELECT k::text, hll_cardinality(hll_agg(x::integer)) + hll_cardinality(hll_agg(substring(y::text, 1, 1))) FROM test_hll_agg_stream GROUP BY k;
 
-CREATE CONTINUOUS VIEW test_sw_hll_agg0 AS SELECT k::text, hll_agg(x::integer) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY k;
+CREATE CONTINUOUS VIEW test_sw_hll_agg0 AS SELECT k::text, hll_print(hll_agg(x::integer)) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour') GROUP BY k;
 
 CREATE CONTINUOUS VIEW test_sw_hll_agg1 AS SELECT k::text, hll_cardinality(hll_agg(x::integer)) + hll_cardinality(hll_agg(y::text)) FROM test_hll_agg_stream WHERE (arrival_timestamp > clock_timestamp() - interval '1 hour')  GROUP BY k;
 
@@ -111,14 +111,14 @@ INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('8', 98, '9800');
 INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('9', 99, '9900');
 INSERT INTO test_hll_agg_stream (k, x, y) VALUES ('0', 0, '0'), ('1', 1, '100'), ('2', 2, '200'), ('3', 3, '300'), ('4', 4, '400'), ('5', 5, '500'), ('6', 6, '600'), ('7', 7, '700'), ('8', 8, '800'), ('9', 9, '900'), ('0', 10, '1000'), ('1', 11, '1100'), ('2', 12, '1200'), ('3', 13, '1300'), ('4', 14, '1400'), ('5', 15, '1500'), ('6', 16, '1600'), ('7', 17, '1700'), ('8', 18, '1800'), ('9', 19, '1900'), ('0', 20, '2000'), ('1', 21, '2100'), ('2', 22, '2200'), ('3', 23, '2300'), ('4', 24, '2400'), ('5', 25, '2500'), ('6', 26, '2600'), ('7', 27, '2700'), ('8', 28, '2800'), ('9', 29, '2900'), ('0', 30, '3000'), ('1', 31, '3100'), ('2', 32, '3200'), ('3', 33, '3300'), ('4', 34, '3400'), ('5', 35, '3500'), ('6', 36, '3600'), ('7', 37, '3700'), ('8', 38, '3800'), ('9', 39, '3900'), ('0', 40, '4000'), ('1', 41, '4100'), ('2', 42, '4200'), ('3', 43, '4300'), ('4', 44, '4400'), ('5', 45, '4500'), ('6', 46, '4600'), ('7', 47, '4700'), ('8', 48, '4800'), ('9', 49, '4900'), ('0', 50, '5000'), ('1', 51, '5100'), ('2', 52, '5200'), ('3', 53, '5300'), ('4', 54, '5400'), ('5', 55, '5500'), ('6', 56, '5600'), ('7', 57, '5700'), ('8', 58, '5800'), ('9', 59, '5900'), ('0', 60, '6000'), ('1', 61, '6100'), ('2', 62, '6200'), ('3', 63, '6300'), ('4', 64, '6400'), ('5', 65, '6500'), ('6', 66, '6600'), ('7', 67, '6700'), ('8', 68, '6800'), ('9', 69, '6900'), ('0', 70, '7000'), ('1', 71, '7100'), ('2', 72, '7200'), ('3', 73, '7300'), ('4', 74, '7400'), ('5', 75, '7500'), ('6', 76, '7600'), ('7', 77, '7700'), ('8', 78, '7800'), ('9', 79, '7900'), ('0', 80, '8000'), ('1', 81, '8100'), ('2', 82, '8200'), ('3', 83, '8300'), ('4', 84, '8400'), ('5', 85, '8500'), ('6', 86, '8600'), ('7', 87, '8700'), ('8', 88, '8800'), ('9', 89, '8900'), ('0', 90, '9000'), ('1', 91, '9100'), ('2', 92, '9200'), ('3', 93, '9300'), ('4', 94, '9400'), ('5', 95, '9500'), ('6', 96, '9600'), ('7', 97, '9700'), ('8', 98, '9800'), ('9', 99, '9900');
 
-SELECT * FROM test_hll_agg0 ORDER BY k;
+SELECT k, hll_print(hll_agg) FROM test_hll_agg0 ORDER BY k;
 SELECT * FROM test_hll_agg1 ORDER BY k;
 SELECT * FROM test_hll_agg2 ORDER BY k;
 SELECT * FROM test_sw_hll_agg0 ORDER BY k;
 SELECT * FROM test_sw_hll_agg1 ORDER BY k;
 SELECT * FROM test_sw_hll_agg2 ORDER BY k;
 
-SELECT combine(hll_agg) FROM test_hll_agg0;
+SELECT hll_print(combine(hll_agg)) FROM test_hll_agg0;
 SELECT hll_cardinality(combine(hll_agg)) FROM test_hll_agg0;
 
 DROP CONTINUOUS VIEW test_hll_agg0;

--- a/src/test/regress/sql/custom_data_types.sql
+++ b/src/test/regress/sql/custom_data_types.sql
@@ -1,0 +1,59 @@
+CREATE TABLE custom_dt_hll (x text, y hll);
+
+INSERT INTO custom_dt_hll VALUES ('a', hll_empty()), ('b', hll_empty(5)), ('c', NULL);
+
+SELECT hll_print(y) FROM custom_dt_hll;
+
+UPDATE custom_dt_hll SET y = hll_add(y, 'hello');
+UPDATE custom_dt_hll SET y = hll_add(y, 'world');
+
+SELECT hll_print(y) FROM custom_dt_hll;
+SELECT hll_print(hll_agg(x)) FROM custom_dt_hll;
+SELECT hll_print(hll_agg(x, 10)) FROM custom_dt_hll;
+
+DROP TABLE custom_dt_hll;
+
+CREATE TABLE custom_dt_bloom (x text, y bloom);
+
+INSERT INTO custom_dt_bloom VALUES ('a', bloom_empty()), ('b', bloom_empty(0.05, 1000)), ('c', NULL);
+
+SELECT bloom_print(y) FROM custom_dt_bloom;
+
+UPDATE custom_dt_bloom SET y = bloom_add(y, 'hello');
+UPDATE custom_dt_bloom SET y = bloom_add(y, 'world');
+
+SELECT bloom_print(y) FROM custom_dt_bloom;
+SELECT bloom_print(bloom_agg(x)) FROM custom_dt_bloom;
+SELECT bloom_print(bloom_agg(x, 0.05, 1000)) FROM custom_dt_bloom;
+
+DROP TABLE custom_dt_bloom;
+
+CREATE TABLE custom_dt_cmsketch (x text, y cmsketch);
+
+INSERT INTO custom_dt_cmsketch VALUES ('a', cmsketch_empty()), ('b', cmsketch_empty(0.05, 0.80)), ('c', NULL);
+
+SELECT cmsketch_print(y) FROM custom_dt_cmsketch;
+
+UPDATE custom_dt_cmsketch SET y = cmsketch_add(y, 'hello');
+UPDATE custom_dt_cmsketch SET y = cmsketch_add(y, 'world', 5);
+
+SELECT cmsketch_print(y) FROM custom_dt_cmsketch;
+SELECT cmsketch_print(cmsketch_agg(x)) FROM custom_dt_cmsketch;
+SELECT cmsketch_print(cmsketch_agg(x, 0.05, 0.80)) FROM custom_dt_cmsketch;
+
+DROP TABLE custom_dt_cmsketch;
+
+CREATE TABLE custom_dt_tdigest (x text, y tdigest);
+
+INSERT INTO custom_dt_tdigest VALUES ('a', tdigest_empty()), ('b', tdigest_empty(25)), ('c', NULL);
+
+SELECT tdigest_print(y) FROM custom_dt_tdigest;
+
+UPDATE custom_dt_tdigest SET y = tdigest_add(y, 10);
+UPDATE custom_dt_tdigest SET y = tdigest_add(y, 20, 2);
+
+SELECT tdigest_print(y) FROM custom_dt_tdigest;
+SELECT tdigest_print(tdigest_agg(x)) FROM custom_dt_tdigest;
+SELECT tdigest_print(tdigest_agg(x, 25)) FROM custom_dt_tdigest;
+
+DROP TABLE custom_dt_tdigest;


### PR DESCRIPTION
- Now supports in/out functions so can be used with `COPY`
- Fixed a few segfaults where the datatype was `NULL`
- Adding an element to a `NULL` value automatically initializes a default empty data structure
- Hashing fix for `text` type when inserted from `psql` which was previously failing because polymorphic type coercion fails with `unknown` types
- Added a print function for all types
- A few `nargs` bugs in `pg_proc` catalog
