### PR TITLE
Remove empty_wait configuration parameter

### DIFF
--- a/src/backend/pipeline/cont_scheduler.c
+++ b/src/backend/pipeline/cont_scheduler.c
@@ -68,7 +68,6 @@ int continuous_query_num_combiners;
 int continuous_query_num_workers;
 int continuous_query_batch_size;
 int continuous_query_max_wait;
-int continuous_query_empty_sleep;
 int continuous_query_combiner_work_mem;
 int continuous_query_combiner_cache_mem;
 int continuous_query_combiner_synchronous_commit;
@@ -105,7 +104,6 @@ static void
 update_tuning_params(void)
 {
 	ContQuerySchedulerShmem->params.batch_size = continuous_query_batch_size;
-	ContQuerySchedulerShmem->params.empty_sleep = continuous_query_empty_sleep;
 	ContQuerySchedulerShmem->params.max_wait = continuous_query_max_wait;
 }
 

--- a/src/backend/pipeline/tuplebuf.c
+++ b/src/backend/pipeline/tuplebuf.c
@@ -882,7 +882,7 @@ TupleBufferBatchReaderReset(TupleBufferBatchReader *reader)
 
 	MemoryContextSwitchTo(old_ctx);
 
-	/* we need to restart scanning from the underlyng reader */
+	/* we need to restart scanning from the underlying reader */
 	reader->started = false;
 	reader->batch_done = false;
 }
@@ -904,7 +904,7 @@ void
 TupleBufferBatchReaderTrySleep(TupleBufferBatchReader *reader, TimestampTz last_processed)
 {
 	if (!TupleBufferHasUnreadSlots(reader->rdr) &&
-			TimestampDifferenceExceeds(last_processed, GetCurrentTimestamp(), reader->params->empty_sleep))
+			TimestampDifferenceExceeds(last_processed, GetCurrentTimestamp(), reader->params->max_wait))
 	{
 		cq_stat_report(true);
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2594,18 +2594,6 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"continuous_query_empty_sleep", PGC_SIGHUP, QUERY_TUNING,
-		 gettext_noop("Sets the time a continuous query process will wait for new data to arrive before going to sleep."),
-		 gettext_noop("A higher value may cause a continuous query worker process to waste CPU cycles but it will sleep "
-					  "less often."),
-		 GUC_UNIT_MS
-		},
-		&continuous_query_empty_sleep,
-		5, 1, 60000,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"continuous_query_combiner_cache_mem", PGC_BACKEND, RESOURCES_MEM,
 		 gettext_noop("Sets the maximum memory to be used by the combiner for caching. This is independent of combiner_work_mem."),
 		 NULL,
@@ -2624,7 +2612,7 @@ static struct config_int ConfigureNamesInt[] =
 		 GUC_UNIT_MS
 		},
 		&continuous_query_max_wait,
-		5, 1, 60000,
+		25, 1, 60000,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/pipelinedb.conf.sample
+++ b/src/backend/utils/misc/pipelinedb.conf.sample
@@ -598,10 +598,6 @@
 # size of the buffer for storing unread stream tuples
 #tuple_buffer_blocks = 128MB
 
-# time in milliseconds that a continuous query process will wait for new data
-# to arrive before going to sleep
-#continuous_query_empty_sleep = 250
-
 # synchronization level for combiner commits; off, local, remote_write, or on
 #continuous_query_combiner_synchronous_commit = off
 
@@ -617,7 +613,7 @@
 
 # the time in milliseconds a continuous query process will wait for a batch
 # to accumulate
-# continuous_query_max_wait = 5
+# continuous_query_max_wait = 25
 
 # the maximum number of events to accumulate before executing a continuous query
 # plan on them

--- a/src/include/pipeline/cont_scheduler.h
+++ b/src/include/pipeline/cont_scheduler.h
@@ -51,7 +51,6 @@ typedef struct
 {
 	int batch_size;
 	int max_wait;
-	int empty_sleep;
 } ContQueryRunParams;
 
 /* per proc structures */
@@ -65,7 +64,6 @@ extern int continuous_query_num_combiners;
 extern int continuous_query_num_workers;
 extern int continuous_query_batch_size;
 extern int continuous_query_max_wait;
-extern int continuous_query_empty_sleep;
 extern int continuous_query_combiner_work_mem;
 extern int continuous_query_combiner_cache_mem;
 extern int continuous_query_combiner_synchronous_commit;


### PR DESCRIPTION
Don't think it's that useful to tune it, we just use `max_wait` as the sleep time now. Also increased the default from 5ms to 25ms.