### PR TITLE
#1144 Add SW convenience parameter (max_age)

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1271,7 +1271,16 @@ ProcessUtilitySlow(Node *parsetree,
 				break;
 
 			case T_ViewStmt:	/* CREATE VIEW */
-				DefineView((ViewStmt *) parsetree, queryString);
+				{
+					ViewStmt *vstmt = (ViewStmt *) parsetree;
+					DefElem *max_age = GetContinuousViewOption(vstmt->options, OPTION_MAX_AGE);
+					if (max_age)
+					{
+						ApplyMaxAge((SelectStmt *) vstmt->query, max_age);
+						vstmt->options = list_delete(vstmt->options, max_age);
+					}
+					DefineView(vstmt, queryString);
+				}
 				break;
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -40,6 +40,9 @@ typedef struct ContAnalyzeContext
 #define MATREL_COMBINE "combine"
 #define MATREL_FINALIZE "finalize"
 
+#define OPTION_FILLFACTOR "fillfactor"
+#define OPTION_MAX_AGE "max_age"
+
 #define ARRIVAL_TIMESTAMP_REF 65100
 #define IS_ARRIVAL_TIMESTAMP_REF(var) (IsA((var), Var) && ((Var *) (var))->varno >= ARRIVAL_TIMESTAMP_REF)
 
@@ -74,6 +77,8 @@ extern Node *GetSWExpr(RangeVar *rv);
 extern ColumnRef *GetSWTimeColumn(RangeVar *rv);
 extern ColumnRef *GetWindowTimeColumn(RangeVar *cv);
 extern Node *CreateOuterArrivalTimestampRef(ParseState *pstate, ColumnRef *cref, Node *var);
+extern DefElem *GetContinuousViewOption(List *options, char *name);
+extern void ApplyMaxAge(SelectStmt *stmt, DefElem *max_age);
 
 /* Deparsing */
 extern char *deparse_query_def(Query *query);

--- a/src/test/regress/expected/cont_multiple_sw.out
+++ b/src/test/regress/expected/cont_multiple_sw.out
@@ -1,3 +1,4 @@
+SET IntervalStyle to postgres;
 -- We can't reference arrival_timestamp if the underlying CV isn't a SW
 CREATE CONTINUOUS VIEW msw0 AS SELECT x::integer, COUNT(*) FROM msw_stream
 WHERE x > 10 GROUP BY x;
@@ -11,6 +12,20 @@ CREATE CONTINUOUS VIEW msw0 AS SELECT x::integer, COUNT(*), avg(x) FROM msw_stre
 WHERE arrival_timestamp > clock_timestamp() - interval '10 seconds' GROUP BY x;
 CREATE VIEW msw1 AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0
 WHERE arrival_timestamp > clock_timestamp() - interval '2 seconds';
+-- Verify that we can use max_age on views that read from SW CVs
+CREATE VIEW msw1_ma WITH (max_age = '2 seconds') AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0;
+\d+ msw1_ma;
+                View "public.msw1_ma"
+ Column |  Type   | Modifiers | Storage | Description 
+--------+---------+-----------+---------+-------------
+ count  | bigint  |           | plain   | 
+ avg    | numeric |           | main    | 
+View definition:
+ SELECT combine(msw0.count) AS count,
+    int8_avg(combine(msw0.avg)) AS avg
+   FROM msw0
+  WHERE arrival_timestamp > (clock_timestamp() - '00:00:02'::interval);
+
 CREATE VIEW msw2 AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0
 WHERE arrival_timestamp > clock_timestamp() - interval '5 seconds';
 INSERT INTO msw_stream (x) SELECT generate_series(1, 100) AS x;
@@ -120,6 +135,12 @@ SELECT * FROM msw0 ORDER BY x;
 (100 rows)
 
 SELECT * FROM msw1;
+ count |         avg         
+-------+---------------------
+   100 | 50.5000000000000000
+(1 row)
+
+SELECT * FROM msw1_ma;
  count |         avg         
 -------+---------------------
    100 | 50.5000000000000000
@@ -248,6 +269,12 @@ SELECT * FROM msw1;
      0 |    
 (1 row)
 
+SELECT * FROM msw1_ma;
+ count | avg 
+-------+-----
+     0 |    
+(1 row)
+
 SELECT * FROM msw2;
  count |         avg         
 -------+---------------------
@@ -371,6 +398,12 @@ SELECT * FROM msw1;
      0 |    
 (1 row)
 
+SELECT * FROM msw1_ma;
+ count | avg 
+-------+-----
+     0 |    
+(1 row)
+
 SELECT * FROM msw2;
  count | avg 
 -------+-----
@@ -381,11 +414,13 @@ SELECT * FROM msw2;
 DROP CONTINUOUS VIEW msw0;
 ERROR:  cannot drop continuous view msw0 because other objects depend on it
 DETAIL:  view msw1 depends on continuous view msw0
+view msw1_ma depends on continuous view msw0
 view msw2 depends on continuous view msw0
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP CONTINUOUS VIEW msw0 CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to view msw1
+drop cascades to view msw1_ma
 drop cascades to view msw2
 CREATE CONTINUOUS VIEW msw3 AS SELECT
 	x::integer + 10 AS a,

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -697,10 +697,10 @@ View definition:
 
 -- max_age must be a valid interval string
 CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42) AS SELECT COUNT(*) FROM stream;
-ERROR:  max_age must be a valid interval string
+ERROR:  "max_age" must be a valid interval string
 HINT:  For example, ... WITH (max_age = '1 hour') ...
 CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42.1) AS SELECT COUNT(*) FROM stream;
-ERROR:  max_age must be a valid interval string
+ERROR:  "max_age" must be a valid interval string
 HINT:  For example, ... WITH (max_age = '1 hour') ...
 CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT COUNT(*) FROM stream;
 ERROR:  invalid input syntax for type interval: "not an interval"
@@ -718,9 +718,14 @@ View definition:
    FROM ONLY stream
   WHERE arrival_timestamp::timestamp with time zone > (clock_timestamp() - '1 day'::interval) AND x::integer = 1;
 
--- or on non-sliding window continuous views
+DROP CONTINUOUS VIEW mawhere;
+-- max_age can't be used on non-sliding window continuous views
 CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
-ERROR:  max_age can only be specified when reading from a stream or continuous view
+ERROR:  "max_age" can only be specified when reading from a stream or continuous view
+-- or in conjunction with another sliding-window predicate
+CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
+WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
+ERROR:  cannot specify both "max_age" and a sliding window expression in the WHERE clause
 DROP CONTINUOUS VIEW ma0 CASCADE;
 NOTICE:  drop cascades to view ma1
 DROP CONTINUOUS VIEW cqcreate0;

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -672,6 +672,52 @@ CREATE CONTINUOUS VIEW arrts AS SELECT x::integer AS arrival_timestamp FROM stre
 ERROR:  arrival_timestamp is a reserved column name
 CREATE CONTINUOUS VIEW arrts AS SELECT arrival_timestamp AS arrival_timestamp FROM stream;
 DROP CONTINUOUS VIEW arrts;
+-- WITH max_age
+CREATE CONTINUOUS VIEW ma0 WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream;
+\d+ ma0;
+            Continuous view "public.ma0"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
+View definition:
+ SELECT count(*) AS count
+   FROM ONLY stream
+  WHERE arrival_timestamp::timestamp with time zone > (clock_timestamp() - '1 day'::interval);
+
+CREATE VIEW ma1 WITH (max_age = '1 hour') AS SELECT COUNT(*) FROM ma0;
+\d+ ma1;
+                  View "public.ma1"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
+View definition:
+ SELECT count(*) AS count
+   FROM ma0
+  WHERE arrival_timestamp > (clock_timestamp() - '01:00:00'::interval);
+
+-- max_age must be a valid interval string
+CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42) AS SELECT COUNT(*) FROM stream;
+ERROR:  max_age must be a valid interval string
+HINT:  For example, ... WITH (max_age = '1 hour') ...
+CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42.1) AS SELECT COUNT(*) FROM stream;
+ERROR:  max_age must be a valid interval string
+HINT:  For example, ... WITH (max_age = '1 hour') ...
+CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT COUNT(*) FROM stream;
+ERROR:  invalid input syntax for type interval: "not an interval"
+LINE 1: CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an int...
+        ^
+-- max_age not allowed with a WHERE clause
+CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
+WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
+ERROR:  WHERE clauses cannot be specified in conjunction with max_age
+-- or on non-sliding window continuous views
+CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
+ERROR:  max_age can only be specified when reading from a stream or continuous view
+CREATE VIEW manowhere WITH (max_age = '1 hour') AS SELECT COUNT(*) FROM ma0
+WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
+ERROR:  WHERE clauses cannot be specified in conjunction with max_age
+DROP CONTINUOUS VIEW ma0 CASCADE;
+NOTICE:  drop cascades to view ma1
 DROP CONTINUOUS VIEW cqcreate0;
 DROP CONTINUOUS VIEW cqcreate1;
 DROP CONTINUOUS VIEW cqcreate2;

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -706,16 +706,21 @@ CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT CO
 ERROR:  invalid input syntax for type interval: "not an interval"
 LINE 1: CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an int...
         ^
--- max_age not allowed with a WHERE clause
 CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
-WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
-ERROR:  WHERE clauses cannot be specified in conjunction with max_age
+WHERE x::integer = 1;
+\d+ mawhere;
+          Continuous view "public.mawhere"
+ Column |  Type  | Modifiers | Storage | Description 
+--------+--------+-----------+---------+-------------
+ count  | bigint |           | plain   | 
+View definition:
+ SELECT count(*) AS count
+   FROM ONLY stream
+  WHERE arrival_timestamp::timestamp with time zone > (clock_timestamp() - '1 day'::interval) AND x::integer = 1;
+
 -- or on non-sliding window continuous views
 CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
 ERROR:  max_age can only be specified when reading from a stream or continuous view
-CREATE VIEW manowhere WITH (max_age = '1 hour') AS SELECT COUNT(*) FROM ma0
-WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
-ERROR:  WHERE clauses cannot be specified in conjunction with max_age
 DROP CONTINUOUS VIEW ma0 CASCADE;
 NOTICE:  drop cascades to view ma1
 DROP CONTINUOUS VIEW cqcreate0;

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -147,14 +147,12 @@ CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42) AS SELECT COUNT(*) FROM str
 CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42.1) AS SELECT COUNT(*) FROM stream;
 CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT COUNT(*) FROM stream;
 
--- max_age not allowed with a WHERE clause
 CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
-WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
+WHERE x::integer = 1;
+\d+ mawhere;
 
 -- or on non-sliding window continuous views
 CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
-CREATE VIEW manowhere WITH (max_age = '1 hour') AS SELECT COUNT(*) FROM ma0
-WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
 
 DROP CONTINUOUS VIEW ma0 CASCADE;
 

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -136,6 +136,28 @@ CREATE CONTINUOUS VIEW arrts AS SELECT x::integer AS arrival_timestamp FROM stre
 CREATE CONTINUOUS VIEW arrts AS SELECT arrival_timestamp AS arrival_timestamp FROM stream;
 DROP CONTINUOUS VIEW arrts;
 
+-- WITH max_age
+CREATE CONTINUOUS VIEW ma0 WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream;
+\d+ ma0;
+CREATE VIEW ma1 WITH (max_age = '1 hour') AS SELECT COUNT(*) FROM ma0;
+\d+ ma1;
+
+-- max_age must be a valid interval string
+CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42) AS SELECT COUNT(*) FROM stream;
+CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42.1) AS SELECT COUNT(*) FROM stream;
+CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT COUNT(*) FROM stream;
+
+-- max_age not allowed with a WHERE clause
+CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
+WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
+
+-- or on non-sliding window continuous views
+CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
+CREATE VIEW manowhere WITH (max_age = '1 hour') AS SELECT COUNT(*) FROM ma0
+WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
+
+DROP CONTINUOUS VIEW ma0 CASCADE;
+
 DROP CONTINUOUS VIEW cqcreate0;
 DROP CONTINUOUS VIEW cqcreate1;
 DROP CONTINUOUS VIEW cqcreate2;

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -151,8 +151,14 @@ CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM 
 WHERE x::integer = 1;
 \d+ mawhere;
 
--- or on non-sliding window continuous views
+DROP CONTINUOUS VIEW mawhere;
+
+-- max_age can't be used on non-sliding window continuous views
 CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
+
+-- or in conjunction with another sliding-window predicate
+CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
+WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
 
 DROP CONTINUOUS VIEW ma0 CASCADE;
 


### PR DESCRIPTION
SWs can now be created using a `WITH` param:

```
CREATE CONTINUOUS VIEW cv WITH (max_age = '10 days') AS SELECT count(*) FROM stream
CREATE VIEW v WITH (max_age = '1 day') AS SELECT * from cv;
```