### PR TITLE
Fix deadlock between drop view and combiner.

### DIFF
--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -734,6 +734,7 @@ init_query_state(ContExecutor *cont_exec, ContQueryState *base)
 			ALLOCSET_DEFAULT_INITSIZE,
 			ALLOCSET_DEFAULT_MAXSIZE);
 
+	matrel = heap_openrv_extended(base->query->matrel, AccessShareLock, true);
 	pstmt = GetContPlan(base->query, COMBINER);
 
 	state->batch = tuplestore_begin_heap(true, true, continuous_query_combiner_work_mem);
@@ -749,7 +750,6 @@ init_query_state(ContExecutor *cont_exec, ContQueryState *base)
 	state->group_hashes_len = continuous_query_batch_size;
 	state->group_hashes = palloc0(state->group_hashes_len * sizeof(int64));
 
-	matrel = heap_openrv_extended(base->query->matrel, AccessShareLock, true);
 	if (matrel == NULL)
 	{
 		base->query = NULL;


### PR DESCRIPTION
GetContPlan grabs a lock on the matrel index, before the lock on the matrel was being taken.
This is in reverse order to dropping, so this causes a deadlock.

Moving the matrel lock above GetContPlan fixes this.