### PR TITLE
Enable data files to reside on a host bind-mounted volume

### DIFF
--- a/pkg/docker/scripts/startpipeline
+++ b/pkg/docker/scripts/startpipeline
@@ -2,11 +2,17 @@
 
 set -e
 
-# check if the data directory already exists
-# if not, create it
-if [ ! -d "/mnt/pipelinedb/data" ]; then
-    mkdir -p /mnt/pipelinedb
-    chmod 777 /mnt/pipelinedb
+# Initialize database if:
+# 1) data directory does not exist
+#    (when data directory volume is not bind-mounted from host;
+#     example: docker run -d pipelinedb), or,
+# 2) data directory already exists, but is empty
+#    (when data directory volume has been bind-mounted from host;
+#     example: docker run -d -v host_volume:/mnt/pipelinedb/data pipelinedb).
+if [ ! -d "/mnt/pipelinedb/data" ] || [ ! "$(ls -A /mnt/pipelinedb/data)" ]; then
+    mkdir -p /mnt/pipelinedb/data
+    sudo chmod 777 /mnt/pipelinedb
+    chown pipeline /mnt/pipelinedb/data
     su - pipeline -c "pipeline-init --encoding=UTF8 -D /mnt/pipelinedb/data"
     su - pipeline -c "pipeline-ctl -D /mnt/pipelinedb/data -w start"
     psql -U pipeline -c "ALTER USER pipeline PASSWORD 'pipeline'"


### PR DESCRIPTION
When PipelineDB is started in a Docker container, ``/mnt/pipelinedb/data/`` is currently volatile if the database container is rescheduled to a different compute node. In order to make data portable across compute nodes, starting the container with a host bind-mounted volume (``docker run -d -v host_volume:/mnt/pipelinedb/data pipelinedb``) helps tools like Flocker migrate host volume to destination compute node.

This PR adds supports for starting PipelineDB container with a bind-mounted host volume.

Ran the following test cases with the change:

1) Regression test: Verified container start up without ``-v`` flag.

```
docker@testvm:~/pipelinedb/pkg/docker$ docker run -it  testhostvolume
The files belonging to this database system will be owned by user "pipeline".
This user must also own the server process.
...
LOG:  database system was shut down at 2016-01-20 05:29:41 GMT
LOG:  MultiXact member wraparound protections are now enabled
LOG:  database system is ready to accept connections
LOG:  continuous query scheduler started
LOG:  autovacuum launcher started
```

2) Start container bind-mounting an empty host directory into ``/mnt/pipelinedb/data/``:

```
docker@testvm:~/pipelinedb/pkg/docker$ ls -la /tmp/hostvolume1
ls: /tmp/hostvolume1: No such file or directory
docker@testvm:~/pipelinedb/pkg/docker$ docker run -it -v /tmp/hostvolume1:/mnt/pipelinedb/data testhostvolu
me
The files belonging to this database system will be owned by user "pipeline".
This user must also own the server process.
...
LOG:  database system was shut down at 2016-01-20 05:57:23 GMT
LOG:  MultiXact member wraparound protections are now enabled
LOG:  database system is ready to accept connections
LOG:  continuous query scheduler started
LOG:  autovacuum launcher started
```
```
docker@testvm:~/pipelinedb/pkg/docker$ ls -la /tmp/hostvolume1
total 96
drwx------   18 docker   root          4096 Jan 20 06:00 ./
drwxrwxrwt   13 root     staff         4096 Jan 20 05:57 ../
-rw-------    1 docker   1000             4 Jan 20 05:57 PG_VERSION
drwx------    5 docker   1000          4096 Jan 20 05:57 base/
drwx------    2 docker   1000          4096 Jan 20 05:57 global/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_clog/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_dynshmem/
-rw-------    1 docker   1000           842 Jan 20 05:57 pg_hba.conf
-rw-------    1 docker   1000          1636 Jan 20 05:57 pg_ident.conf
drwx------    4 docker   1000          4096 Jan 20 05:57 pg_logical/
drwx------    4 docker   1000          4096 Jan 20 05:57 pg_multixact/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_notify/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_replslot/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_serial/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_snapshots/
drwx------    2 docker   1000          4096 Jan 20 06:00 pg_stat/
drwx------    2 docker   1000          4096 Jan 20 06:00 pg_stat_tmp/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_subtrans/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_tblspc/
drwx------    2 docker   1000          4096 Jan 20 05:57 pg_twophase/
drwx------    3 docker   1000          4096 Jan 20 05:57 pg_xlog/
-rw-------    1 docker   1000            88 Jan 20 05:57 pipelinedb.auto.conf
-rw-------    1 docker   1000          3155 Jan 20 05:57 pipelinedb.conf
-rw-------    1 docker   1000            68 Jan 20 05:57 postmaster.opts
docker@testvm:~/pipelinedb/pkg/docker$ 
```

3) Start a container with a bind-mounted host volume that has database files:

```
docker@testvm:~/pipelinedb/pkg/docker$ docker run -it -v /tmp/hostvolume1:/mnt/pipelinedb/data testhostvolu
me
    ____  _            ___            ____  ____
   / __ \(_)___  ___  / (_)___  ___  / __ \/ __ )
  / /_/ / / __ \/ _ \/ / / __ \/ _ \/ / / / __  |
 / ____/ / /_/ /  __/ / / / / /  __/ /_/ / /_/ /
/_/   /_/ .___/\___/_/_/_/ /_/\___/_____/_____/
       /_/

LOG:  database system was shut down at 2016-01-20 06:00:11 GMT
LOG:  MultiXact member wraparound protections are now enabled
LOG:  database system is ready to accept connections
LOG:  continuous query scheduler started
LOG:  autovacuum launcher started
```
