### PR TITLE
SW views can be created even if time column alias isn't arrival_timestamp

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1608,7 +1608,7 @@ find_expr_references_walker(Node *node,
 		List	   *rtable;
 		RangeTblEntry *rte;
 
-		if (IS_ARRIVAL_TIMESTAMP_REF(var))
+		if (IS_SW_TIMESTAMP_REF(var))
 			return false;
 
 		/* Find matching rtable entry, or complain if not found */

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -973,7 +973,7 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	transformFromClause(pstate, stmt->fromClause);
 
 	if (ContainsSlidingWindowContinuousView(stmt->fromClause))
-		pstate->p_post_columnref_hook = CreateOuterArrivalTimestampRef;
+		pstate->p_post_columnref_hook = CreateOuterSWTimeColumnRef;
 
 	/* transform targetlist */
 	qry->targetList = transformTargetList(pstate, stmt->targetList,

--- a/src/backend/pipeline/cont_analyze.c
+++ b/src/backend/pipeline/cont_analyze.c
@@ -3194,8 +3194,6 @@ push_down_sw_predicate(Var *dummy, Query *upper, Query *lower)
 {
 	List *vars = NIL;
 	Var *real;
-	RangeTblEntry *rte;
-	Value *colname;
 
 	pull_vars(lower->jointree->quals, &vars);
 
@@ -3207,11 +3205,6 @@ push_down_sw_predicate(Var *dummy, Query *upper, Query *lower)
 		elog(ERROR, "column \"arrival_timestamp\" does not exist");
 
 	real = (Var *) linitial(vars);
-	rte = list_nth(lower->rtable, real->varno - 1);
-	colname = list_nth(rte->eref->colnames, real->varattno - 1);
-
-	if (pg_strcasecmp(ARRIVAL_TIMESTAMP, strVal(colname)) != 0)
-		elog(ERROR, "column \"arrival_timestamp\" does not exist");
 
 	memcpy(dummy, real, sizeof(Var));
 	lower->jointree->quals = upper->jointree->quals;

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -5646,10 +5646,10 @@ get_variable(Var *var, int levelsup, bool istoplevel, deparse_context *context)
 
 		return NULL;
 	}
-	else if (IS_ARRIVAL_TIMESTAMP_REF(var))
+	else if (IS_SW_TIMESTAMP_REF(var))
 	{
+		/* TODO(usmanm): Fix deparsing to print out the name of the SW column */
 		appendStringInfoString(buf, ARRIVAL_TIMESTAMP);
-
 		return NULL;
 	}
 	else

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -43,8 +43,8 @@ typedef struct ContAnalyzeContext
 #define OPTION_FILLFACTOR "fillfactor"
 #define OPTION_MAX_AGE "max_age"
 
-#define ARRIVAL_TIMESTAMP_REF 65100
-#define IS_ARRIVAL_TIMESTAMP_REF(var) (IsA((var), Var) && ((Var *) (var))->varno >= ARRIVAL_TIMESTAMP_REF)
+#define SW_TIMESTAMP_REF 65100
+#define IS_SW_TIMESTAMP_REF(var) (IsA((var), Var) && ((Var *) (var))->varno >= SW_TIMESTAMP_REF)
 
 #define IsMatRelCombine(proname) (pg_strcasecmp(NameStr(proname), MATREL_COMBINE) == 0)
 #define IsMatRelFinalize(proname) (pg_strcasecmp(NameStr(proname), MATREL_FINALIZE) == 0)
@@ -76,7 +76,7 @@ extern Query *GetContCombinerQuery(RangeVar *rv);
 extern Node *GetSWExpr(RangeVar *rv);
 extern ColumnRef *GetSWTimeColumn(RangeVar *rv);
 extern ColumnRef *GetWindowTimeColumn(RangeVar *cv);
-extern Node *CreateOuterArrivalTimestampRef(ParseState *pstate, ColumnRef *cref, Node *var);
+extern Node *CreateOuterSWTimeColumnRef(ParseState *pstate, ColumnRef *cref, Node *var);
 extern DefElem *GetContinuousViewOption(List *options, char *name);
 extern void ApplyMaxAge(SelectStmt *stmt, DefElem *max_age);
 

--- a/src/test/regress/expected/cont_multiple_sw.out
+++ b/src/test/regress/expected/cont_multiple_sw.out
@@ -472,32 +472,52 @@ DROP CONTINUOUS VIEW msw3 CASCADE;
 NOTICE:  drop cascades to view msw4
 CREATE CONTINUOUS VIEW msw5 AS
 SELECT
-  minute(arrival_timestamp)
+  minute(arrival_timestamp) AS sw_time
 FROM stream
 WHERE minute(arrival_timestamp) > clock_timestamp() - INTERVAL '10 minute';
 \d+ msw5
                      Continuous view "public.msw5"
- Column |           Type           | Modifiers | Storage | Description 
---------+--------------------------+-----------+---------+-------------
- minute | timestamp with time zone |           | plain   | 
+ Column  |           Type           | Modifiers | Storage | Description 
+---------+--------------------------+-----------+---------+-------------
+ sw_time | timestamp with time zone |           | plain   | 
 View definition:
- SELECT minute(arrival_timestamp::timestamp with time zone) AS minute
+ SELECT minute(arrival_timestamp::timestamp with time zone) AS sw_time
    FROM ONLY stream
   WHERE minute(arrival_timestamp::timestamp with time zone) > (clock_timestamp() - '00:10:00'::interval);
 
 CREATE VIEW msw6 WITH (max_age = '1 minute') AS SELECT * FROM msw5;
 \d+ msw6
-                          View "public.msw6"
- Column |           Type           | Modifiers | Storage | Description 
---------+--------------------------+-----------+---------+-------------
- minute | timestamp with time zone |           | plain   | 
+                           View "public.msw6"
+ Column  |           Type           | Modifiers | Storage | Description 
+---------+--------------------------+-----------+---------+-------------
+ sw_time | timestamp with time zone |           | plain   | 
 View definition:
- SELECT msw5.minute
+ SELECT msw5.sw_time
    FROM msw5
   WHERE arrival_timestamp > (clock_timestamp() - '00:01:00'::interval);
 
 SELECT * FROM msw6;
- minute 
---------
+ sw_time 
+---------
 (0 rows)
 
+CREATE VIEW msw7 AS SELECT * FROM msw5 WHERE sw_time > clock_timestamp() - INTERVAL '1 minute';
+\d+ msw7
+                           View "public.msw7"
+ Column  |           Type           | Modifiers | Storage | Description 
+---------+--------------------------+-----------+---------+-------------
+ sw_time | timestamp with time zone |           | plain   | 
+View definition:
+ SELECT msw5.sw_time
+   FROM msw5
+  WHERE msw5.sw_time > (clock_timestamp() - '00:01:00'::interval);
+
+SELECT * FROM msw7;
+ sw_time 
+---------
+(0 rows)
+
+DROP CONTINUOUS VIEW msw5 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to view msw6
+drop cascades to view msw7

--- a/src/test/regress/expected/cont_multiple_sw.out
+++ b/src/test/regress/expected/cont_multiple_sw.out
@@ -470,3 +470,34 @@ SELECT * FROM msw4 ORDER BY a;
 
 DROP CONTINUOUS VIEW msw3 CASCADE;
 NOTICE:  drop cascades to view msw4
+CREATE CONTINUOUS VIEW msw5 AS
+SELECT
+  minute(arrival_timestamp)
+FROM stream
+WHERE minute(arrival_timestamp) > clock_timestamp() - INTERVAL '10 minute';
+\d+ msw5
+                     Continuous view "public.msw5"
+ Column |           Type           | Modifiers | Storage | Description 
+--------+--------------------------+-----------+---------+-------------
+ minute | timestamp with time zone |           | plain   | 
+View definition:
+ SELECT minute(arrival_timestamp::timestamp with time zone) AS minute
+   FROM ONLY stream
+  WHERE minute(arrival_timestamp::timestamp with time zone) > (clock_timestamp() - '00:10:00'::interval);
+
+CREATE VIEW msw6 WITH (max_age = '1 minute') AS SELECT * FROM msw5;
+\d+ msw6
+                          View "public.msw6"
+ Column |           Type           | Modifiers | Storage | Description 
+--------+--------------------------+-----------+---------+-------------
+ minute | timestamp with time zone |           | plain   | 
+View definition:
+ SELECT msw5.minute
+   FROM msw5
+  WHERE arrival_timestamp > (clock_timestamp() - '00:01:00'::interval);
+
+SELECT * FROM msw6;
+ minute 
+--------
+(0 rows)
+

--- a/src/test/regress/sql/cont_multiple_sw.sql
+++ b/src/test/regress/sql/cont_multiple_sw.sql
@@ -70,3 +70,17 @@ SELECT * FROM msw3 ORDER BY a;
 SELECT * FROM msw4 ORDER BY a;
 
 DROP CONTINUOUS VIEW msw3 CASCADE;
+
+CREATE CONTINUOUS VIEW msw5 AS
+SELECT
+  minute(arrival_timestamp)
+FROM stream
+WHERE minute(arrival_timestamp) > clock_timestamp() - INTERVAL '10 minute';
+
+\d+ msw5
+
+CREATE VIEW msw6 WITH (max_age = '1 minute') AS SELECT * FROM msw5;
+
+\d+ msw6
+
+SELECT * FROM msw6;

--- a/src/test/regress/sql/cont_multiple_sw.sql
+++ b/src/test/regress/sql/cont_multiple_sw.sql
@@ -73,14 +73,17 @@ DROP CONTINUOUS VIEW msw3 CASCADE;
 
 CREATE CONTINUOUS VIEW msw5 AS
 SELECT
-  minute(arrival_timestamp)
+  minute(arrival_timestamp) AS sw_time
 FROM stream
 WHERE minute(arrival_timestamp) > clock_timestamp() - INTERVAL '10 minute';
-
 \d+ msw5
 
 CREATE VIEW msw6 WITH (max_age = '1 minute') AS SELECT * FROM msw5;
-
 \d+ msw6
-
 SELECT * FROM msw6;
+
+CREATE VIEW msw7 AS SELECT * FROM msw5 WHERE sw_time > clock_timestamp() - INTERVAL '1 minute';
+\d+ msw7
+SELECT * FROM msw7;
+
+DROP CONTINUOUS VIEW msw5 CASCADE;


### PR DESCRIPTION
Also, since we allow SWs to be defined on columns other than `arrival_timestamp`, maybe we should use an alias like `sw_column` to refer to the time column in the SW clause rather than `arrival_timestamp` when referring to it in `CREATE VIEW`.