### PR TITLE
link pg_config and pg_ctl on debian install pkg

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -10,8 +10,11 @@ ln -s $INSTALL_PREFIX/bin/pipeline-server /usr/bin/pipeline-server
 ln -s $INSTALL_PREFIX/bin/pipeline-ctl /usr/bin/pipeline-ctl
 ln -s $INSTALL_PREFIX/bin/pipeline-init /usr/bin/pipeline-init
 ln -s $INSTALL_PREFIX/bin/psql /usr/bin/psql
+ln -s $INSTALL_PREFIX/bin/pg_config /usr/bin/pg_config
+ln -s $INSTALL_PREFIX/bin/pipeline-ctl /usr/bin/pg_ctl
 ln -s /usr/bin/psql /usr/bin/pipeline
 ln -s $INSTALL_PREFIX/bin/padhoc /usr/bin/padhoc
+
 
 echo "
     ____  _            ___            ____  ____

--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -15,7 +15,6 @@ ln -s $INSTALL_PREFIX/bin/pipeline-ctl /usr/bin/pg_ctl
 ln -s /usr/bin/psql /usr/bin/pipeline
 ln -s $INSTALL_PREFIX/bin/padhoc /usr/bin/padhoc
 
-
 echo "
     ____  _            ___            ____  ____
    / __ \(_)___  ___  / (_)___  ___  / __ \/ __ )

--- a/pkg/debian/postrm
+++ b/pkg/debian/postrm
@@ -10,5 +10,7 @@ rm -f /usr/bin/pipeline-server
 rm -f /usr/bin/pipeline-ctl
 rm -f /usr/bin/pipeline-init
 rm -f /usr/bin/psql
+rm -f /usr/bin/pg_config
+rm -f /usr/bin/pg_ctl
 rm -f /usr/bin/pipeline
 rm -f /usr/bin/padhoc


### PR DESCRIPTION
These tools are missing and are required for other packages to be installed (e.g. Psycopg2)