### PR TITLE
Fixes #1160: Abort current transaction on the worker in the event of …

### DIFF
--- a/src/backend/pipeline/cont_worker.c
+++ b/src/backend/pipeline/cont_worker.c
@@ -452,6 +452,11 @@ ContinuousQueryWorkerMain(void)
 
 				if (!continuous_query_crash_recovery)
 					exit(1);
+
+				AbortCurrentTransaction();
+				StartTransactionCommand();
+
+				MemoryContextSwitchTo(ContQueryBatchContext);
 			}
 			PG_END_TRY();
 


### PR DESCRIPTION
…an error to avoid reference leaks