### PR TITLE
fixed docker pid issue

### DIFF
--- a/pkg/docker/scripts/startpipeline
+++ b/pkg/docker/scripts/startpipeline
@@ -20,4 +20,4 @@ if [ ! -d "/mnt/pipelinedb/data" ] || [ ! "$(ls -A /mnt/pipelinedb/data)" ]; the
     cp /scripts/conf/*.conf /mnt/pipelinedb/data/
 fi
 
-su - pipeline -c "pipeline-server -D /mnt/pipelinedb/data"
+exec su - pipeline -c "pipeline-server -D /mnt/pipelinedb/data"


### PR DESCRIPTION
Docker will not signal child process within a container. So when you fork in a shell script you need to use exec to replace PID 1 with the server binary. This allows clean shutdowns.

See: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/

with:
```
ubuntu@tstmesos19:~$ sudo docker stop e28d8e565b91df3e06386
e28d8e565b91df3e06386
ubuntu@tstmesos19:~$ sudo docker logs -f e28d8e565b91df3e06386
LOG:  database system was interrupted; last known up at 2016-05-26 22:17:43 GMT
LOG:  database system was not properly shut down; automatic recovery in progress
LOG:  redo starts at 25/5B138BC8
LOG:  invalid record length at 25/8B715480
LOG:  redo done at 25/8B715410
LOG:  last completed transaction was at log time 2016-05-26 22:17:42.588157+00
LOG:  MultiXact member wraparound protections are now enabled
    ____  _            ___            ____  ____
   / __ \(_)___  ___  / (_)___  ___  / __ \/ __ )
  / /_/ / / __ \/ _ \/ / / __ \/ _ \/ / / / __  |
 / ____/ / /_/ /  __/ / / / / /  __/ /_/ / /_/ /
/_/   /_/ .___/\___/_/_/_/ /_/\___/_____/_____/
       /_/

LOG:  database system is ready to accept connections
LOG:  continuous query scheduler started
LOG:  ipc message broker started
LOG:  autovacuum launcher started
LOG:  starting continuous query processes for database: "pipeline"
LOG:  continuous query process "worker2 [pipeline]" running with pid 29
LOG:  continuous query process "combiner4 [pipeline]" running with pid 19
LOG:  continuous query process "worker5 [pipeline]" running with pid 26
LOG:  continuous query process "worker4 [pipeline]" running with pid 27
LOG:  continuous query process "worker0 [pipeline]" running with pid 31
LOG:  continuous query process "combiner1 [pipeline]" running with pid 22
LOG:  continuous query process "worker3 [pipeline]" running with pid 28
LOG:  continuous query process "combiner3 [pipeline]" running with pid 20
LOG:  continuous query process "combiner0 [pipeline]" running with pid 23
LOG:  continuous query process "combiner2 [pipeline]" running with pid 21
LOG:  continuous query process "worker6 [pipeline]" running with pid 25
LOG:  continuous query process "worker1 [pipeline]" running with pid 30
LOG:  continuous query process "worker7 [pipeline]" running with pid 24

Session terminated, terminating shell...LOG:  received smart shutdown request
LOG:  ipc message broker shutting down
LOG:  autovacuum launcher shutting down
LOG:  continuous query scheduler shutting down
LOG:  continuous query process "combiner0 [pipeline]" was killed
LOG:  continuous query process "combiner1 [pipeline]" was killed
LOG:  continuous query process "combiner3 [pipeline]" was killed
LOG:  continuous query process "combiner2 [pipeline]" was killed
LOG:  continuous query process "combiner4 [pipeline]" was killed
LOG:  worker process: combiner0 [pipeline] (PID 23) exited with exit code 1
LOG:  worker process: combiner1 [pipeline] (PID 22) exited with exit code 1
LOG:  worker process: combiner3 [pipeline] (PID 20) exited with exit code 1
LOG:  worker process: combiner4 [pipeline] (PID 19) exited with exit code 1
LOG:  worker process: combiner2 [pipeline] (PID 21) exited with exit code 1
LOG:  continuous query process "worker5 [pipeline]" was killed
LOG:  continuous query process "worker0 [pipeline]" was killed
LOG:  worker process: worker5 [pipeline] (PID 26) exited with exit code 1
LOG:  continuous query process "worker4 [pipeline]" was killed
LOG:  continuous query process "worker3 [pipeline]" was killed
LOG:  continuous query process "worker6 [pipeline]" was killed
LOG:  continuous query process "worker7 [pipeline]" was killed
LOG:  continuous query process "worker1 [pipeline]" was killed
LOG:  worker process: worker4 [pipeline] (PID 27) exited with exit code 1
LOG:  worker process: worker0 [pipeline] (PID 31) exited with exit code 1
LOG:  worker process: worker3 [pipeline] (PID 28) exited with exit code 1
LOG:  worker process: worker6 [pipeline] (PID 25) exited with exit code 1
LOG:  worker process: worker7 [pipeline] (PID 24) exited with exit code 1
LOG:  worker process: worker1 [pipeline] (PID 30) exited with exit code 1
LOG:  continuous query process "worker2 [pipeline]" was killed
LOG:  worker process: worker2 [pipeline] (PID 29) exited with exit code 1
LOG:  shutting down
LOG:  database system is shut down
 ...terminated.```