### PR TITLE
Abort batch transaction if trigger function fails.

### DIFF
--- a/src/backend/pipeline/trigger/trigger.c
+++ b/src/backend/pipeline/trigger/trigger.c
@@ -399,20 +399,10 @@ exec_trigger_proc(TriggerData *tcontext, FmgrInfo *finfo,
 
 	pgstat_init_function_usage(&fcinfo, &fcusage);
 
-	PG_TRY();
-	{
-		/* Consume return value */
-		FunctionCallInvoke(&fcinfo);
-	}
-	PG_CATCH();
-	{
-		EmitErrorReport();
-		FlushErrorState();
-	}
-	PG_END_TRY();
+	/* Any errors get handled by process_batches in batching.c */
+	FunctionCallInvoke(&fcinfo);
 
 	pgstat_end_function_usage(&fcusage, true);
-
 	MemoryContextSwitchTo(oldContext);
 }
 

--- a/src/test/regress/expected/cont_trigger.out
+++ b/src/test/regress/expected/cont_trigger.out
@@ -1,4 +1,10 @@
-CREATE CONTINUOUS VIEW cont_tg_cv AS SELECT count(*) FROM cont_tg_stream;
+select pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+CREATE CONTINUOUS VIEW cont_tg_cv AS SELECT x::int, count(*) FROM cont_tg_stream group by x;
 CREATE TABLE cont_tg_t (count int);
 CREATE OR REPLACE FUNCTION cont_tg_func()
 RETURNS trigger AS
@@ -9,12 +15,25 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-select pg_sleep(2);
+CREATE OR REPLACE FUNCTION bad_tg_func()
+RETURNS trigger AS
+$$
+BEGIN
+ INSERT INTO does_not_exist(count) VALUES (NEW.count);
+ RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+CREATE TRIGGER bad_tg AFTER INSERT OR UPDATE ON cont_tg_cv FOR EACH ROW EXECUTE PROCEDURE bad_tg_func();
+INSERT INTO cont_tg_stream (x) VALUES (1), (1), (1); SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
 (1 row)
 
+DROP TRIGGER bad_tg on cont_tg_cv;
+TRUNCATE CONTINUOUS VIEW cont_tg_cv;
+TRUNCATE TABLE cont_tg_t;
 -- Invalid triggers
 CREATE TRIGGER cont_tg BEFORE INSERT ON cont_tg_cv FOR EACH ROW EXECUTE PROCEDURE cont_tg_func();
 ERROR:  "cont_tg_cv" is a continuous view

--- a/src/test/regress/sql/cont_trigger.sql
+++ b/src/test/regress/sql/cont_trigger.sql
@@ -1,4 +1,6 @@
-CREATE CONTINUOUS VIEW cont_tg_cv AS SELECT count(*) FROM cont_tg_stream;
+select pg_sleep(2);
+
+CREATE CONTINUOUS VIEW cont_tg_cv AS SELECT x::int, count(*) FROM cont_tg_stream group by x;
 CREATE TABLE cont_tg_t (count int);
 CREATE OR REPLACE FUNCTION cont_tg_func()
 RETURNS trigger AS
@@ -10,7 +12,22 @@ END;
 $$
 LANGUAGE plpgsql;
 
-select pg_sleep(2);
+CREATE OR REPLACE FUNCTION bad_tg_func()
+RETURNS trigger AS
+$$
+BEGIN
+ INSERT INTO does_not_exist(count) VALUES (NEW.count);
+ RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER bad_tg AFTER INSERT OR UPDATE ON cont_tg_cv FOR EACH ROW EXECUTE PROCEDURE bad_tg_func();
+INSERT INTO cont_tg_stream (x) VALUES (1), (1), (1); SELECT pg_sleep(2);
+DROP TRIGGER bad_tg on cont_tg_cv;
+
+TRUNCATE CONTINUOUS VIEW cont_tg_cv;
+TRUNCATE TABLE cont_tg_t;
 
 -- Invalid triggers
 CREATE TRIGGER cont_tg BEFORE INSERT ON cont_tg_cv FOR EACH ROW EXECUTE PROCEDURE cont_tg_func();


### PR DESCRIPTION
If a trigger function inside a continuous trigger batch to be processed fails, abort the transaction and clean up.