### PR TITLE
Fix offset error in pipeline_kafka \n check.

### DIFF
--- a/contrib/pipeline_kafka/pipeline_kafka.c
+++ b/contrib/pipeline_kafka/pipeline_kafka.c
@@ -691,7 +691,7 @@ kafka_consume_main(Datum arg)
 				if (messages[i]->payload != NULL)
 				{
 					appendBinaryStringInfo(&buf, messages[i]->payload, messages[i]->len);
-					if (buf.data[buf.len] != '\n')
+					if (buf.len > 0 && buf.data[buf.len - 1] != '\n')
 						appendStringInfoChar(&buf, '\n');
 					messages_buffered++;
 				}


### PR DESCRIPTION
buf.data[buf.len] !=  '\n' is always true because appendBinaryStringInfo null terminates message payload.