### PR TITLE
#1057 Use 5432 as the default port

### DIFF
--- a/bin/run-dev
+++ b/bin/run-dev
@@ -111,7 +111,7 @@ if __name__ == '__main__':
   parser.add_argument('--stmt', action='append', dest='stmts', required=False,
                       help='SQL statements to run after all daemons are running')
   parser.add_argument('--port', action='store', dest='port', required=False,
-                      default='6543', help='Server port to connect to')
+                      default='5432', help='Server port to connect to')
   parser.add_argument('--gucs', action='store', dest='gucs', required=False,
                       nargs='*',
                       help='GUC parameters to pass to the postmaster')

--- a/configure
+++ b/configure
@@ -1495,7 +1495,7 @@ Optional Packages:
   --with-includes=DIRS    look for additional header files in DIRS
   --with-libraries=DIRS   look for additional libraries in DIRS
   --with-libs=DIRS        alternative spelling of --with-libraries
-  --with-pgport=PORTNUM   set default port number [6543]
+  --with-pgport=PORTNUM   set default port number [5432]
   --with-blocksize=BLOCKSIZE
                           set table block size in kB [8]
   --with-segsize=SEGSIZE  set table segment size in GB [1]
@@ -3054,7 +3054,7 @@ $as_echo "$enable_nls" >&6; }
 
 
 #
-# Default port number (--with-pgport), default 6543
+# Default port number (--with-pgport), default 5432
 #
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for default port number" >&5
 $as_echo_n "checking for default port number... " >&6; }
@@ -3077,7 +3077,7 @@ if test "${with_pgport+set}" = set; then :
   esac
 
 else
-  default_port=6543
+  default_port=5432
 fi
 
 

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -11,6 +11,6 @@ COPY scripts /scripts/
 
 RUN /scripts/install_pipeline.sh
 
-EXPOSE 6543
+EXPOSE 5432
 
 CMD ["/scripts/startpipeline"]

--- a/pkg/docker/scripts/conf/pipelinedb.conf
+++ b/pkg/docker/scripts/conf/pipelinedb.conf
@@ -11,7 +11,7 @@
 
 listen_addresses = '*'
 max_connections = 25
-port = 6543
+port = 5432
 
 # RESOURCES
 

--- a/pkg/docker/scripts/install_pipeline.sh
+++ b/pkg/docker/scripts/install_pipeline.sh
@@ -7,7 +7,7 @@ apt-get -f install
 apt-get install -y wget nano
 
 # install dependencies
-apt-get install -y libxml2 libxml2-dev libcurl3
+apt-get install -y libxml2 libxml2-dev
 
 wget http://www.pipelinedb.com/download/0.7.7/ubuntu14
 


### PR DESCRIPTION
@jberkus We're now using 5432 as the default port to avoid conflicts with existing libpq installations. I updated the Docker scripts to reflect this (we also removed the dependency on `libcurl`).