### PR TITLE
Fixes #1190: Postmaster should only restart crashed CQ procs

### DIFF
--- a/src/backend/pipeline/cont_scheduler.c
+++ b/src/backend/pipeline/cont_scheduler.c
@@ -433,7 +433,7 @@ run_background_proc(ContQueryProc *proc)
 
 	strcpy(worker.bgw_name, GetContQueryProcName(proc));
 
-	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION | BGWORKER_IS_CONT_QUERY_PROC;
 	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
 	worker.bgw_main = cq_bgproc_main;
 	worker.bgw_notify_pid = MyProcPid;

--- a/src/include/pipeline/cont_scheduler.h
+++ b/src/include/pipeline/cont_scheduler.h
@@ -16,6 +16,7 @@
 #include "storage/spin.h"
 
 #define MAX_CQS 1024
+#define BGWORKER_IS_CONT_QUERY_PROC 0x1000
 
 typedef enum
 {


### PR DESCRIPTION
The issue was being caused because the Postmaster keeps a local-memory copy of background workers, so on restart it would attempt to start CQ procs in a way that they didn't expect. Now, clean starts of CQ procs is handled exclusively by the CQ scheduler, although the Postmaster will restart them in the event of a crash.

This is accomplished by removing the CQ procs from the Postmaster's local-memory list in the event of a system-wide recovery attempt.