### PR TITLE
add tab completion for create and drop command line

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -748,6 +748,7 @@ static const pgsql_thing_t words_after_create[] = {
 	 * to be used only by pg_dump.
 	 */
 	{"CONFIGURATION", Query_for_list_of_ts_configurations, NULL, THING_NO_SHOW},
+	{"CONTINUOUS VIEW", NULL, &Query_for_list_of_views},
 	{"CONVERSION", "SELECT pg_catalog.quote_ident(conname) FROM pg_catalog.pg_conversion WHERE substring(pg_catalog.quote_ident(conname),1,%d)='%s'"},
 	{"DATABASE", Query_for_list_of_databases},
 	{"DICTIONARY", Query_for_list_of_ts_dictionaries, NULL, THING_NO_SHOW},

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -859,8 +859,8 @@ psql_completion(const char *text, int start, int end)
 #define prev6_wd  (previous_words[5])
 
 	static const char *const sql_commands[] = {
-		"ABORT", "ALTER", "ANALYZE", "BEGIN", "CHECKPOINT", "CLOSE", "CLUSTER",
-		"COMMENT", "COMMIT", "COPY", "CREATE", "DEALLOCATE", "DECLARE",
+		"ABORT", "ACTIVATE", "ALTER", "ANALYZE", "BEGIN", "CHECKPOINT", "CLOSE", "CLUSTER",
+		"COMMENT", "COMMIT", "COPY", "CREATE", "DEACTIVATE", "DEALLOCATE", "DECLARE",
 		"DELETE FROM", "DISCARD", "DO", "DROP", "END", "EXECUTE", "EXPLAIN", "FETCH",
 		"GRANT", "INSERT", "LISTEN", "LOAD", "LOCK", "MOVE", "NOTIFY", "PREPARE",
 		"REASSIGN", "REFRESH", "REINDEX", "RELEASE", "RESET", "REVOKE", "ROLLBACK",


### PR DESCRIPTION
Check the output:

```
q=# create 
AGGREGATE             CONVERSION            EXTENSION             GROUP                 OPERATOR              SEQUENCE              TEMP                  UNIQUE                VIEW                  
CAST                  DATABASE              FOREIGN DATA WRAPPER  INDEX                 ROLE                  SERVER                TEXT SEARCH           UNLOGGED              
COLLATION             DOMAIN                FOREIGN TABLE         LANGUAGE              RULE                  TABLE                 TRIGGER               USER                  
CONTINUOUS VIEW       EVENT TRIGGER         FUNCTION              MATERIALIZED VIEW     SCHEMA                TABLESPACE            TYPE                  USER MAPPING FOR      
q=# drop 
AGGREGATE             CONVERSION            EXTENSION             GROUP                 OPERATOR              SCHEMA                TABLESPACE            USER                  
CAST                  DATABASE              FOREIGN DATA WRAPPER  INDEX                 OWNED                 SEQUENCE              TEXT SEARCH           USER MAPPING FOR      
COLLATION             DOMAIN                FOREIGN TABLE         LANGUAGE              ROLE                  SERVER                TRIGGER               VIEW                  
CONTINUOUS VIEW       EVENT TRIGGER         FUNCTION              MATERIALIZED VIEW     RULE                  TABLE                 TYPE                  
```
Nice. :)