### PR TITLE
Matrel vac improvements

### DIFF
--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -995,6 +995,7 @@ next:
 		}
 
 		CommitTransactionCommand();
+		pgstat_report_stat(false);
 
 		if (num_processed)
 			last_processed = GetCurrentTimestamp();

--- a/src/backend/pipeline/streamReceiver.c
+++ b/src/backend/pipeline/streamReceiver.c
@@ -9,6 +9,9 @@
  * IDENTIFICATION
  *	  src/backend/pipeline/streamReceiver.c
  */
+#include "postgres.h"
+
+#include "access/xact.h"
 #include "pipeline/stream.h"
 #include "pipeline/streamReceiver.h"
 #include "pipeline/tuplebuf.h"
@@ -39,6 +42,22 @@ stream_receive(TupleTableSlot *slot, DestReceiver *self)
 		stream->bytes += tuple->heaptup->t_len + HEAPTUPLESIZE;
 	}
 
+	/*
+	 * Writing to streams from a long-running process is presumably a common case,
+	 * so we periodically commit to avoid a long-running transaction. Long-running xacts
+	 * blocks the autovac from freeing up space, because tuples that have long since been
+	 * deleted would technically still be visible from the point of view of a long-running
+	 * xact.
+	 */
+	if (stream_insertion_commit_interval > 0 &&
+			TimestampDifferenceExceeds(stream->lastcommit, GetCurrentTimestamp(), stream_insertion_commit_interval * 1000))
+	{
+		 CommitTransactionCommand();
+		 stream->lastcommit = GetCurrentTimestamp();
+
+		 StartTransactionCommand();
+	}
+
 	MemoryContextSwitchTo(old);
 }
 
@@ -60,6 +79,7 @@ CreateStreamDestReceiver(void)
 	self->pub.rDestroy = stream_destroy;
 	self->pub.mydest = DestCombiner;
 	self->count = 0;
+	self->lastcommit = GetCurrentTimestamp();
 
 	return (DestReceiver *) self;
 }

--- a/src/backend/pipeline/sw_vacuum.c
+++ b/src/backend/pipeline/sw_vacuum.c
@@ -205,6 +205,7 @@ CreateSWVacuumContext(Relation rel)
 	context->slot = MakeSingleTupleTableSlot(RelationGetDescr(rel));
 	context->econtext->ecxt_scantuple = context->slot;
 	context->predicate = list_make1(ExecInitExpr(expression_planner(expr), NULL));
+	context->expired = NIL;
 
 	return context;
 }

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -53,6 +53,7 @@
 #include "parser/parser.h"
 #include "parser/scansup.h"
 #include "pgstat.h"
+#include "pipeline/stream.h"
 #include "pipeline/update.h"
 #include "postmaster/autovacuum.h"
 #include "postmaster/bgworker.h"
@@ -2397,7 +2398,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_S
 		},
 		&autovacuum_naptime,
-		60, 1, INT_MAX / 1000,
+		15, 1, INT_MAX / 1000,
 		NULL, NULL, NULL
 	},
 	{
@@ -2665,6 +2666,17 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&continuous_view_fillfactor,
 		50, 1, 100,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"stream_insertion_commit_interval", PGC_BACKEND, QUERY_TUNING_OTHER,
+		 gettext_noop("Sets the default amount of time to periodically commit from a stream insertion process."),
+		 gettext_noop("A lower number will minimize the amount of time the autovacuumer can be blocked from freeing unused space by long-running stream insertion processes. Additionally, continuous views created during the insertion process will begin accepting writes by the inserter sooner."),
+		 GUC_UNIT_S
+		},
+		&stream_insertion_commit_interval,
+		1, -1, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/pipelinedb.conf.sample
+++ b/src/backend/utils/misc/pipelinedb.conf.sample
@@ -473,7 +473,7 @@
 					# of milliseconds.
 #autovacuum_max_workers = 3		# max number of autovacuum subprocesses
 					# (change requires restart)
-#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_naptime = 15s		  # time between autovacuum runs
 #autovacuum_vacuum_threshold = 50	# min number of row updates before
 					# vacuum
 #autovacuum_analyze_threshold = 50	# min number of row updates before
@@ -630,6 +630,10 @@
 # the number of parallel continuous query worker processes to use for
 # each database
 #continuous_query_num_workers = 2
+
+# the default amount of time to periodically commit from a stream insertion
+# process
+#stream_insertion_commit_interval = 1s
 
 #------------------------------------------------------------------------------
 # CONFIG FILE INCLUDES

--- a/src/include/pipeline/stream.h
+++ b/src/include/pipeline/stream.h
@@ -13,7 +13,6 @@
 #ifndef STREAM_H
 #define STREAM_H
 
-#include "postgres.h"
 #include "nodes/bitmapset.h"
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
@@ -21,6 +20,8 @@
 #include "utils/hsearch.h"
 #include "utils/relcache.h"
 #include "utils/timestamp.h"
+
+extern int stream_insertion_commit_interval;
 
 #define QueryIsStreaming(query) ((query)->isContinuous)
 #define QueryIsCombine(query) ((query)->isCombine)
@@ -48,7 +49,7 @@ extern PreparedStreamInsertStmt *FetchPreparedStreamInsert(const char *name);
 extern void DropPreparedStreamInsert(const char *name);
 extern int InsertIntoStreamPrepared(PreparedStreamInsertStmt *pstmt);
 extern int InsertIntoStream(InsertStmt *ins, List *params);
-extern uint64 CopyIntoStream(Relation stream, TupleDesc desc, HeapTuple *tuples, int ntuples);
+extern uint64 CopyIntoStream(Relation stream, TupleDesc desc, HeapTuple *tuples, int ntuples, TimestampTz *timer);
 
 /* Represents a single batch of inserts made into a stream. */
 typedef struct InsertBatch {

--- a/src/include/pipeline/streamReceiver.h
+++ b/src/include/pipeline/streamReceiver.h
@@ -28,6 +28,7 @@ typedef struct StreamReceiver
 	TupleDesc desc;
 	MemoryContext context;
 	Size bytes;
+	TimestampTz lastcommit;
 } StreamReceiver;
 
 extern DestReceiver *CreateStreamDestReceiver(void);

--- a/src/include/pipeline/sw_vacuum.h
+++ b/src/include/pipeline/sw_vacuum.h
@@ -25,6 +25,7 @@ typedef struct SWVacuumContext
 	TupleTableSlot *slot;
 	ExprContext *econtext;
 	List *predicate;
+	List *expired;
 } SWVacuumContext;
 
 extern uint64_t NumSWVacuumTuples(Oid relid);


### PR DESCRIPTION
Fixes some matrel bloating issues. There were a few things going on here:

* Long running-xacts block autovac garbage collection, so long-running stream insertions will now periodically commit to prevent this from happening
* Table stats weren't being reported often enough after `sync_combine`, which prevented that autovac from realizing that a matrel was due for a vacuum
* Since we don't call `heap_delete` when deleting an expired SW tuple, a tuple's TOAST rows weren't being marked for deletion

The default naptime for the autovac also isn't ideal for update-heavy matrels, so I globally lowered it from `60s` to `15s`. It's not a table-level parameter.