### PR TITLE
#1083 Display continuous view definition when describing a continuous…

### DIFF
--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -466,6 +466,7 @@ GetContinuousView(Oid id)
 	view->id = id;
 
 	namespace = get_namespace_name(row->namespace);
+	view->namespace = row->namespace;
 	view->matrel = makeRangeVar(namespace, pstrdup(NameStr(row->matrelname)), -1);
 
 	namestrcpy(&view->name, NameStr(row->name));

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5399,6 +5399,9 @@ DESCR("generic user finalize function");
 DATA(insert OID = 4389 ( pipeline_stat_get PGNSP PGUID 12 1 1 0 0 f f f f t t s 0 0 2249 "" "{25,1184,20,20,20,20,20,20,20,20,20,20}" "{o,o,o,o,o,o,o,o,o,o,o,o}" "{type,start_time,input_rows,output_rows,updates,input_bytes,output_bytes,updated_bytes,executions,errors,cv_create,cv_drop}" _null_ pipeline_stat_get _null_ _null_ _null_ ));
 DESCR("global pipelinedb status");
 
+DATA(insert OID = 4390 ( pipeline_get_overlay_viewdef	   PGNSP PGUID 12 1 0 0 0 f f f f t f s 1 0 25 "25" _null_ _null_ _null_ _null_ pipeline_get_overlay_viewdef _null_ _null_ _null_ ));
+DESCR("gets a materialization table overlay view");
+
 /*
  * Symbolic values for provolatile column: these indicate whether the result
  * of a function is dependent *only* on the values of its explicit arguments,

--- a/src/include/utils/pipelinefuncs.h
+++ b/src/include/utils/pipelinefuncs.h
@@ -14,6 +14,8 @@
 #ifndef CQSTATFUNCS_H
 #define CQSTATFUNCS_H
 
+#define DISPLAY_OVERLAY_VIEW -2
+
 /* continuous query process stats */
 extern Datum cq_proc_stat_get(PG_FUNCTION_ARGS);
 
@@ -31,5 +33,8 @@ extern Datum pipeline_streams(PG_FUNCTION_ARGS);
 
 /* global pipeline stats */
 extern Datum pipeline_stat_get(PG_FUNCTION_ARGS);
+
+/* matrel overlay view definition */
+extern Datum pipeline_get_overlay_viewdef(PG_FUNCTION_ARGS);
 
 #endif

--- a/src/test/regress/expected/cont_window.out
+++ b/src/test/regress/expected/cont_window.out
@@ -17,9 +17,17 @@ Options: fillfactor=50
  key    | text(0) |           | extended | 
  sum    | numeric |           | main     | 
 View definition:
- SELECT cqwindow0_mrel0.key,
-    combine(naggstaterecv(cqwindow0_mrel0.sum)) OVER (PARTITION BY cqwindow0_mrel0.key ORDER BY cqwindow0_mrel0._0 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS sum
-   FROM cqwindow0_mrel0;
+ SELECT key::text,
+    sum(x::numeric) OVER (PARTITION BY key::text ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS sum
+   FROM ONLY cqwindow_stream;
+
+SELECT pipeline_get_overlay_viewdef('cqwindow0');
+                                                                    pipeline_get_overlay_viewdef                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT cqwindow0_mrel0.key,                                                                                                                                       +
+     combine(naggstaterecv(cqwindow0_mrel0.sum)) OVER (PARTITION BY cqwindow0_mrel0.key ORDER BY cqwindow0_mrel0._0 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS sum+
+    FROM cqwindow0_mrel0;
+(1 row)
 
 INSERT INTO cqwindow_stream (key, x) VALUES ('a', 1), ('b', 2);
 SELECT pg_sleep(1);
@@ -75,9 +83,17 @@ Options: fillfactor=50
  key    | text(0) |           | extended | 
  avg    | numeric |           | main     | 
 View definition:
- SELECT cqwindow1_mrel0.key,
-    combine(cqwindow1_mrel0.avg) OVER (PARTITION BY cqwindow1_mrel0.key ORDER BY cqwindow1_mrel0._0 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg
-   FROM cqwindow1_mrel0;
+ SELECT key::text,
+    avg(x::integer) OVER (PARTITION BY key::text ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg
+   FROM ONLY cqwindow_stream;
+
+SELECT pipeline_get_overlay_viewdef('cqwindow1');
+                                                             pipeline_get_overlay_viewdef                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT cqwindow1_mrel0.key,                                                                                                                        +
+     combine(cqwindow1_mrel0.avg) OVER (PARTITION BY cqwindow1_mrel0.key ORDER BY cqwindow1_mrel0._0 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg+
+    FROM cqwindow1_mrel0;
+(1 row)
 
 INSERT INTO cqwindow_stream (key, x) VALUES ('a', 1), ('b', 2), ('a', 3);
 SELECT pg_sleep(1);

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -1,12 +1,12 @@
 -- Simple ones
 CREATE CONTINUOUS VIEW cqcreate0 AS SELECT key::integer FROM create_cont_stream1;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate0';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate0';
  count 
 -------
      1
 (1 row)
 
-SELECT gc FROM pipeline_query WHERE name='cqcreate0';
+SELECT gc FROM pipeline_query WHERE name = 'cqcreate0';
  gc 
 ----
  f
@@ -18,8 +18,8 @@ SELECT gc FROM pipeline_query WHERE name='cqcreate0';
 --------+---------+-----------+---------+-------------
  key    | integer |           | plain   | 
 View definition:
- SELECT cqcreate0_mrel0.key
-   FROM cqcreate0_mrel0;
+ SELECT key::integer
+   FROM ONLY create_cont_stream1;
 
 \d+ cqcreate0_mrel0;
                    Table "public.cqcreate0_mrel0"
@@ -28,8 +28,15 @@ View definition:
  key    | integer |           | plain   |              | 
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate0');
+ pipeline_get_overlay_viewdef 
+------------------------------
+  SELECT cqcreate0_mrel0.key +
+    FROM cqcreate0_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqcreate1 AS SELECT substring(url::text, 1, 2) FROM create_cont_stream1;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate1';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate1';
  count 
 -------
      1
@@ -41,8 +48,8 @@ SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate1';
 -----------+------+-----------+----------+-------------
  substring | text |           | extended | 
 View definition:
- SELECT cqcreate1_mrel0."substring"
-   FROM cqcreate1_mrel0;
+ SELECT "substring"(url::text, 1, 2) AS "substring"
+   FROM ONLY create_cont_stream1;
 
 \d+ cqcreate1_mrel0;
                     Table "public.cqcreate1_mrel0"
@@ -51,8 +58,15 @@ View definition:
  substring | text |           | extended |              | 
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate1');
+    pipeline_get_overlay_viewdef     
+-------------------------------------
+  SELECT cqcreate1_mrel0."substring"+
+    FROM cqcreate1_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqcreate2 AS SELECT key::integer, substring(value::text, 1, 2) AS s FROM create_cont_stream1;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate2';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate2';
  count 
 -------
      1
@@ -65,9 +79,9 @@ SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate2';
  key    | integer |           | plain    | 
  s      | text    |           | extended | 
 View definition:
- SELECT cqcreate2_mrel0.key,
-    cqcreate2_mrel0.s
-   FROM cqcreate2_mrel0;
+ SELECT key::integer,
+    "substring"(value::text, 1, 2) AS s
+   FROM ONLY create_cont_stream1;
 
 \d+ cqcreate2_mrel0;
                     Table "public.cqcreate2_mrel0"
@@ -77,9 +91,17 @@ View definition:
  s      | text    |           | extended |              | 
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate2');
+ pipeline_get_overlay_viewdef 
+------------------------------
+  SELECT cqcreate2_mrel0.key,+
+     cqcreate2_mrel0.s       +
+    FROM cqcreate2_mrel0;
+(1 row)
+
 -- Group by projections
 CREATE CONTINUOUS VIEW cqcreate3 AS SELECT key::text, COUNT(*), SUM(value::int8) FROM cont_create_stream2 GROUP BY key;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate3';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate3';
  count 
 -------
      1
@@ -93,10 +115,11 @@ SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate3';
  count  | bigint  |           | plain    | 
  sum    | numeric |           | main     | 
 View definition:
- SELECT cqcreate3_mrel0.key,
-    cqcreate3_mrel0.count,
-    numeric_sum(naggstaterecv(cqcreate3_mrel0.sum)) AS sum
-   FROM cqcreate3_mrel0;
+ SELECT key::text,
+    count(*) AS count,
+    sum(value::bigint) AS sum
+   FROM ONLY cont_create_stream2
+  GROUP BY key::text;
 
 \d+ cqcreate3_mrel0;
                     Table "public.cqcreate3_mrel0"
@@ -109,8 +132,17 @@ Indexes:
     "cqcreate3_mrel0_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate3');
+                pipeline_get_overlay_viewdef                
+------------------------------------------------------------
+  SELECT cqcreate3_mrel0.key,                              +
+     cqcreate3_mrel0.count,                                +
+     numeric_sum(naggstaterecv(cqcreate3_mrel0.sum)) AS sum+
+    FROM cqcreate3_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM cont_create_stream2 GROUP BY key::text;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate4';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate4';
  count 
 -------
      1
@@ -123,9 +155,10 @@ SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate4';
  count  | bigint  |           | plain   | 
  sum    | numeric |           | main    | 
 View definition:
- SELECT cqcreate4_mrel0.count,
-    numeric_sum(naggstaterecv(cqcreate4_mrel0.sum)) AS sum
-   FROM cqcreate4_mrel0;
+ SELECT count(*) AS count,
+    sum(value::bigint) AS sum
+   FROM ONLY cont_create_stream2
+  GROUP BY key::text;
 
 \d+ cqcreate4_mrel0;
                     Table "public.cqcreate4_mrel0"
@@ -138,17 +171,25 @@ Indexes:
     "cqcreate4_mrel0_expr_idx" btree (hash_group(_0))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate4');
+                pipeline_get_overlay_viewdef                
+------------------------------------------------------------
+  SELECT cqcreate4_mrel0.count,                            +
+     numeric_sum(naggstaterecv(cqcreate4_mrel0.sum)) AS sum+
+    FROM cqcreate4_mrel0;
+(1 row)
+
 -- Sliding window queries
 CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second);
 NOTICE:  window width is "5" with a step size of "1 second"
 HINT:  Use a datetime truncation function to explicitly set the step size.
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate5';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate5';
  count 
 -------
      1
 (1 row)
 
-SELECT gc FROM pipeline_query WHERE name='cqcreate5';
+SELECT gc FROM pipeline_query WHERE name = 'cqcreate5';
  gc 
 ----
  t
@@ -160,9 +201,9 @@ SELECT gc FROM pipeline_query WHERE name='cqcreate5';
 --------+---------+-----------+----------+-------------
  key    | text(0) |           | extended | 
 View definition:
- SELECT cqcreate5_mrel0.key
-   FROM cqcreate5_mrel0
-  WHERE cqcreate5_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second);
+ SELECT key::text
+   FROM ONLY cont_create_stream2
+  WHERE arrival_timestamp::timestamp with time zone > (clock_timestamp() - '@ 5 secs'::interval second);
 
 \d+ cqcreate5_mrel0;
                               Table "public.cqcreate5_mrel0"
@@ -174,16 +215,24 @@ Indexes:
     "cqcreate5_mrel0__0_idx" btree (_0)
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate5');
+                           pipeline_get_overlay_viewdef                            
+-----------------------------------------------------------------------------------
+  SELECT cqcreate5_mrel0.key                                                      +
+    FROM cqcreate5_mrel0                                                          +
+   WHERE (cqcreate5_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second));
+(1 row)
+
 CREATE CONTINUOUS VIEW cqcreate6 AS SELECT COUNT(*) FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key::text;
 NOTICE:  window width is "5" with a step size of "1 second"
 HINT:  Use a datetime truncation function to explicitly set the step size.
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate6';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate6';
  count 
 -------
      1
 (1 row)
 
-SELECT gc FROM pipeline_query WHERE name='cqcreate5';
+SELECT gc FROM pipeline_query WHERE name = 'cqcreate6';
  gc 
 ----
  t
@@ -195,10 +244,10 @@ SELECT gc FROM pipeline_query WHERE name='cqcreate5';
 --------+--------+-----------+---------+-------------
  count  | bigint |           | plain   | 
 View definition:
- SELECT combine(cqcreate6_mrel0.count) AS count
-   FROM cqcreate6_mrel0
-  WHERE cqcreate6_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second)
-  GROUP BY cqcreate6_mrel0._1;
+ SELECT count(*) AS count
+   FROM ONLY cont_create_stream2
+  WHERE arrival_timestamp::timestamp with time zone > (clock_timestamp() - '@ 5 secs'::interval second)
+  GROUP BY key::text;
 
 \d+ cqcreate6_mrel0;
                             Table "public.cqcreate6_mrel0"
@@ -211,6 +260,15 @@ Indexes:
     "cqcreate6_mrel0_expr_idx" btree (ls_hash_group(_1, _0))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqcreate6');
+                           pipeline_get_overlay_viewdef                           
+----------------------------------------------------------------------------------
+  SELECT combine(cqcreate6_mrel0.count) AS count                                 +
+    FROM cqcreate6_mrel0                                                         +
+   WHERE (cqcreate6_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second))+
+   GROUP BY cqcreate6_mrel0._1;
+(1 row)
+
 -- These use a combine state column
 CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, AVG(y::integer) AS int_avg, AVG(ts0::timestamp - ts1::timestamp) AS internal_avg FROM cont_create_stream2 GROUP BY key;
 \d+ cvavg;
@@ -222,11 +280,12 @@ CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, A
  int_avg      | numeric          |           | main     | 
  internal_avg | interval         |           | plain    | 
 View definition:
- SELECT cvavg_mrel0.key,
-    float8_avg(cvavg_mrel0.float_avg) AS float_avg,
-    int8_avg(cvavg_mrel0.int_avg) AS int_avg,
-    interval_avg(cvavg_mrel0.internal_avg) AS internal_avg
-   FROM cvavg_mrel0;
+ SELECT key::text,
+    avg(x::double precision) AS float_avg,
+    avg(y::integer) AS int_avg,
+    avg(ts0::timestamp without time zone - ts1::timestamp without time zone) AS internal_avg
+   FROM ONLY cont_create_stream2
+  GROUP BY key::text;
 
 \d+ cvavg_mrel0;
                               Table "public.cvavg_mrel0"
@@ -240,6 +299,16 @@ Indexes:
     "cvavg_mrel0_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cvavg');
+                pipeline_get_overlay_viewdef                
+------------------------------------------------------------
+  SELECT cvavg_mrel0.key,                                  +
+     float8_avg(cvavg_mrel0.float_avg) AS float_avg,       +
+     int8_avg(cvavg_mrel0.int_avg) AS int_avg,             +
+     interval_avg(cvavg_mrel0.internal_avg) AS internal_avg+
+    FROM cvavg_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM create_cont_stream1;
 \d+ cvjson;
                  View "public.cvjson"
@@ -247,8 +316,8 @@ CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM crea
 -----------+------+-----------+----------+-------------
  count_col | json |           | extended | 
 View definition:
- SELECT json_agg_finalfn(byteatostringinfo(cvjson_mrel0.count_col)) AS count_col
-   FROM cvjson_mrel0;
+ SELECT json_agg(x::text) AS count_col
+   FROM ONLY create_cont_stream1;
 
 \d+ cvjson_mrel0;
                       Table "public.cvjson_mrel0"
@@ -257,6 +326,13 @@ View definition:
  count_col | bytea |           | extended |              | 
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cvjson');
+                           pipeline_get_overlay_viewdef                           
+----------------------------------------------------------------------------------
+  SELECT json_agg_finalfn(byteatostringinfo(cvjson_mrel0.count_col)) AS count_col+
+    FROM cvjson_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cvjsonobj AS SELECT json_object_agg(key::text, value::integer) FROM cont_create_stream2;
 \d+ cvjsonobj;
                    View "public.cvjsonobj"
@@ -264,8 +340,8 @@ CREATE CONTINUOUS VIEW cvjsonobj AS SELECT json_object_agg(key::text, value::int
 -----------------+------+-----------+----------+-------------
  json_object_agg | json |           | extended | 
 View definition:
- SELECT json_object_agg_finalfn(byteatostringinfo(cvjsonobj_mrel0.json_object_agg)) AS json_object_agg
-   FROM cvjsonobj_mrel0;
+ SELECT json_object_agg(key::text, value::integer) AS json_object_agg
+   FROM ONLY cont_create_stream2;
 
 \d+ cvjsonobj_mrel0;
                        Table "public.cvjsonobj_mrel0"
@@ -273,6 +349,13 @@ View definition:
 -----------------+-------+-----------+----------+--------------+-------------
  json_object_agg | bytea |           | extended |              | 
 Options: fillfactor=50
+
+SELECT pipeline_get_overlay_viewdef('cvjsonobj');
+                                      pipeline_get_overlay_viewdef                                      
+--------------------------------------------------------------------------------------------------------
+  SELECT json_object_agg_finalfn(byteatostringinfo(cvjsonobj_mrel0.json_object_agg)) AS json_object_agg+
+    FROM cvjsonobj_mrel0;
+(1 row)
 
 -- But these aggregates don't
 CREATE CONTINUOUS VIEW cvcount AS SELECT SUM(x::integer + y::float8) AS sum_col FROM cont_create_stream2;
@@ -282,8 +365,8 @@ CREATE CONTINUOUS VIEW cvcount AS SELECT SUM(x::integer + y::float8) AS sum_col 
 ---------+------------------+-----------+---------+-------------
  sum_col | double precision |           | plain   | 
 View definition:
- SELECT cvcount_mrel0.sum_col
-   FROM cvcount_mrel0;
+ SELECT sum(x::integer::double precision + y::double precision) AS sum_col
+   FROM ONLY cont_create_stream2;
 
 \d+ cvcount_mrel0;
                          Table "public.cvcount_mrel0"
@@ -292,6 +375,13 @@ View definition:
  sum_col | double precision |           | plain   |              | 
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cvcount');
+ pipeline_get_overlay_viewdef  
+-------------------------------
+  SELECT cvcount_mrel0.sum_col+
+    FROM cvcount_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cvarray AS SELECT COUNT(*) as count_col FROM create_cont_stream1;
 \d+ cvarray;
                  View "public.cvarray"
@@ -299,8 +389,8 @@ CREATE CONTINUOUS VIEW cvarray AS SELECT COUNT(*) as count_col FROM create_cont_
 -----------+--------+-----------+---------+-------------
  count_col | bigint |           | plain   | 
 View definition:
- SELECT cvarray_mrel0.count_col
-   FROM cvarray_mrel0;
+ SELECT count(*) AS count_col
+   FROM ONLY create_cont_stream1;
 
 \d+ cvarray_mrel0;
                      Table "public.cvarray_mrel0"
@@ -308,6 +398,13 @@ View definition:
 -----------+--------+-----------+---------+--------------+-------------
  count_col | bigint |           | plain   |              | 
 Options: fillfactor=50
+
+SELECT pipeline_get_overlay_viewdef('cvarray');
+  pipeline_get_overlay_viewdef   
+---------------------------------
+  SELECT cvarray_mrel0.count_col+
+    FROM cvarray_mrel0;
+(1 row)
 
 CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text, 1, 2), ',') FROM cont_create_stream2 GROUP BY key;
 \d+ cvtext;
@@ -317,9 +414,10 @@ CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text,
  key        | text(0) |           | extended | 
  string_agg | text    |           | extended | 
 View definition:
- SELECT cvtext_mrel0.key,
-    string_agg_finalfn(stringaggstaterecv(cvtext_mrel0.string_agg)) AS string_agg
-   FROM cvtext_mrel0;
+ SELECT key::text,
+    string_agg("substring"(s::text, 1, 2), ','::text) AS string_agg
+   FROM ONLY cont_create_stream2
+  GROUP BY key::text;
 
 \d+ cvtext_mrel0;
                        Table "public.cvtext_mrel0"
@@ -331,6 +429,14 @@ Indexes:
     "cvtext_mrel0_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cvtext');
+                           pipeline_get_overlay_viewdef                            
+-----------------------------------------------------------------------------------
+  SELECT cvtext_mrel0.key,                                                        +
+     string_agg_finalfn(stringaggstaterecv(cvtext_mrel0.string_agg)) AS string_agg+
+    FROM cvtext_mrel0;
+(1 row)
+
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM cont_create_stream2;
 \d+ cqaggexpr1;
@@ -339,8 +445,8 @@ CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM cont_cre
 ----------+--------+-----------+---------+-------------
  ?column? | bigint |           | plain   | 
 View definition:
- SELECT cqaggexpr1_mrel0._0 + cqaggexpr1_mrel0._1
-   FROM cqaggexpr1_mrel0;
+ SELECT count(*) + sum(x::integer)
+   FROM ONLY cont_create_stream2;
 
 \d+ cqaggexpr1_mrel0;
                   Table "public.cqaggexpr1_mrel0"
@@ -350,6 +456,13 @@ View definition:
  _1     | bigint |           | plain   |              | 
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
+            pipeline_get_overlay_viewdef             
+-----------------------------------------------------
+  SELECT (cqaggexpr1_mrel0._0 + cqaggexpr1_mrel0._1)+
+    FROM cqaggexpr1_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::integer) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr2;
                     View "public.cqaggexpr2"
@@ -358,9 +471,10 @@ CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::in
  key    | text(0)          |           | extended | 
  value  | double precision |           | plain    | 
 View definition:
- SELECT cqaggexpr2_mrel0.key,
-    float8_avg(cqaggexpr2_mrel0._0) + cqaggexpr2_mrel0._1::double precision AS value
-   FROM cqaggexpr2_mrel0;
+ SELECT key::text,
+    avg(x::double precision) OPERATOR(pg_catalog.+) max(y::integer)::double precision AS value
+   FROM ONLY cont_create_stream2
+  GROUP BY key::text;
 
 \d+ cqaggexpr2_mrel0;
                          Table "public.cqaggexpr2_mrel0"
@@ -373,6 +487,14 @@ Indexes:
     "cqaggexpr2_mrel0_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
+                               pipeline_get_overlay_viewdef                               
+------------------------------------------------------------------------------------------
+  SELECT cqaggexpr2_mrel0.key,                                                           +
+     (float8_avg(cqaggexpr2_mrel0._0) + (cqaggexpr2_mrel0._1)::double precision) AS value+
+    FROM cqaggexpr2_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key;
 NOTICE:  window width is "5" with a step size of "1 second"
 HINT:  Use a datetime truncation function to explicitly set the step size.
@@ -383,11 +505,11 @@ HINT:  Use a datetime truncation function to explicitly set the step size.
  key    | text(0) |           | extended | 
  value  | bigint  |           | plain    | 
 View definition:
- SELECT cqaggexpr3_mrel0.key,
-    combine(cqaggexpr3_mrel0.value) AS value
-   FROM cqaggexpr3_mrel0
-  WHERE cqaggexpr3_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second)
-  GROUP BY cqaggexpr3_mrel0.key;
+ SELECT key::text,
+    count(*) AS value
+   FROM ONLY cont_create_stream2
+  WHERE arrival_timestamp::timestamp with time zone > (clock_timestamp() - '@ 5 secs'::interval second)
+  GROUP BY key::text;
 
 \d+ cqaggexpr3_mrel0;
                             Table "public.cqaggexpr3_mrel0"
@@ -400,6 +522,16 @@ Indexes:
     "cqaggexpr3_mrel0_expr_idx" btree (ls_hash_group(key, _0))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
+                           pipeline_get_overlay_viewdef                            
+-----------------------------------------------------------------------------------
+  SELECT cqaggexpr3_mrel0.key,                                                    +
+     combine(cqaggexpr3_mrel0.value) AS value                                     +
+    FROM cqaggexpr3_mrel0                                                         +
+   WHERE (cqaggexpr3_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second))+
+   GROUP BY cqaggexpr3_mrel0.key;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr4;
                     View "public.cqaggexpr4"
@@ -408,9 +540,10 @@ CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS v
  key    | text(0)          |           | extended | 
  value  | double precision |           | plain    | 
 View definition:
- SELECT cqaggexpr4_mrel0.key,
-    floor(float8_avg(cqaggexpr4_mrel0._0)) AS value
-   FROM cqaggexpr4_mrel0;
+ SELECT key::text,
+    pg_catalog.floor(avg(x::double precision)) AS value
+   FROM ONLY cont_create_stream2
+  GROUP BY key::text;
 
 \d+ cqaggexpr4_mrel0;
                          Table "public.cqaggexpr4_mrel0"
@@ -422,6 +555,14 @@ Indexes:
     "cqaggexpr4_mrel0_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
+            pipeline_get_overlay_viewdef             
+-----------------------------------------------------
+  SELECT cqaggexpr4_mrel0.key,                      +
+     floor(float8_avg(cqaggexpr4_mrel0._0)) AS value+
+    FROM cqaggexpr4_mrel0;
+(1 row)
+
 CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM create_cont_stream1 GROUP BY k0, k1;
 \d+ cqgroupby
                 View "public.cqgroupby"
@@ -431,10 +572,11 @@ CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM 
  k1     | integer |           | plain    | 
  count  | bigint  |           | plain    | 
 View definition:
- SELECT cqgroupby_mrel0.k0,
-    cqgroupby_mrel0.k1,
-    cqgroupby_mrel0.count
-   FROM cqgroupby_mrel0;
+ SELECT k0::text,
+    k1::integer,
+    count(*) AS count
+   FROM ONLY create_cont_stream1
+  GROUP BY k0::text, k1::integer;
 
 \d+ cqgroupby_mrel0;
                     Table "public.cqgroupby_mrel0"
@@ -446,6 +588,15 @@ View definition:
 Indexes:
     "cqgroupby_mrel0_expr_idx" btree (hash_group(k0, k1))
 Options: fillfactor=50
+
+SELECT pipeline_get_overlay_viewdef('cqgroupby');
+ pipeline_get_overlay_viewdef 
+------------------------------
+  SELECT cqgroupby_mrel0.k0, +
+     cqgroupby_mrel0.k1,     +
+     cqgroupby_mrel0.count   +
+    FROM cqgroupby_mrel0;
+(1 row)
 
 CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM create_cont_stream1
 GROUP BY a, b, c, d, e;
@@ -460,13 +611,14 @@ GROUP BY a, b, c, d, e;
  e      | double precision |           | plain    | 
  count  | bigint           |           | plain    | 
 View definition:
- SELECT multigroupindex_mrel0.a,
-    multigroupindex_mrel0.b,
-    multigroupindex_mrel0.c,
-    multigroupindex_mrel0.d,
-    multigroupindex_mrel0.e,
-    multigroupindex_mrel0.count
-   FROM multigroupindex_mrel0;
+ SELECT a::text,
+    b::bigint,
+    c::integer,
+    d::smallint,
+    e::double precision,
+    count(*) AS count
+   FROM ONLY create_cont_stream1
+  GROUP BY a::text, b::bigint, c::integer, d::smallint, e::double precision;
 
 \d+ multigroupindex_mrel0;
                      Table "public.multigroupindex_mrel0"
@@ -481,6 +633,18 @@ View definition:
 Indexes:
     "multigroupindex_mrel0_expr_idx" btree (hash_group(a, b, c, d, e))
 Options: fillfactor=50
+
+SELECT pipeline_get_overlay_viewdef('multigroupindex');
+   pipeline_get_overlay_viewdef   
+----------------------------------
+  SELECT multigroupindex_mrel0.a,+
+     multigroupindex_mrel0.b,    +
+     multigroupindex_mrel0.c,    +
+     multigroupindex_mrel0.d,    +
+     multigroupindex_mrel0.e,    +
+     multigroupindex_mrel0.count +
+    FROM multigroupindex_mrel0;
+(1 row)
 
 -- A user-specified fillfactor should override the default
 CREATE CONTINUOUS VIEW withff WITH (fillfactor = 42) AS SELECT COUNT(*) FROM stream;

--- a/src/test/regress/sql/cont_window.sql
+++ b/src/test/regress/sql/cont_window.sql
@@ -1,6 +1,7 @@
 CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PARTITION BY key ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM cqwindow_stream;
 \d+ cqwindow0_mrel0;
 \d+ cqwindow0;
+SELECT pipeline_get_overlay_viewdef('cqwindow0');
 
 INSERT INTO cqwindow_stream (key, x) VALUES ('a', 1), ('b', 2);
 SELECT pg_sleep(1);
@@ -15,6 +16,7 @@ SELECT * FROM cqwindow0 ORDER BY key;
 CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITION BY key ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) FROM cqwindow_stream;
 \d+ cqwindow1_mrel0;
 \d+ cqwindow1;
+SELECT pipeline_get_overlay_viewdef('cqwindow1');
 
 INSERT INTO cqwindow_stream (key, x) VALUES ('a', 1), ('b', 2), ('a', 3);
 SELECT pg_sleep(1);

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -1,92 +1,115 @@
 -- Simple ones
 CREATE CONTINUOUS VIEW cqcreate0 AS SELECT key::integer FROM create_cont_stream1;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate0';
-SELECT gc FROM pipeline_query WHERE name='cqcreate0';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate0';
+SELECT gc FROM pipeline_query WHERE name = 'cqcreate0';
 \d+ cqcreate0;
 \d+ cqcreate0_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate0');
+
 CREATE CONTINUOUS VIEW cqcreate1 AS SELECT substring(url::text, 1, 2) FROM create_cont_stream1;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate1';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate1';
 \d+ cqcreate1;
 \d+ cqcreate1_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate1');
+
 CREATE CONTINUOUS VIEW cqcreate2 AS SELECT key::integer, substring(value::text, 1, 2) AS s FROM create_cont_stream1;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate2';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate2';
 \d+ cqcreate2;
 \d+ cqcreate2_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate2');
 
 -- Group by projections
 CREATE CONTINUOUS VIEW cqcreate3 AS SELECT key::text, COUNT(*), SUM(value::int8) FROM cont_create_stream2 GROUP BY key;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate3';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate3';
 \d+ cqcreate3;
 \d+ cqcreate3_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate3');
+
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM cont_create_stream2 GROUP BY key::text;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate4';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate4';
 \d+ cqcreate4;
 \d+ cqcreate4_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate4');
 
 -- Sliding window queries
 CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second);
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate5';
-SELECT gc FROM pipeline_query WHERE name='cqcreate5';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate5';
+SELECT gc FROM pipeline_query WHERE name = 'cqcreate5';
 \d+ cqcreate5;
 \d+ cqcreate5_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate5');
+
 CREATE CONTINUOUS VIEW cqcreate6 AS SELECT COUNT(*) FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key::text;
-SELECT COUNT(*) FROM pipeline_query WHERE name='cqcreate6';
-SELECT gc FROM pipeline_query WHERE name='cqcreate5';
+SELECT COUNT(*) FROM pipeline_query WHERE name = 'cqcreate6';
+SELECT gc FROM pipeline_query WHERE name = 'cqcreate6';
 \d+ cqcreate6;
 \d+ cqcreate6_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqcreate6');
 
 -- These use a combine state column
 CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, AVG(y::integer) AS int_avg, AVG(ts0::timestamp - ts1::timestamp) AS internal_avg FROM cont_create_stream2 GROUP BY key;
 \d+ cvavg;
 \d+ cvavg_mrel0;
+SELECT pipeline_get_overlay_viewdef('cvavg');
 
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM create_cont_stream1;
 \d+ cvjson;
 \d+ cvjson_mrel0;
+SELECT pipeline_get_overlay_viewdef('cvjson');
 
 CREATE CONTINUOUS VIEW cvjsonobj AS SELECT json_object_agg(key::text, value::integer) FROM cont_create_stream2;
 \d+ cvjsonobj;
 \d+ cvjsonobj_mrel0;
+SELECT pipeline_get_overlay_viewdef('cvjsonobj');
 
 -- But these aggregates don't
 CREATE CONTINUOUS VIEW cvcount AS SELECT SUM(x::integer + y::float8) AS sum_col FROM cont_create_stream2;
 \d+ cvcount;
 \d+ cvcount_mrel0;
+SELECT pipeline_get_overlay_viewdef('cvcount');
 
 CREATE CONTINUOUS VIEW cvarray AS SELECT COUNT(*) as count_col FROM create_cont_stream1;
 \d+ cvarray;
 \d+ cvarray_mrel0;
+SELECT pipeline_get_overlay_viewdef('cvarray');
 
 CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text, 1, 2), ',') FROM cont_create_stream2 GROUP BY key;
 \d+ cvtext;
 \d+ cvtext_mrel0;
+SELECT pipeline_get_overlay_viewdef('cvtext');
 
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM cont_create_stream2;
 \d+ cqaggexpr1;
 \d+ cqaggexpr1_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
 
 CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::integer) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr2;
 \d+ cqaggexpr2_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
 
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5' second) GROUP BY key;
 \d+ cqaggexpr3;
 \d+ cqaggexpr3_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
 
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr4;
 \d+ cqaggexpr4_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
 
 CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM create_cont_stream1 GROUP BY k0, k1;
 \d+ cqgroupby
 \d+ cqgroupby_mrel0;
+SELECT pipeline_get_overlay_viewdef('cqgroupby');
 
 CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM create_cont_stream1
 GROUP BY a, b, c, d, e;
 
 \d+ multigroupindex;
 \d+ multigroupindex_mrel0;
+SELECT pipeline_get_overlay_viewdef('multigroupindex');
 
 -- A user-specified fillfactor should override the default
 CREATE CONTINUOUS VIEW withff WITH (fillfactor = 42) AS SELECT COUNT(*) FROM stream;


### PR DESCRIPTION
`\d` on a continuous view will now show the CV's definition. Overlay views can be retrieved via:

    SELECT pipeline_get_overlay_viewdef('cv name')