### PR TITLE
#1058 Expose step column as arrival_timestamp in matrels to make it m…

### DIFF
--- a/src/backend/pipeline/cont_analyze.c
+++ b/src/backend/pipeline/cont_analyze.c
@@ -1873,6 +1873,8 @@ hoist_node(List **target_list, Node *node, ContAnalyzeContext *context)
 	if (rt == NULL)
 	{
 		rt = create_unique_res_target(node, context);
+		if (context->hoisted_name)
+			rt->name = context->hoisted_name;
 		*target_list = lappend(*target_list, rt);
 	}
 
@@ -2064,7 +2066,9 @@ hoist_time_node(SelectStmt *proc, Node *time, A_Expr *sw_expr, ContAnalyzeContex
 	}
 
 	time = context->expr;
+	context->hoisted_name = ARRIVAL_TIMESTAMP;
 	cref = hoist_node(&proc->targetList, time, context);
+	context->hoisted_name = NULL;
 
 	foreach(lc, proc->groupClause)
 	{

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -33,6 +33,7 @@ typedef struct ContAnalyzeContext
 	bool is_sw;
 	bool stream_only;
 	bool view_combines;
+	char *hoisted_name;
 	ContQueryProcType proc_type;
 } ContAnalyzeContext;
 

--- a/src/test/regress/expected/cont_distinct.out
+++ b/src/test/regress/expected/cont_distinct.out
@@ -63,13 +63,13 @@ SELECT * FROM test_distinct_sw_count;
 (1 row)
 
 \d+ test_distinct_sw_count_mrel0;
-                      Table "public.test_distinct_sw_count_mrel0"
- Column |           Type           | Modifiers | Storage  | Stats target | Description 
---------+--------------------------+-----------+----------+--------------+-------------
- _0     | timestamp with time zone |           | plain    |              | 
- count  | hll                      |           | extended |              | 
+                           Table "public.test_distinct_sw_count_mrel0"
+      Column       |           Type           | Modifiers | Storage  | Stats target | Description 
+-------------------+--------------------------+-----------+----------+--------------+-------------
+ arrival_timestamp | timestamp with time zone |           | plain    |              | 
+ count             | hll                      |           | extended |              | 
 Indexes:
-    "test_distinct_sw_count_mrel0_expr_idx" btree (ls_hash_group(_0))
+    "test_distinct_sw_count_mrel0_expr_idx" btree (ls_hash_group(arrival_timestamp))
 Options: fillfactor=50
 
 SELECT pg_sleep(1);

--- a/src/test/regress/expected/cont_sw_count.out
+++ b/src/test/regress/expected/cont_sw_count.out
@@ -26,3 +26,38 @@ SELECT * FROM test_count ORDER BY k;
 (2 rows)
 
 DROP CONTINUOUS VIEW test_count;
+CREATE CONTINUOUS VIEW sw_count0 AS SELECT COUNT(*) FROM cqswcount_stream WHERE arrival_timestamp > clock_timestamp() - interval '60 second';
+NOTICE:  window width is "60 second" with a step size of "1 second"
+HINT:  Use a datetime truncation function if you want to explicitly set the step size.
+CREATE VIEW sw_count1 AS SELECT combine(count) FROM sw_count0_mrel0 WHERE arrival_timestamp > clock_timestamp() - interval '2 second';
+INSERT INTO cqswcount_stream (k) VALUES ('x'), ('x');
+SELECT * FROM sw_count0;
+ count 
+-------
+     2
+(1 row)
+
+SELECT * FROM sw_count1;
+ combine 
+---------
+       2
+(1 row)
+
+SELECT pg_sleep(2.2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM sw_count0;
+ count 
+-------
+     2
+(1 row)
+
+SELECT * FROM sw_count1;
+ combine 
+---------
+       0
+(1 row)
+

--- a/src/test/regress/expected/cont_window.out
+++ b/src/test/regress/expected/cont_window.out
@@ -1,13 +1,13 @@
 CREATE CONTINUOUS VIEW cqwindow0 AS SELECT key::text, SUM(x::numeric) OVER (PARTITION BY key ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM cqwindow_stream;
 \d+ cqwindow0_mrel0;
-                            Table "public.cqwindow0_mrel0"
- Column |           Type           | Modifiers | Storage  | Stats target | Description 
---------+--------------------------+-----------+----------+--------------+-------------
- _0     | timestamp with time zone |           | plain    |              | 
- key    | text(0)                  |           | extended |              | 
- sum    | bytea                    |           | extended |              | 
+                                  Table "public.cqwindow0_mrel0"
+      Column       |           Type           | Modifiers | Storage  | Stats target | Description 
+-------------------+--------------------------+-----------+----------+--------------+-------------
+ arrival_timestamp | timestamp with time zone |           | plain    |              | 
+ key               | text(0)                  |           | extended |              | 
+ sum               | bytea                    |           | extended |              | 
 Indexes:
-    "cqwindow0_mrel0_expr_idx" btree (ls_hash_group(_0, key))
+    "cqwindow0_mrel0_expr_idx" btree (ls_hash_group(arrival_timestamp, key))
 Options: fillfactor=50
 
 \d+ cqwindow0;
@@ -22,10 +22,10 @@ View definition:
    FROM ONLY cqwindow_stream;
 
 SELECT pipeline_get_overlay_viewdef('cqwindow0');
-                                                                                pipeline_get_overlay_viewdef                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT cqwindow0_mrel0.key,                                                                                                                                                               +
-     pg_catalog.numeric_sum(combine(naggstaterecv(cqwindow0_mrel0.sum)) OVER (PARTITION BY cqwindow0_mrel0.key ORDER BY cqwindow0_mrel0._0 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)) AS sum+
+                                                                                        pipeline_get_overlay_viewdef                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT cqwindow0_mrel0.key,                                                                                                                                                                              +
+     pg_catalog.numeric_sum(combine(naggstaterecv(cqwindow0_mrel0.sum)) OVER (PARTITION BY cqwindow0_mrel0.key ORDER BY cqwindow0_mrel0.arrival_timestamp ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)) AS sum+
     FROM cqwindow0_mrel0;
 (1 row)
 
@@ -66,14 +66,14 @@ SELECT * FROM cqwindow0 ORDER BY key;
 
 CREATE CONTINUOUS VIEW cqwindow1 AS SELECT key::text, AVG(x::int) OVER (PARTITION BY key ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) FROM cqwindow_stream;
 \d+ cqwindow1_mrel0;
-                            Table "public.cqwindow1_mrel0"
- Column |           Type           | Modifiers | Storage  | Stats target | Description 
---------+--------------------------+-----------+----------+--------------+-------------
- _0     | timestamp with time zone |           | plain    |              | 
- key    | text(0)                  |           | extended |              | 
- avg    | bigint[]                 |           | extended |              | 
+                                  Table "public.cqwindow1_mrel0"
+      Column       |           Type           | Modifiers | Storage  | Stats target | Description 
+-------------------+--------------------------+-----------+----------+--------------+-------------
+ arrival_timestamp | timestamp with time zone |           | plain    |              | 
+ key               | text(0)                  |           | extended |              | 
+ avg               | bigint[]                 |           | extended |              | 
 Indexes:
-    "cqwindow1_mrel0_expr_idx" btree (ls_hash_group(_0, key))
+    "cqwindow1_mrel0_expr_idx" btree (ls_hash_group(arrival_timestamp, key))
 Options: fillfactor=50
 
 \d+ cqwindow1;
@@ -88,31 +88,31 @@ View definition:
    FROM ONLY cqwindow_stream;
 
 SELECT pipeline_get_overlay_viewdef('cqwindow1');
-                                                                  pipeline_get_overlay_viewdef                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT cqwindow1_mrel0.key,                                                                                                                                  +
-     int8_avg(combine(cqwindow1_mrel0.avg) OVER (PARTITION BY cqwindow1_mrel0.key ORDER BY cqwindow1_mrel0._0 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)) AS avg+
+                                                                         pipeline_get_overlay_viewdef                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT cqwindow1_mrel0.key,                                                                                                                                                 +
+     int8_avg(combine(cqwindow1_mrel0.avg) OVER (PARTITION BY cqwindow1_mrel0.key ORDER BY cqwindow1_mrel0.arrival_timestamp ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)) AS avg+
     FROM cqwindow1_mrel0;
 (1 row)
 
 SELECT pipeline_get_worker_querydef('cqwindow1');
-                       pipeline_get_worker_querydef                        
----------------------------------------------------------------------------
-  SELECT second(arrival_timestamp::timestamp with time zone) AS _0,       +
-     key::text,                                                           +
-     avg(x::integer) AS avg                                               +
-    FROM ONLY cqwindow_stream                                             +
+                           pipeline_get_worker_querydef                            
+-----------------------------------------------------------------------------------
+  SELECT second(arrival_timestamp::timestamp with time zone) AS arrival_timestamp,+
+     key::text,                                                                   +
+     avg(x::integer) AS avg                                                       +
+    FROM ONLY cqwindow_stream                                                     +
    GROUP BY key::text, second(arrival_timestamp::timestamp with time zone)
 (1 row)
 
 SELECT pipeline_get_combiner_querydef('cqwindow1');
- pipeline_get_combiner_querydef 
---------------------------------
-  SELECT _0,                   +
-     key,                      +
-     combine(avg) AS avg       +
-    FROM cqwindow1_mrel0       +
-   GROUP BY key, _0
+  pipeline_get_combiner_querydef   
+-----------------------------------
+  SELECT arrival_timestamp,       +
+     key,                         +
+     combine(avg) AS avg          +
+    FROM cqwindow1_mrel0          +
+   GROUP BY key, arrival_timestamp
 (1 row)
 
 INSERT INTO cqwindow_stream (key, x) VALUES ('a', 1), ('b', 2), ('a', 3);

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -250,22 +250,22 @@ View definition:
   GROUP BY key::text;
 
 \d+ cqcreate6_mrel0;
-                            Table "public.cqcreate6_mrel0"
- Column |           Type           | Modifiers | Storage  | Stats target | Description 
---------+--------------------------+-----------+----------+--------------+-------------
- _0     | timestamp with time zone |           | plain    |              | 
- _1     | text(0)                  |           | extended |              | 
- count  | bigint                   |           | plain    |              | 
+                                  Table "public.cqcreate6_mrel0"
+      Column       |           Type           | Modifiers | Storage  | Stats target | Description 
+-------------------+--------------------------+-----------+----------+--------------+-------------
+ arrival_timestamp | timestamp with time zone |           | plain    |              | 
+ _1                | text(0)                  |           | extended |              | 
+ count             | bigint                   |           | plain    |              | 
 Indexes:
-    "cqcreate6_mrel0_expr_idx" btree (ls_hash_group(_0, _1))
+    "cqcreate6_mrel0_expr_idx" btree (ls_hash_group(arrival_timestamp, _1))
 Options: fillfactor=50
 
 SELECT pipeline_get_overlay_viewdef('cqcreate6');
-                           pipeline_get_overlay_viewdef                           
-----------------------------------------------------------------------------------
-  SELECT combine(cqcreate6_mrel0.count) AS count                                 +
-    FROM cqcreate6_mrel0                                                         +
-   WHERE (cqcreate6_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second))+
+                                  pipeline_get_overlay_viewdef                                   
+-------------------------------------------------------------------------------------------------
+  SELECT combine(cqcreate6_mrel0.count) AS count                                                +
+    FROM cqcreate6_mrel0                                                                        +
+   WHERE (cqcreate6_mrel0.arrival_timestamp > (clock_timestamp() - '@ 5 secs'::interval second))+
    GROUP BY cqcreate6_mrel0._1;
 (1 row)
 
@@ -512,23 +512,23 @@ View definition:
   GROUP BY key::text;
 
 \d+ cqaggexpr3_mrel0;
-                            Table "public.cqaggexpr3_mrel0"
- Column |           Type           | Modifiers | Storage  | Stats target | Description 
---------+--------------------------+-----------+----------+--------------+-------------
- _0     | timestamp with time zone |           | plain    |              | 
- key    | text(0)                  |           | extended |              | 
- value  | bigint                   |           | plain    |              | 
+                                 Table "public.cqaggexpr3_mrel0"
+      Column       |           Type           | Modifiers | Storage  | Stats target | Description 
+-------------------+--------------------------+-----------+----------+--------------+-------------
+ arrival_timestamp | timestamp with time zone |           | plain    |              | 
+ key               | text(0)                  |           | extended |              | 
+ value             | bigint                   |           | plain    |              | 
 Indexes:
-    "cqaggexpr3_mrel0_expr_idx" btree (ls_hash_group(_0, key))
+    "cqaggexpr3_mrel0_expr_idx" btree (ls_hash_group(arrival_timestamp, key))
 Options: fillfactor=50
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
-                           pipeline_get_overlay_viewdef                            
------------------------------------------------------------------------------------
-  SELECT cqaggexpr3_mrel0.key,                                                    +
-     combine(cqaggexpr3_mrel0.value) AS value                                     +
-    FROM cqaggexpr3_mrel0                                                         +
-   WHERE (cqaggexpr3_mrel0._0 > (clock_timestamp() - '@ 5 secs'::interval second))+
+                                   pipeline_get_overlay_viewdef                                   
+--------------------------------------------------------------------------------------------------
+  SELECT cqaggexpr3_mrel0.key,                                                                   +
+     combine(cqaggexpr3_mrel0.value) AS value                                                    +
+    FROM cqaggexpr3_mrel0                                                                        +
+   WHERE (cqaggexpr3_mrel0.arrival_timestamp > (clock_timestamp() - '@ 5 secs'::interval second))+
    GROUP BY cqaggexpr3_mrel0.key;
 (1 row)
 

--- a/src/test/regress/expected/hash_group.out
+++ b/src/test/regress/expected/hash_group.out
@@ -169,15 +169,15 @@ Indexes:
 Options: fillfactor=50
 
 \d+ ls_hash_group1_mrel0;
-                         Table "public.ls_hash_group1_mrel0"
- Column |           Type           | Modifiers | Storage | Stats target | Description 
---------+--------------------------+-----------+---------+--------------+-------------
- _0     | timestamp with time zone |           | plain   |              | 
- x      | integer                  |           | plain   |              | 
- minute | timestamp with time zone |           | plain   |              | 
- count  | bigint                   |           | plain   |              | 
+                               Table "public.ls_hash_group1_mrel0"
+      Column       |           Type           | Modifiers | Storage | Stats target | Description 
+-------------------+--------------------------+-----------+---------+--------------+-------------
+ arrival_timestamp | timestamp with time zone |           | plain   |              | 
+ x                 | integer                  |           | plain   |              | 
+ minute            | timestamp with time zone |           | plain   |              | 
+ count             | bigint                   |           | plain   |              | 
 Indexes:
-    "ls_hash_group1_mrel0_expr_idx" btree (ls_hash_group(_0, x, minute))
+    "ls_hash_group1_mrel0_expr_idx" btree (ls_hash_group(arrival_timestamp, x, minute))
 Options: fillfactor=50
 
 \d+ ls_hash_group2_mrel0;

--- a/src/test/regress/sql/cont_sw_count.sql
+++ b/src/test/regress/sql/cont_sw_count.sql
@@ -13,3 +13,17 @@ INSERT INTO cqswcount_stream (k) VALUES ('x'), ('x'), ('x'), ('x'), ('x'), ('x')
 SELECT * FROM test_count ORDER BY k;
 
 DROP CONTINUOUS VIEW test_count;
+
+CREATE CONTINUOUS VIEW sw_count0 AS SELECT COUNT(*) FROM cqswcount_stream WHERE arrival_timestamp > clock_timestamp() - interval '60 second';
+
+CREATE VIEW sw_count1 AS SELECT combine(count) FROM sw_count0_mrel0 WHERE arrival_timestamp > clock_timestamp() - interval '2 second';
+
+INSERT INTO cqswcount_stream (k) VALUES ('x'), ('x');
+
+SELECT * FROM sw_count0;
+SELECT * FROM sw_count1;
+
+SELECT pg_sleep(2.2);
+
+SELECT * FROM sw_count0;
+SELECT * FROM sw_count1;


### PR DESCRIPTION
Exposes the hidden step column as `arrival_timestamp`, which makes it more intuitive for users to create multiple windows over the same matrel using `combine`.