### PR TITLE
Update docker env's continuous_query_ipc_shared_mem unit from mb to MB.

### DIFF
--- a/pkg/docker/scripts/conf/pipelinedb.conf
+++ b/pkg/docker/scripts/conf/pipelinedb.conf
@@ -85,7 +85,7 @@ continuous_query_combiner_work_mem = 16MB
 
 # amount of shared memory reserved by each continuous query process
 # for IPC
-continuous_query_ipc_shared_mem = 8mb
+continuous_query_ipc_shared_mem = 8MB
 
 # the default step factor for sliding window continuous queries (as a percentage
 # of the total window size)

--- a/pkg/docker/scripts/startpipeline
+++ b/pkg/docker/scripts/startpipeline
@@ -2,10 +2,9 @@
 
 set -e
 
-# check if the data directory is empty,
-# if not, initialize it.
-# if [ ! -d "/mnt/pipelinedb/data" ]; then
-if [ ! "$(ls -A /mnt/pipelinedb/data)" ]; then
+# check if the data directory already exists
+# if not, create it
+if [ ! -d "/mnt/pipelinedb/data" ]; then
     mkdir -p /mnt/pipelinedb
     chmod 777 /mnt/pipelinedb
     su - pipeline -c "pipeline-init --encoding=UTF8 -D /mnt/pipelinedb/data"

--- a/pkg/docker/scripts/startpipeline
+++ b/pkg/docker/scripts/startpipeline
@@ -2,9 +2,10 @@
 
 set -e
 
-# check if the data directory already exists
-# if not, create it
-if [ ! -d "/mnt/pipelinedb/data" ]; then
+# check if the data directory is empty,
+# if not, initialize it.
+# if [ ! -d "/mnt/pipelinedb/data" ]; then
+if [ ! "$(ls -A /mnt/pipelinedb/data)" ]; then
     mkdir -p /mnt/pipelinedb
     chmod 777 /mnt/pipelinedb
     su - pipeline -c "pipeline-init --encoding=UTF8 -D /mnt/pipelinedb/data"


### PR DESCRIPTION
Starting PipelineDB in a container using configuration file https://github.com/pipelinedb/pipelinedb/blob/master/pkg/docker/scripts/conf/pipelinedb.conf fails with the following error:

_______
ALTER ROLE
LOG:  received smart shutdown request
LOG:  autovacuum launcher shutting down
LOG:  continuous query scheduler shutting down
LOG:  shutting down
waiting for server to shut down....LOG:  database system is shut down

 done
server stopped
LOG:  invalid value for parameter "continuous_query_ipc_shared_mem": "8mb"
HINT:  Valid units for this parameter are "kB", "MB", "GB", and "TB".
FATAL:  configuration file "/mnt/pipelinedb/data/pipelinedb.conf" contains errors
_______

This PR attempts to fix the unit for continuous_query_ipc_shared_mem in pipelinedb.conf.

Tested the fix, db container came up fine:
_______
LOG:  database system is ready to accept connections
LOG:  continuous query scheduler started
LOG:  autovacuum launcher started
_______