### PR TITLE
1573 changestreams

### DIFF
--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -211,7 +211,7 @@ GetPipelineQueryTuple(RangeVar *name)
  * Adds a CV to the `pipeline_query` catalog table.
  */
 Oid
-DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid csrelid, Oid seqrelid, bool gc, bool adhoc, Oid *pq_id)
+DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid osrelid, Oid seqrelid, bool gc, bool adhoc, Oid *pq_id)
 {
 	Relation pipeline_query;
 	HeapTuple tup;
@@ -242,7 +242,7 @@ DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid csrelid, Oid seq
 	values[Anum_pipeline_query_relid - 1] = ObjectIdGetDatum(relid);
 	values[Anum_pipeline_query_active - 1] = BoolGetDatum(continuous_queries_enabled);
 	values[Anum_pipeline_query_query - 1] = CStringGetTextDatum(query_str);
-	values[Anum_pipeline_query_csrelid - 1] = ObjectIdGetDatum(csrelid);
+	values[Anum_pipeline_query_osrelid - 1] = ObjectIdGetDatum(osrelid);
 	values[Anum_pipeline_query_matrelid - 1] = ObjectIdGetDatum(matrelid);
 	values[Anum_pipeline_query_seqrelid - 1] = ObjectIdGetDatum(seqrelid);
 	values[Anum_pipeline_query_gc - 1] = BoolGetDatum(gc);
@@ -553,7 +553,7 @@ GetContQueryForId(Oid id)
 	cq->seqrelid = row->seqrelid;
 	cq->matrelid = row->matrelid;
 	cq->active = row->active;
-	cq->csrel = makeRangeVar(get_namespace_name(get_rel_namespace(row->csrelid)), get_rel_name(row->csrelid), -1);
+	cq->osrel = makeRangeVar(get_namespace_name(get_rel_namespace(row->osrelid)), get_rel_name(row->osrelid), -1);
 
 	if (cq->type == CONT_VIEW)
 	{

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -550,7 +550,7 @@ GetContQueryForId(Oid id)
 	cq->type = row->type == PIPELINE_QUERY_TRANSFORM ? CONT_TRANSFORM : CONT_VIEW;
 
 	cq->relid = row->relid;
-	cq->relname = get_rel_name(row->relid);
+	cq->name = makeRangeVar(get_namespace_name(get_rel_namespace(row->relid)), get_rel_name(row->relid), -1);
 	cq->seqrelid = row->seqrelid;
 	cq->matrelid = row->matrelid;
 	cq->active = row->active;

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -554,7 +554,7 @@ GetContQueryForId(Oid id)
 	cq->seqrelid = row->seqrelid;
 	cq->matrelid = row->matrelid;
 	cq->active = row->active;
-	cq->osrel = makeRangeVar(get_namespace_name(get_rel_namespace(row->osrelid)), get_rel_name(row->osrelid), -1);
+	cq->osrelid = row->osrelid;
 
 	if (cq->type == CONT_VIEW)
 	{

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -211,7 +211,7 @@ GetPipelineQueryTuple(RangeVar *name)
  * Adds a CV to the `pipeline_query` catalog table.
  */
 Oid
-DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid seqrelid, bool gc, bool adhoc, Oid *pq_id)
+DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid csrelid, Oid seqrelid, bool gc, bool adhoc, Oid *pq_id)
 {
 	Relation pipeline_query;
 	HeapTuple tup;
@@ -242,6 +242,7 @@ DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid seqrelid, bool g
 	values[Anum_pipeline_query_relid - 1] = ObjectIdGetDatum(relid);
 	values[Anum_pipeline_query_active - 1] = BoolGetDatum(continuous_queries_enabled);
 	values[Anum_pipeline_query_query - 1] = CStringGetTextDatum(query_str);
+	values[Anum_pipeline_query_csrelid - 1] = ObjectIdGetDatum(csrelid);
 	values[Anum_pipeline_query_matrelid - 1] = ObjectIdGetDatum(matrelid);
 	values[Anum_pipeline_query_seqrelid - 1] = ObjectIdGetDatum(seqrelid);
 	values[Anum_pipeline_query_gc - 1] = BoolGetDatum(gc);
@@ -552,6 +553,7 @@ GetContQueryForId(Oid id)
 	cq->seqrelid = row->seqrelid;
 	cq->matrelid = row->matrelid;
 	cq->active = row->active;
+	cq->csrel = makeRangeVar(get_namespace_name(get_rel_namespace(row->csrelid)), get_rel_name(row->csrelid), -1);
 
 	if (cq->type == CONT_VIEW)
 	{

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -568,6 +568,7 @@ GetContQueryForId(Oid id)
 	tmp = SysCacheGetAttr(PIPELINEQUERYRELID, tup, Anum_pipeline_query_query, &isnull);
 	query = (Query *) stringToNode(TextDatumGetCString(tmp));
 	cq->sql = deparse_query_def(query);
+	cq->is_sw = row->gc;
 	cq->sw_step_factor = query->swStepFactor;
 
 	cq->tgfn = row->tgfn;

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -211,7 +211,7 @@ GetPipelineQueryTuple(RangeVar *name)
  * Adds a CV to the `pipeline_query` catalog table.
  */
 Oid
-DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid osrelid, Oid seqrelid, bool gc, bool adhoc, Oid *pq_id)
+DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid seqrelid, bool gc, bool adhoc, Oid *pq_id)
 {
 	Relation pipeline_query;
 	HeapTuple tup;
@@ -242,7 +242,6 @@ DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid osrelid, Oid seq
 	values[Anum_pipeline_query_relid - 1] = ObjectIdGetDatum(relid);
 	values[Anum_pipeline_query_active - 1] = BoolGetDatum(continuous_queries_enabled);
 	values[Anum_pipeline_query_query - 1] = CStringGetTextDatum(query_str);
-	values[Anum_pipeline_query_osrelid - 1] = ObjectIdGetDatum(osrelid);
 	values[Anum_pipeline_query_matrelid - 1] = ObjectIdGetDatum(matrelid);
 	values[Anum_pipeline_query_seqrelid - 1] = ObjectIdGetDatum(seqrelid);
 	values[Anum_pipeline_query_gc - 1] = BoolGetDatum(gc);
@@ -279,7 +278,7 @@ DefineContinuousView(Oid relid, Query *query, Oid matrelid, Oid osrelid, Oid seq
 }
 
 void
-UpdateContViewRelId(Oid cvid, Oid cvrelid)
+UpdateContViewRelIds(Oid cvid, Oid cvrelid, Oid osrelid)
 {
 	Relation pipeline_query = heap_open(PipelineQueryRelationId, RowExclusiveLock);
 	HeapTuple tup = SearchSysCache1(PIPELINEQUERYID, ObjectIdGetDatum(cvid));
@@ -296,7 +295,9 @@ UpdateContViewRelId(Oid cvid, Oid cvrelid)
 	MemSet(replace, 0 , sizeof(replace));
 	MemSet(nulls, 0 , sizeof(nulls));
 	replace[Anum_pipeline_query_relid - 1] = true;
+	replace[Anum_pipeline_query_osrelid - 1] = true;
 	values[Anum_pipeline_query_relid - 1] = ObjectIdGetDatum(cvrelid);
+	values[Anum_pipeline_query_osrelid - 1] = ObjectIdGetDatum(osrelid);
 
 	new = heap_modify_tuple(tup, RelationGetDescr(pipeline_query), values, nulls, replace);
 

--- a/src/backend/pipeline/cont_adhoc.c
+++ b/src/backend/pipeline/cont_adhoc.c
@@ -635,7 +635,7 @@ CleanupAdhocContinuousView(ContQuery *view)
 	Portal portal;
 
 	stmt->objects = list_make1(
-			list_make2(makeString(get_namespace_name(get_rel_namespace(view->relid))), makeString(view->relname)));
+			list_make2(makeString(view->name->schemaname), makeString(view->name->relname)));
 	stmt->removeType = OBJECT_CONTVIEW;
 
 	querytree_list = pg_analyze_and_rewrite((Node *) stmt, "DROP",

--- a/src/backend/pipeline/cont_analyze.c
+++ b/src/backend/pipeline/cont_analyze.c
@@ -2888,8 +2888,6 @@ make_finalize_for_viewdef(ParseState *pstate, Oid cvid, Var *var, Node *arg)
 	Oid finaltype = InvalidOid;
 	Query *q = get_worker_query_for_id(cvid);
 
-	Assert(IsContQueryAdhocProcess() || !IsContQueryProcess());
-
 	result = attr_to_aggs(var->varattno, q->targetList);
 	extract_agg_final_info(result, &fnoid, &type, &finaltype);
 	GetCombineInfo(fnoid, &combinefn, &transoutfn, &combineinfn, &statetype);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -602,7 +602,7 @@ sync_sw_matrel_groups(ContQueryCombinerState *state)
 	/* We only need to scan for in-window rows */
 	ScanKeyInit(&skey[0],
 				state->sw->arrival_ts_attr,
-				BTGreaterEqualStrategyNumber, F_TIMESTAMP_GE, TimestampTzGetDatum(0));
+				BTGreaterEqualStrategyNumber, F_TIMESTAMP_GE, TimestampTzGetDatum(oldest));
 
 	scan = heap_beginscan(matrel, GetTransactionSnapshot(), 1, skey);
 

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -831,6 +831,9 @@ assign_output_stream_projection(ContQueryCombinerState *state)
 	EState *estate = CreateExecutorState();
 	ExprContext *context = CreateStandaloneExprContext();
 
+	if (state->base.query->sw_step_factor)
+		return;
+
 	foreach(lc, overlay->planTree->targetlist)
 	{
 		TargetEntry *te = (TargetEntry *) lfirst(lc);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -1393,9 +1393,6 @@ assign_output_stream_projection(ContQueryCombinerState *state)
 	EState *estate = CreateExecutorState();
 	ExprContext *context = CreateStandaloneExprContext();
 
-	if (state->base.query->is_sw)
-		return;
-
 	/* Non-sliding windows not supported */
 	if (GetWindowTimeColumn(state->base.query->name))
 		return;
@@ -1415,7 +1412,6 @@ assign_output_stream_projection(ContQueryCombinerState *state)
 
 	state->output_stream_proj = build_projection(overlay->planTree->targetlist, estate, context, NULL);
 	state->proj_input_slot = MakeSingleTupleTableSlot(state->desc);
-	state->output_stream_arrival_ts = find_arrival_ts_attr(state->os_slot->tts_tupleDescriptor);
 }
 
 static ContQueryState *
@@ -1480,6 +1476,9 @@ init_query_state(ContExecutor *cont_exec, ContQueryState *base)
 	state->overlay_desc = CreateTupleDescCopy(RelationGetDescr(overlay));
 	state->overlay_slot = MakeSingleTupleTableSlot(state->overlay_desc);
 	state->overlay_prev_slot = MakeSingleTupleTableSlot(state->overlay_desc);
+	state->output_stream_arrival_ts = find_arrival_ts_attr(state->os_slot->tts_tupleDescriptor);
+
+	Assert(state->output_stream_arrival_ts);
 	heap_close(overlay, NoLock);
 
 	assign_output_stream_projection(state);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -579,7 +579,8 @@ sync_combine(ContQueryCombinerState *state)
 		return;
 
 	osri = CQOSRelOpen(osrel);
-	BeginStreamModify(NULL, osri, NIL, 0, 0);
+
+	BeginStreamModify(NULL, osri, NIL, 0, REENTRANT_STREAM_INSERT);
 	sis = (StreamInsertState *) osri->ri_FdwState;
 	Assert(sis);
 
@@ -831,7 +832,7 @@ assign_output_stream_projection(ContQueryCombinerState *state)
 	EState *estate = CreateExecutorState();
 	ExprContext *context = CreateStandaloneExprContext();
 
-	if (state->base.query->sw_step_factor)
+	if (state->base.query->is_sw)
 		return;
 
 	foreach(lc, overlay->planTree->targetlist)

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -906,7 +906,7 @@ tick_sw_groups(ContQueryCombinerState *state, Relation matrel, bool force)
 	if (!hash_get_num_entries(state->sw->step_groups->hashtab))
 		return;
 
-	osrel = heap_openrv_extended(state->base.query->osrel, RowExclusiveLock, true);
+	osrel = try_relation_open(state->base.query->osrelid, RowExclusiveLock);
 	if (osrel == NULL)
 		return;
 
@@ -1201,7 +1201,7 @@ sync_combine(ContQueryCombinerState *state)
 	 */
 	if (!state->base.query->is_sw)
 	{
-		osrel = heap_openrv_extended(state->base.query->osrel, RowExclusiveLock, true);
+		osrel = try_relation_open(state->base.query->osrelid, RowExclusiveLock);
 		if (osrel == NULL)
 			return;
 
@@ -1528,7 +1528,7 @@ init_query_state(ContExecutor *cont_exec, ContQueryState *base)
 		return base;
 	}
 
-	osrel = heap_openrv_extended(base->query->osrel, AccessShareLock, true);
+	osrel = try_relation_open(base->query->osrelid, AccessShareLock);
 	state->os_slot = MakeSingleTupleTableSlot(CreateTupleDescCopy(RelationGetDescr(osrel)));
 	heap_close(osrel, AccessShareLock);
 

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -671,6 +671,13 @@ sync_combine(ContQueryCombinerState *state)
 	CQMatRelClose(ri);
 	heap_close(matrel, NoLock);
 
+
+
+
+
+
+
+
 	EndStreamModify(NULL, osri);
 	CQOSRelClose(osri);
 	heap_close(osrel, NoLock);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -907,6 +907,9 @@ tick_sw_groups(ContQueryCombinerState *state, Relation matrel, bool force)
 		return;
 
 	osrel = heap_openrv_extended(state->base.query->osrel, RowExclusiveLock, true);
+	if (osrel == NULL)
+		return;
+
 	osri = CQOSRelOpen(osrel);
 
 	BeginStreamModify(NULL, osri, NIL, 0, REENTRANT_STREAM_INSERT);
@@ -1199,6 +1202,9 @@ sync_combine(ContQueryCombinerState *state)
 	if (!state->base.query->is_sw)
 	{
 		osrel = heap_openrv_extended(state->base.query->osrel, RowExclusiveLock, true);
+		if (osrel == NULL)
+			return;
+
 		osri = CQOSRelOpen(osrel);
 
 		BeginStreamModify(NULL, osri, NIL, 0, REENTRANT_STREAM_INSERT);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -1742,7 +1742,7 @@ ContinuousQueryCombinerMain(void)
 				if (state->sw)
 				{
 					tick_sw_groups(state, NULL, false);
-					min_tick_ms = Min(min_tick_ms, state->base.query->sw_step_ms);
+					min_tick_ms = min_tick_ms ? Min(min_tick_ms, state->base.query->sw_step_ms) : state->base.query->sw_step_ms;
 				}
 
 				MemoryContextResetAndDeleteChildren(state->base.tmp_cxt);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -1742,7 +1742,7 @@ ContinuousQueryCombinerMain(void)
 				if (state->sw)
 				{
 					tick_sw_groups(state, NULL, false);
-					min_tick_ms = state->base.query->sw_step_ms;
+					min_tick_ms = Min(min_tick_ms, state->base.query->sw_step_ms);
 				}
 
 				MemoryContextResetAndDeleteChildren(state->base.tmp_cxt);

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -593,6 +593,7 @@ sync_sw_matrel_groups(ContQueryCombinerState *state, Relation matrel)
 	FunctionCallInfoData hashfcinfo;
 	FmgrInfo flinfo;
 	int64 cv_name_hash;
+	bool close_matrel = matrel == NULL;
 
 	/*
 	 * We only need to sync once, all other groups will be cached
@@ -670,7 +671,9 @@ sync_sw_matrel_groups(ContQueryCombinerState *state, Relation matrel)
 	}
 
 	heap_endscan(scan);
-	heap_close(matrel, AccessShareLock);
+
+	if (close_matrel)
+		heap_close(matrel, AccessShareLock);
 }
 
 /*

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -971,35 +971,6 @@ find_arrival_ts_attr(TupleDesc desc)
 }
 
 /*
- * lookup_eq_func_oid
- *
- * Get the pk field eq opr, so we can use it for hashing.
- * If the tuple desc doesn't match what we are expecting, we return InvalidOid
- */
-static Oid
-lookup_eq_func_oid(TupleDesc desc, AttrNumber pk)
-{
-	bool is_hash;
-	Form_pg_attribute attr;
-	int pki = pk - 1;
-	Oid eqOpr = InvalidOid;
-
-	Assert(pki >= 0 && pki < desc->natts);
-
-	attr = desc->attrs[pki];
-
-	get_sort_group_operators(attr->atttypid,
-							 false, true, false,
-							 NULL, &eqOpr, NULL,
-							 &is_hash);
-
-	if (!is_hash)
-		return InvalidOid;
-
-	return eqOpr;
-}
-
-/*
  * init_sw_state
  *
  * Initialize the state necessary to write SW results to output streams
@@ -1007,7 +978,6 @@ lookup_eq_func_oid(TupleDesc desc, AttrNumber pk)
 static void
 init_sw_state(ContQueryCombinerState *state, Relation matrel)
 {
-	Oid eq_func_oid = lookup_eq_func_oid(state->desc, state->pk);
 	MemoryContext tmp_cxt;
 	TuplestoreScan *scan;
 	MemoryContext old;
@@ -1017,8 +987,6 @@ init_sw_state(ContQueryCombinerState *state, Relation matrel)
 	FmgrInfo *eq_funcs;
 	FmgrInfo *hash_funcs;
 	int n_group_attr = 0;
-
-	Assert(OidIsValid(eq_func_oid));
 
 	if (!state->isagg)
 		return;

--- a/src/backend/pipeline/cont_execute.c
+++ b/src/backend/pipeline/cont_execute.c
@@ -475,7 +475,7 @@ ContExecutorDestroy(ContExecutor *exec)
 }
 
 void
-ContExecutorStartBatch(ContExecutor *exec)
+ContExecutorStartBatch(ContExecutor *exec, int timeout)
 {
 	bool is_empty;
 
@@ -494,11 +494,10 @@ ContExecutorStartBatch(ContExecutor *exec)
 
 			pgstat_report_activity(STATE_IDLE, proc_name);
 
-			// if we need to tick SW tuples, time out here at the minimum step size
 			if (exec->ptype == WORKER)
-				ipc_multi_queue_wait_non_empty(exec->ipcmq, 0);
+				ipc_multi_queue_wait_non_empty(exec->ipcmq, timeout);
 			else
-				ipc_queue_wait_non_empty(exec->ipcq, 0);
+				ipc_queue_wait_non_empty(exec->ipcq, timeout);
 
 			pgstat_report_activity(STATE_RUNNING, proc_name);
 

--- a/src/backend/pipeline/cont_execute.c
+++ b/src/backend/pipeline/cont_execute.c
@@ -494,11 +494,11 @@ ContExecutorStartBatch(ContExecutor *exec)
 
 			pgstat_report_activity(STATE_IDLE, proc_name);
 
+			// if we need to tick SW tuples, time out here at the minimum step size
 			if (exec->ptype == WORKER)
 				ipc_multi_queue_wait_non_empty(exec->ipcmq, 0);
 			else
 				ipc_queue_wait_non_empty(exec->ipcq, 0);
-
 
 			pgstat_report_activity(STATE_RUNNING, proc_name);
 
@@ -674,7 +674,7 @@ ContExecutorStartNextQuery(ContExecutor *exec)
 			MemoryContextSwitchTo(old);
 		}
 		else
-			debug_query_string = exec->current_query->query->relname;
+			debug_query_string = exec->current_query->query->name->relname;
 	}
 
 	if (exec->current_query)

--- a/src/backend/pipeline/cont_worker.c
+++ b/src/backend/pipeline/cont_worker.c
@@ -197,7 +197,7 @@ ContinuousQueryWorkerMain(void)
 
 		ContExecutorStartBatch(cont_exec, 0);
 
-		while ((query_id = ContExecutorStartNextQuery(cont_exec)) != InvalidOid)
+		while ((query_id = ContExecutorStartNextQuery(cont_exec, 0)) != InvalidOid)
 		{
 			Plan *plan = NULL;
 			EState *estate = NULL;

--- a/src/backend/pipeline/cont_worker.c
+++ b/src/backend/pipeline/cont_worker.c
@@ -195,7 +195,7 @@ ContinuousQueryWorkerMain(void)
 		if (ShouldTerminateContQueryProcess())
 			break;
 
-		ContExecutorStartBatch(cont_exec);
+		ContExecutorStartBatch(cont_exec, 0);
 
 		while ((query_id = ContExecutorStartNextQuery(cont_exec)) != InvalidOid)
 		{

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -28,6 +28,34 @@
 bool continuous_query_materialization_table_updatable;
 
 /*
+ * CQOSRelOpen
+ *
+ * Open an output stream
+ */
+ResultRelInfo *
+CQOSRelOpen(Relation osrel)
+{
+	ResultRelInfo *resultRelInfo;
+
+	resultRelInfo = makeNode(ResultRelInfo);
+	resultRelInfo->ri_RangeTableIndex = 1; /* dummy */
+	resultRelInfo->ri_RelationDesc = osrel;
+	resultRelInfo->ri_TrigDesc = NULL;
+
+	return resultRelInfo;
+}
+
+/*
+ * CQCSRelClose
+ */
+void
+CQOSRelClose(ResultRelInfo *rinfo)
+{
+	ExecCloseIndices(rinfo);
+	pfree(rinfo);
+}
+
+/*
  * CQMatViewOpen
  *
  * Open any indexes associated with the given materialization table

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -51,7 +51,6 @@ CQOSRelOpen(Relation osrel)
 void
 CQOSRelClose(ResultRelInfo *rinfo)
 {
-	ExecCloseIndices(rinfo);
 	pfree(rinfo);
 }
 

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -147,6 +147,17 @@ ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
 }
 
 char *
+CVNameToCSRelName(char *cv_name)
+{
+	char *relname = palloc0(NAMEDATALEN);
+
+	strcpy(relname, cv_name);
+	append_suffix(relname, CQ_CSREL_SUFFIX, NAMEDATALEN);
+
+	return relname;
+}
+
+char *
 CVNameToMatRelName(char *cv_name)
 {
 	char *relname = palloc0(NAMEDATALEN);

--- a/src/backend/pipeline/cqmatrel.c
+++ b/src/backend/pipeline/cqmatrel.c
@@ -175,12 +175,12 @@ ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate)
 }
 
 char *
-CVNameToCSRelName(char *cv_name)
+CVNameToOSRelName(char *cv_name)
 {
 	char *relname = palloc0(NAMEDATALEN);
 
 	strcpy(relname, cv_name);
-	append_suffix(relname, CQ_CSREL_SUFFIX, NAMEDATALEN);
+	append_suffix(relname, CQ_OSREL_SUFFIX, NAMEDATALEN);
 
 	return relname;
 }

--- a/src/backend/pipeline/ipc/queue.c
+++ b/src/backend/pipeline/ipc/queue.c
@@ -332,6 +332,9 @@ ipc_queue_wait_non_empty(ipc_queue *ipcq, int timeoutms)
 		if (r & WL_POSTMASTER_DEATH)
 			break;
 
+		if (r & WL_TIMEOUT)
+			break;
+
 		if (ShouldTerminateContQueryProcess())
 			break;
 

--- a/src/backend/pipeline/stream_fdw.c
+++ b/src/backend/pipeline/stream_fdw.c
@@ -520,6 +520,7 @@ BeginStreamModify(ModifyTableState *mtstate, ResultRelInfo *result_info,
 	if (!bms_is_empty(adhoc_targets))
 		sis->adhoc_state = AdhocInsertStateCreate(adhoc_targets);
 
+	sis->flags = eflags;
 	sis->targets = worker_targets;
 	sis->ack = ack;
 	sis->batch = batch;
@@ -609,7 +610,7 @@ EndStreamModify(EState *estate, ResultRelInfo *result_info)
 	if (sis->worker_queue)
 	{
 		ipc_queue_unlock(sis->worker_queue);
-		if (synchronous_stream_insert)
+		if (!(sis->flags & REENTRANT_STREAM_INSERT) && synchronous_stream_insert)
 			InsertBatchWaitAndRemove(sis->batch, sis->count);
 	}
 

--- a/src/backend/pipeline/transformReceiver.c
+++ b/src/backend/pipeline/transformReceiver.c
@@ -163,7 +163,7 @@ SetTransformDestReceiverParams(DestReceiver *self, ContExecutor *exec, ContQuery
 		fmgr_info(query->tgfn, finfo);
 
 		/* Create mock TriggerData and Trigger */
-		trig->tgname = query->relname;
+		trig->tgname = query->name->relname;
 		trig->tgenabled = TRIGGER_FIRES_ALWAYS;
 		trig->tgfoid = query->tgfn;
 		trig->tgnargs = query->tgnargs;

--- a/src/backend/pipeline/transformReceiver.c
+++ b/src/backend/pipeline/transformReceiver.c
@@ -108,9 +108,6 @@ transform_receive(TupleTableSlot *slot, DestReceiver *self)
 			t->acks = InsertBatchAckCreate(t->cont_exec->yielded_msgs, &t->nacks);
 	}
 
-	// insert into ostream of necessary
-
-
 	MemoryContextSwitchTo(old);
 }
 

--- a/src/backend/pipeline/transformReceiver.c
+++ b/src/backend/pipeline/transformReceiver.c
@@ -108,6 +108,9 @@ transform_receive(TupleTableSlot *slot, DestReceiver *self)
 			t->acks = InsertBatchAckCreate(t->cont_exec->yielded_msgs, &t->nacks);
 	}
 
+	// insert into ostream of necessary
+
+
 	MemoryContextSwitchTo(old);
 }
 

--- a/src/backend/utils/adt/hashfuncs.c
+++ b/src/backend/utils/adt/hashfuncs.c
@@ -168,3 +168,33 @@ hash_group(PG_FUNCTION_ARGS)
 
 	PG_RETURN_INT32(result);
 }
+
+
+/*
+ * hash_group_for_combiner
+ *
+ * Hashes a tuple's group in order to determine which combiner it belongs to
+ */
+uint64
+hash_group_for_combiner(TupleTableSlot *slot, FuncExpr *hash, FunctionCallInfo fcinfo)
+{
+	ListCell *lc;
+	Datum result;
+	int i = 0;
+
+	foreach(lc, hash->args)
+	{
+		AttrNumber attno = ((Var *) lfirst(lc))->varattno;
+		bool isnull;
+		Datum d;
+
+		d = slot_getattr(slot, attno, &isnull);
+		fcinfo->arg[i] = d;
+		fcinfo->argnull[i] = isnull;
+		i++;
+	}
+
+	result = FunctionCallInvoke(fcinfo);
+
+	return DatumGetInt64(result);
+}

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -53,6 +53,6 @@
  */
 
 /*							yyyymmddN */
-#define CATALOG_VERSION_NO	201605311
+#define CATALOG_VERSION_NO	201607181
 
 #endif

--- a/src/include/catalog/pipeline_query.h
+++ b/src/include/catalog/pipeline_query.h
@@ -33,6 +33,7 @@ CATALOG(pipeline_query,4242)
 	char 		type;
 	Oid			relid;
 	bool 		active;
+	Oid 		osrelid;
 
 	/* valid for views only */
 	Oid			matrelid;
@@ -62,20 +63,21 @@ typedef FormData_pipeline_query *Form_pipeline_query;
  *		compiler constants for pipeline_query
  * ----------------
  */
-#define Natts_pipeline_query			13
+#define Natts_pipeline_query			14
 #define Anum_pipeline_query_id			1
 #define Anum_pipeline_query_type		2
 #define Anum_pipeline_query_relid		3
 #define Anum_pipeline_query_active		4
-#define Anum_pipeline_query_matrelid	5
-#define Anum_pipeline_query_seqrelid	6
-#define Anum_pipeline_query_gc			7
-#define Anum_pipeline_query_adhoc		8
-#define Anum_pipeline_query_step_factor 9
-#define Anum_pipeline_query_tgfn		10
-#define Anum_pipeline_query_tgnargs		11
-#define Anum_pipeline_query_tgargs		12
-#define Anum_pipeline_query_query 		13
+#define Anum_pipeline_query_osrelid		5
+#define Anum_pipeline_query_matrelid	6
+#define Anum_pipeline_query_seqrelid	7
+#define Anum_pipeline_query_gc			8
+#define Anum_pipeline_query_adhoc		9
+#define Anum_pipeline_query_step_factor 10
+#define Anum_pipeline_query_tgfn		11
+#define Anum_pipeline_query_tgnargs		12
+#define Anum_pipeline_query_tgargs		13
+#define Anum_pipeline_query_query 		14
 
 #define PIPELINE_QUERY_VIEW 		'v'
 #define PIPELINE_QUERY_TRANSFORM 	't'

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -45,7 +45,7 @@ typedef struct ContQuery
 	Oid seqrelid;
 	int sw_step_factor;
 	int sw_step_ms;
-	int sw_interval_ms;
+	uint64 sw_interval_ms;
 	bool is_sw;
 
 	/* for transform */

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -44,6 +44,7 @@ typedef struct ContQuery
 	RangeVar *matrel;
 	Oid seqrelid;
 	int sw_step_factor;
+	bool is_sw;
 
 	/* for transform */
 	Oid tgfn;

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -54,8 +54,8 @@ typedef struct ContQuery
 extern HeapTuple GetPipelineQueryTuple(RangeVar *name);
 extern void RemovePipelineQueryById(Oid oid);
 
-extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid csrelid, Oid seqrel, bool gc, bool adhoc, Oid *pq_id);
-extern void UpdateContViewRelId(Oid cvid, Oid cvrelid);
+extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid seqrel, bool gc, bool adhoc, Oid *pq_id);
+extern void UpdateContViewRelIds(Oid cvid, Oid cvrelid, Oid osrelid);
 extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid fnoid, List *args);
 
 extern Relation OpenCVRelFromMatRel(Relation matrel, LOCKMODE lockmode);

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -29,6 +29,7 @@ typedef enum ContQueryType
 typedef struct ContQuery
 {
 	Oid id;
+	RangeVar *name;
 	Oid oid; /* OID in pipeline_query table */
 	bool active;
 	ContQueryType type;
@@ -37,7 +38,6 @@ typedef struct ContQuery
 	Oid relid;
 	char *sql;
 	Oid matrelid;
-	char *relname;
 	RangeVar *osrel;
 
 	/* for view */

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -38,7 +38,7 @@ typedef struct ContQuery
 	Oid relid;
 	char *sql;
 	Oid matrelid;
-	RangeVar *osrel;
+	Oid osrelid;
 
 	/* for view */
 	RangeVar *matrel;

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -44,6 +44,8 @@ typedef struct ContQuery
 	RangeVar *matrel;
 	Oid seqrelid;
 	int sw_step_factor;
+	int sw_step_ms;
+	int sw_interval_ms;
 	bool is_sw;
 
 	/* for transform */

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -38,6 +38,7 @@ typedef struct ContQuery
 	char *sql;
 	Oid matrelid;
 	char *relname;
+	RangeVar *osrel;
 
 	/* for view */
 	RangeVar *matrel;
@@ -53,7 +54,7 @@ typedef struct ContQuery
 extern HeapTuple GetPipelineQueryTuple(RangeVar *name);
 extern void RemovePipelineQueryById(Oid oid);
 
-extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid seqrel, bool gc, bool adhoc, Oid *pq_id);
+extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid csrelid, Oid seqrel, bool gc, bool adhoc, Oid *pq_id);
 extern void UpdateContViewRelId(Oid cvid, Oid cvrelid);
 extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid fnoid, List *args);
 

--- a/src/include/pipeline/cont_execute.h
+++ b/src/include/pipeline/cont_execute.h
@@ -156,7 +156,7 @@ struct ContExecutor
 extern ContExecutor *ContExecutorNew(ContQueryProcType type, ContQueryStateInit initfn);
 extern void ContExecutorDestroy(ContExecutor *exec);
 extern void ContExecutorStartBatch(ContExecutor *exec, int timeout);
-extern Oid ContExecutorStartNextQuery(ContExecutor *exec);
+extern Oid ContExecutorStartNextQuery(ContExecutor *exec, int timeout);
 extern void ContExecutorPurgeQuery(ContExecutor *exec);
 extern void *ContExecutorYieldNextMessage(ContExecutor *exec, int *len);
 extern void ContExecutorEndQuery(ContExecutor *exec);

--- a/src/include/pipeline/cont_execute.h
+++ b/src/include/pipeline/cont_execute.h
@@ -155,7 +155,7 @@ struct ContExecutor
 
 extern ContExecutor *ContExecutorNew(ContQueryProcType type, ContQueryStateInit initfn);
 extern void ContExecutorDestroy(ContExecutor *exec);
-extern void ContExecutorStartBatch(ContExecutor *exec);
+extern void ContExecutorStartBatch(ContExecutor *exec, int timeout);
 extern Oid ContExecutorStartNextQuery(ContExecutor *exec);
 extern void ContExecutorPurgeQuery(ContExecutor *exec);
 extern void *ContExecutorYieldNextMessage(ContExecutor *exec, int *len);

--- a/src/include/pipeline/cqmatrel.h
+++ b/src/include/pipeline/cqmatrel.h
@@ -16,7 +16,7 @@
 
 extern bool continuous_query_materialization_table_updatable;
 
-#define CQ_CSREL_SUFFIX "_csrel"
+#define CQ_OSREL_SUFFIX "_osrel"
 #define CQ_MATREL_SUFFIX "_mrel"
 #define CQ_SEQREL_SUFFIX "_seq"
 #define CQ_MATREL_PKEY "$pk"
@@ -30,7 +30,7 @@ extern void ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlo
 extern void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);
 extern void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);
 
-extern char *CVNameToCSRelName(char *cv_name);
+extern char *CVNameToOSRelName(char *cv_name);
 extern char *CVNameToMatRelName(char *cv_name);
 extern char *CVNameToSeqRelName(char *cv_name);
 

--- a/src/include/pipeline/cqmatrel.h
+++ b/src/include/pipeline/cqmatrel.h
@@ -23,6 +23,8 @@ extern bool continuous_query_materialization_table_updatable;
 #define MatRelUpdatesEnabled() (continuous_query_materialization_table_updatable)
 
 extern ResultRelInfo *CQMatRelOpen(Relation matrel);
+extern void CQOSRelClose(ResultRelInfo *rinfo);
+extern ResultRelInfo *CQOSRelOpen(Relation osrel);
 extern void CQMatRelClose(ResultRelInfo *rinfo);
 extern void ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlot *slot, EState *estate);
 extern void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);

--- a/src/include/pipeline/cqmatrel.h
+++ b/src/include/pipeline/cqmatrel.h
@@ -16,6 +16,7 @@
 
 extern bool continuous_query_materialization_table_updatable;
 
+#define CQ_CSREL_SUFFIX "_csrel"
 #define CQ_MATREL_SUFFIX "_mrel"
 #define CQ_SEQREL_SUFFIX "_seq"
 #define CQ_MATREL_PKEY "$pk"
@@ -27,6 +28,7 @@ extern void ExecInsertCQMatRelIndexTuples(ResultRelInfo *indstate, TupleTableSlo
 extern void ExecCQMatRelUpdate(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);
 extern void ExecCQMatRelInsert(ResultRelInfo *ri, TupleTableSlot *slot, EState *estate);
 
+extern char *CVNameToCSRelName(char *cv_name);
 extern char *CVNameToMatRelName(char *cv_name);
 extern char *CVNameToSeqRelName(char *cv_name);
 

--- a/src/include/pipeline/stream_fdw.h
+++ b/src/include/pipeline/stream_fdw.h
@@ -18,6 +18,8 @@
 #include "nodes/relation.h"
 #include "utils/rel.h"
 
+#define REENTRANT_STREAM_INSERT 0x1
+
 typedef struct StreamProjectionInfo StreamProjectionInfo;
 
 typedef struct StreamScanState
@@ -45,6 +47,8 @@ typedef struct StreamInsertState
 
 	ipc_queue *worker_queue;
 	AdhocInsertState *adhoc_state;
+
+	int flags;
 } StreamInsertState;
 
 extern Datum stream_fdw_handler(PG_FUNCTION_ARGS);

--- a/src/include/pipeline/stream_fdw.h
+++ b/src/include/pipeline/stream_fdw.h
@@ -29,6 +29,24 @@ typedef struct StreamScanState
 	int ntuples;
 } StreamScanState;
 
+typedef struct StreamInsertState
+{
+	Bitmapset *targets;
+
+	long count;
+	long bytes;
+	int num_batches;
+
+	InsertBatch *batch;
+	InsertBatchAck *ack;
+
+	TupleDesc desc;
+	bytea *packed_desc;
+
+	ipc_queue *worker_queue;
+	AdhocInsertState *adhoc_state;
+} StreamInsertState;
+
 extern Datum stream_fdw_handler(PG_FUNCTION_ARGS);
 
 extern void GetStreamSize(PlannerInfo *root, RelOptInfo *baserel, Oid streamid);

--- a/src/include/utils/hashfuncs.h
+++ b/src/include/utils/hashfuncs.h
@@ -15,7 +15,12 @@
 #include "postgres.h"
 #include "fmgr.h"
 
+#define get_combiner_for_group_hash(hash) ((hash) % continuous_query_num_combiners)
+#define is_group_hash_mine(hash) (get_combiner_for_group_hash(hash) == MyContQueryProc->group_id)
+
 extern Datum hash_group(PG_FUNCTION_ARGS);
 extern Datum ls_hash_group(PG_FUNCTION_ARGS);
+extern uint64 hash_group_for_combiner(TupleTableSlot *slot, FuncExpr *hash, FunctionCallInfo fcinfo);
+
 
 #endif

--- a/src/test/py/test_output_streams.py
+++ b/src/test/py/test_output_streams.py
@@ -1,0 +1,70 @@
+from base import pipeline, clean_db
+import time
+
+
+def test_output_tree(pipeline, clean_db):
+  """
+  Create a relatively complex tree of continuous views
+  and transforms chained together by their output streams,
+  and verify that all output correctly propagates to the leaves.
+  """
+  pipeline.create_cv('level0_0', 'SELECT x::integer, count(*) FROM root GROUP BY x')
+
+  pipeline.create_cv('level1_0', 'SELECT (new).x, (new).count FROM level0_0_osrel')
+  pipeline.create_cv('level1_1', 'SELECT (new).x, (new).count FROM level0_0_osrel')
+
+  pipeline.create_cv('level2_0', 'SELECT (new).x, (new).count FROM level1_0_osrel')
+  pipeline.create_cv('level2_1', 'SELECT (new).x, (new).count FROM level1_0_osrel')
+  pipeline.create_cv('level2_2', 'SELECT (new).x, (new).count FROM level1_1_osrel')
+  pipeline.create_cv('level2_3', 'SELECT (new).x, (new).count FROM level1_1_osrel')
+
+  pipeline.create_cv('level3_0', 'SELECT (new).x, (new).count FROM level2_0_osrel')
+  pipeline.create_cv('level3_1', 'SELECT (new).x, (new).count FROM level2_0_osrel')
+  pipeline.create_cv('level3_2', 'SELECT (new).x, (new).count FROM level2_1_osrel')
+  pipeline.create_cv('level3_3', 'SELECT (new).x, (new).count FROM level2_1_osrel')
+  pipeline.create_cv('level3_4', 'SELECT (new).x, (new).count FROM level2_2_osrel')
+  pipeline.create_cv('level3_5', 'SELECT (new).x, (new).count FROM level2_2_osrel')
+  pipeline.create_cv('level3_6', 'SELECT (new).x, (new).count FROM level2_3_osrel')
+  pipeline.create_cv('level3_7', 'SELECT (new).x, (new).count FROM level2_3_osrel')
+
+  pipeline.insert('root', ('x',), [(x % 100,) for x in range(10000)])
+  time.sleep(5)
+
+  names = [r[0] for r in pipeline.execute('SELECT name FROM pipeline_views() ORDER BY name DESC')]
+  assert len(names) == 15
+
+  # Verify all values propagated to each node in the tree
+  for name in names:
+    rows = pipeline.execute('SELECT x, max(count) FROM %s GROUP BY x' % name)
+    for row in rows:
+      x, count = row
+      assert count == 100
+
+  pipeline.insert('root', ('x',), [(x % 100,) for x in range(10000)])
+  time.sleep(5)
+
+  # Verify all values propagated to each node in the tree again
+  for name in names:
+    rows = pipeline.execute('SELECT x, max(count) FROM %s GROUP BY x' % name)
+    for row in rows:
+      x, count = row
+      assert count == 200
+
+  # Drop these in reverse dependency order to prevent deadlocks
+  for name in names:
+    pipeline.drop_cv(name)
+
+
+def test_no_ticking_non_sw(pipeline, clean_db):
+  """
+  Verify that no ticking is done for non-SW queries. We should
+  only see new rows in the output stream when the combiner syncs
+  rows to disk.
+  """
+
+
+def test_concurrent_sw_ticking(pipeline, clean_db):
+  """
+  Verify that several concurrent sliding-window queries each
+  having different windows tick correctly at different intervals.
+  """

--- a/src/test/py/test_output_streams.py
+++ b/src/test/py/test_output_streams.py
@@ -93,3 +93,26 @@ def test_concurrent_sw_ticking(pipeline, clean_db):
   for name in names:
     pipeline.drop_cv(name)
 
+
+def test_transforms(pipeline, clean_db):
+  """
+  Verify that continuous transforms work properly on output streams
+  """
+  pipeline.create_cv('sw', 'SELECT x::integer, COUNT(*) FROM stream GROUP BY x',
+                     max_age='10 seconds')
+
+  # Write a row to a stream each time a row goes out of window
+  q = """
+  SELECT CASE WHEN (old).x IS NULL THEN (new).x ELSE (old).x END AS x
+  FROM sw_osrel WHERE old IS NOT NULL AND new IS NULL
+  """
+  pipeline.create_stream('oow_stream', x='integer')
+  pipeline.create_ct('ct', q, "pipeline_stream_insert('oow_stream')")
+  pipeline.create_cv('ct_recv', 'SELECT x FROM oow_stream')
+
+  pipeline.insert('stream', ('x',), [(x % 100,) for x in range(10000)])
+  time.sleep(20)
+
+  rows = list(pipeline.execute('SELECT * FROM ct_recv'))
+  assert len(rows) == 100
+

--- a/src/test/py/test_output_streams.py
+++ b/src/test/py/test_output_streams.py
@@ -80,8 +80,7 @@ def test_concurrent_sw_ticking(pipeline, clean_db):
   time.sleep(30)
 
   for name in output_names:
-
-    rows = pipeline.execute('SELECT COUNT(DISTINCT x) FROM %s' % name)
+    rows = list(pipeline.execute('SELECT COUNT(DISTINCT x) FROM %s' % name))
     assert rows[0][0] == 100
 
     for x in range(100):

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -26,6 +26,14 @@ Indexes:
     "cqcreate0_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
+\d+ cqcreate0_csrel;
+              Stream "public.cqcreate0_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate0_mrel(0)           | extended
+ new               | cqcreate0_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cqcreate0');
  pipeline_get_overlay_viewdef 
 ------------------------------
@@ -58,6 +66,14 @@ View definition:
 Indexes:
     "cqcreate1_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
+
+\d+ cqcreate1_csrel;
+              Stream "public.cqcreate1_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate1_mrel(0)           | extended
+ new               | cqcreate1_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate1');
     pipeline_get_overlay_viewdef    
@@ -94,6 +110,14 @@ View definition:
 Indexes:
     "cqcreate2_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
+
+\d+ cqcreate2_csrel;
+              Stream "public.cqcreate2_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate2_mrel(0)           | extended
+ new               | cqcreate2_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate2');
  pipeline_get_overlay_viewdef 
@@ -138,6 +162,14 @@ Indexes:
     "cqcreate3_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+\d+ cqcreate3_csrel;
+              Stream "public.cqcreate3_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate3_mrel(0)           | extended
+ new               | cqcreate3_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cqcreate3');
                      pipeline_get_overlay_viewdef                     
 ----------------------------------------------------------------------
@@ -179,6 +211,14 @@ Indexes:
     "cqcreate4_mrel_expr_idx" btree (hash_group(_0))
 Options: fillfactor=50
 
+\d+ cqcreate4_csrel;
+              Stream "public.cqcreate4_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate4_mrel(0)           | extended
+ new               | cqcreate4_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cqcreate4');
                      pipeline_get_overlay_viewdef                     
 ----------------------------------------------------------------------
@@ -216,6 +256,14 @@ Indexes:
     "cqcreate5_mrel_pkey" PRIMARY KEY, btree ("$pk")
     "cqcreate5_mrel_arrival_timestamp_idx" btree (arrival_timestamp)
 Options: fillfactor=50
+
+\d+ cqcreate5_csrel;
+              Stream "public.cqcreate5_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate5_mrel(0)           | extended
+ new               | cqcreate5_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate5');
                                pipeline_get_overlay_viewdef                               
@@ -255,6 +303,14 @@ Indexes:
     "cqcreate6_mrel_pkey" PRIMARY KEY, btree ("$pk")
     "cqcreate6_mrel_expr_idx" btree (ls_hash_group(arrival_timestamp, _0))
 Options: fillfactor=50
+
+\d+ cqcreate6_csrel;
+              Stream "public.cqcreate6_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqcreate6_mrel(0)           | extended
+ new               | cqcreate6_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate6');
                               pipeline_get_overlay_viewdef                               
@@ -297,6 +353,14 @@ Indexes:
     "cvavg_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+\d+ cvavg_csrel;
+                Stream "public.cvavg_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cvavg_mrel(0)               | extended
+ new               | cvavg_mrel(0)               | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cvavg');
                pipeline_get_overlay_viewdef                
 -----------------------------------------------------------
@@ -327,6 +391,14 @@ Indexes:
     "cvjson_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
+\d+ cvjson_csrel;
+                Stream "public.cvjson_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cvjson_mrel(0)              | extended
+ new               | cvjson_mrel(0)              | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cvjson');
                           pipeline_get_overlay_viewdef                          
 --------------------------------------------------------------------------------
@@ -353,6 +425,14 @@ View definition:
 Indexes:
     "cvjsonobj_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
+
+\d+ cvjsonobj_csrel;
+              Stream "public.cvjsonobj_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cvjsonobj_mrel(0)           | extended
+ new               | cvjsonobj_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvjsonobj');
                                      pipeline_get_overlay_viewdef                                     
@@ -382,6 +462,14 @@ Indexes:
     "cvcount_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
+\d+ cvcount_csrel;
+               Stream "public.cvcount_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cvcount_mrel(0)             | extended
+ new               | cvcount_mrel(0)             | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cvcount');
  pipeline_get_overlay_viewdef 
 ------------------------------
@@ -408,6 +496,14 @@ View definition:
 Indexes:
     "cvarray_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
+
+\d+ cvarray_csrel;
+               Stream "public.cvarray_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cvarray_mrel(0)             | extended
+ new               | cvarray_mrel(0)             | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvarray');
   pipeline_get_overlay_viewdef  
@@ -441,6 +537,14 @@ Indexes:
     "cvtext_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
+\d+ cvtext_csrel;
+                Stream "public.cvtext_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cvtext_mrel(0)              | extended
+ new               | cvtext_mrel(0)              | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cvtext');
                            pipeline_get_overlay_viewdef                           
 ----------------------------------------------------------------------------------
@@ -470,6 +574,14 @@ View definition:
 Indexes:
     "cqaggexpr1_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
+
+\d+ cqaggexpr1_csrel;
+              Stream "public.cqaggexpr1_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqaggexpr1_mrel(0)          | extended
+ new               | cqaggexpr1_mrel(0)          | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
            pipeline_get_overlay_viewdef            
@@ -503,6 +615,14 @@ Indexes:
     "cqaggexpr2_mrel_pkey" PRIMARY KEY, btree ("$pk")
     "cqaggexpr2_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
+
+\d+ cqaggexpr2_csrel;
+              Stream "public.cqaggexpr2_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqaggexpr2_mrel(0)          | extended
+ new               | cqaggexpr2_mrel(0)          | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
                               pipeline_get_overlay_viewdef                              
@@ -539,6 +659,14 @@ Indexes:
     "cqaggexpr3_mrel_expr_idx" btree (ls_hash_group(arrival_timestamp, key))
 Options: fillfactor=50
 
+\d+ cqaggexpr3_csrel;
+              Stream "public.cqaggexpr3_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqaggexpr3_mrel(0)          | extended
+ new               | cqaggexpr3_mrel(0)          | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
+
 SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
                                pipeline_get_overlay_viewdef                               
 ------------------------------------------------------------------------------------------
@@ -573,6 +701,14 @@ Indexes:
     "cqaggexpr4_mrel_pkey" PRIMARY KEY, btree ("$pk")
     "cqaggexpr4_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
+
+\d+ cqaggexpr4_csrel;
+              Stream "public.cqaggexpr4_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqaggexpr4_mrel(0)          | extended
+ new               | cqaggexpr4_mrel(0)          | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
             pipeline_get_overlay_viewdef            
@@ -609,6 +745,14 @@ Indexes:
     "cqgroupby_mrel_pkey" PRIMARY KEY, btree ("$pk")
     "cqgroupby_mrel_expr_idx" btree (hash_group(k0, k1))
 Options: fillfactor=50
+
+\d+ cqgroupby_csrel;
+              Stream "public.cqgroupby_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | cqgroupby_mrel(0)           | extended
+ new               | cqgroupby_mrel(0)           | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqgroupby');
  pipeline_get_overlay_viewdef 
@@ -656,6 +800,14 @@ Indexes:
     "multigroupindex_mrel_pkey" PRIMARY KEY, btree ("$pk")
     "multigroupindex_mrel_expr_idx" btree (hash_group(a, b, c, d, e))
 Options: fillfactor=50
+
+\d+ multigroupindex_csrel;
+           Stream "public.multigroupindex_csrel"
+      Column       |            Type             | Storage  
+-------------------+-----------------------------+----------
+ old               | multigroupindex_mrel(0)     | extended
+ new               | multigroupindex_mrel(0)     | extended
+ arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('multigroupindex');
     pipeline_get_overlay_viewdef    
@@ -758,6 +910,7 @@ CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
 WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
 ERROR:  cannot specify both "max_age" and a sliding window expression in the WHERE clause
 CREATE TYPE custom_type AS (integerone integer, integertwo integer);
+ERROR:  type "custom_type" already exists
 CREATE CONTINUOUS VIEW type_cv as SELECT val::custom_type, count(*) FROM my_stream GROUP BY val;
 ERROR:  each grouping column type must be associated with an operator class
 HINT:  Define an operator class using CREATE OPERATOR CLASS.

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -910,7 +910,6 @@ CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM stream
 WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
 ERROR:  cannot specify both "max_age" and a sliding window expression in the WHERE clause
 CREATE TYPE custom_type AS (integerone integer, integertwo integer);
-ERROR:  type "custom_type" already exists
 CREATE CONTINUOUS VIEW type_cv as SELECT val::custom_type, count(*) FROM my_stream GROUP BY val;
 ERROR:  each grouping column type must be associated with an operator class
 HINT:  Define an operator class using CREATE OPERATOR CLASS.

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -26,12 +26,12 @@ Indexes:
     "cqcreate0_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cqcreate0_csrel;
-              Stream "public.cqcreate0_csrel"
+\d+ cqcreate0_osrel;
+              Stream "public.cqcreate0_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate0_mrel(0)           | extended
- new               | cqcreate0_mrel(0)           | extended
+ old               | cqcreate0(0)                | extended
+ new               | cqcreate0(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate0');
@@ -67,12 +67,12 @@ Indexes:
     "cqcreate1_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cqcreate1_csrel;
-              Stream "public.cqcreate1_csrel"
+\d+ cqcreate1_osrel;
+              Stream "public.cqcreate1_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate1_mrel(0)           | extended
- new               | cqcreate1_mrel(0)           | extended
+ old               | cqcreate1(0)                | extended
+ new               | cqcreate1(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate1');
@@ -111,12 +111,12 @@ Indexes:
     "cqcreate2_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cqcreate2_csrel;
-              Stream "public.cqcreate2_csrel"
+\d+ cqcreate2_osrel;
+              Stream "public.cqcreate2_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate2_mrel(0)           | extended
- new               | cqcreate2_mrel(0)           | extended
+ old               | cqcreate2(0)                | extended
+ new               | cqcreate2(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate2');
@@ -162,12 +162,12 @@ Indexes:
     "cqcreate3_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
-\d+ cqcreate3_csrel;
-              Stream "public.cqcreate3_csrel"
+\d+ cqcreate3_osrel;
+              Stream "public.cqcreate3_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate3_mrel(0)           | extended
- new               | cqcreate3_mrel(0)           | extended
+ old               | cqcreate3(0)                | extended
+ new               | cqcreate3(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate3');
@@ -211,12 +211,12 @@ Indexes:
     "cqcreate4_mrel_expr_idx" btree (hash_group(_0))
 Options: fillfactor=50
 
-\d+ cqcreate4_csrel;
-              Stream "public.cqcreate4_csrel"
+\d+ cqcreate4_osrel;
+              Stream "public.cqcreate4_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate4_mrel(0)           | extended
- new               | cqcreate4_mrel(0)           | extended
+ old               | cqcreate4(0)                | extended
+ new               | cqcreate4(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate4');
@@ -257,12 +257,12 @@ Indexes:
     "cqcreate5_mrel_arrival_timestamp_idx" btree (arrival_timestamp)
 Options: fillfactor=50
 
-\d+ cqcreate5_csrel;
-              Stream "public.cqcreate5_csrel"
+\d+ cqcreate5_osrel;
+              Stream "public.cqcreate5_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate5_mrel(0)           | extended
- new               | cqcreate5_mrel(0)           | extended
+ old               | cqcreate5(0)                | extended
+ new               | cqcreate5(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate5');
@@ -304,12 +304,12 @@ Indexes:
     "cqcreate6_mrel_expr_idx" btree (ls_hash_group(arrival_timestamp, _0))
 Options: fillfactor=50
 
-\d+ cqcreate6_csrel;
-              Stream "public.cqcreate6_csrel"
+\d+ cqcreate6_osrel;
+              Stream "public.cqcreate6_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate6_mrel(0)           | extended
- new               | cqcreate6_mrel(0)           | extended
+ old               | cqcreate6(0)                | extended
+ new               | cqcreate6(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate6');
@@ -353,12 +353,12 @@ Indexes:
     "cvavg_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
-\d+ cvavg_csrel;
-                Stream "public.cvavg_csrel"
+\d+ cvavg_osrel;
+                Stream "public.cvavg_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvavg_mrel(0)               | extended
- new               | cvavg_mrel(0)               | extended
+ old               | cvavg(0)                    | extended
+ new               | cvavg(0)                    | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvavg');
@@ -391,12 +391,12 @@ Indexes:
     "cvjson_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cvjson_csrel;
-                Stream "public.cvjson_csrel"
+\d+ cvjson_osrel;
+                Stream "public.cvjson_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvjson_mrel(0)              | extended
- new               | cvjson_mrel(0)              | extended
+ old               | cvjson(0)                   | extended
+ new               | cvjson(0)                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvjson');
@@ -426,12 +426,12 @@ Indexes:
     "cvjsonobj_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cvjsonobj_csrel;
-              Stream "public.cvjsonobj_csrel"
+\d+ cvjsonobj_osrel;
+              Stream "public.cvjsonobj_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvjsonobj_mrel(0)           | extended
- new               | cvjsonobj_mrel(0)           | extended
+ old               | cvjsonobj(0)                | extended
+ new               | cvjsonobj(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvjsonobj');
@@ -462,12 +462,12 @@ Indexes:
     "cvcount_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cvcount_csrel;
-               Stream "public.cvcount_csrel"
+\d+ cvcount_osrel;
+               Stream "public.cvcount_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvcount_mrel(0)             | extended
- new               | cvcount_mrel(0)             | extended
+ old               | cvcount(0)                  | extended
+ new               | cvcount(0)                  | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvcount');
@@ -497,12 +497,12 @@ Indexes:
     "cvarray_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cvarray_csrel;
-               Stream "public.cvarray_csrel"
+\d+ cvarray_osrel;
+               Stream "public.cvarray_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvarray_mrel(0)             | extended
- new               | cvarray_mrel(0)             | extended
+ old               | cvarray(0)                  | extended
+ new               | cvarray(0)                  | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvarray');
@@ -537,12 +537,12 @@ Indexes:
     "cvtext_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
-\d+ cvtext_csrel;
-                Stream "public.cvtext_csrel"
+\d+ cvtext_osrel;
+                Stream "public.cvtext_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvtext_mrel(0)              | extended
- new               | cvtext_mrel(0)              | extended
+ old               | cvtext(0)                   | extended
+ new               | cvtext(0)                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvtext');
@@ -575,12 +575,12 @@ Indexes:
     "cqaggexpr1_mrel_pkey" PRIMARY KEY, btree ("$pk")
 Options: fillfactor=50
 
-\d+ cqaggexpr1_csrel;
-              Stream "public.cqaggexpr1_csrel"
+\d+ cqaggexpr1_osrel;
+              Stream "public.cqaggexpr1_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr1_mrel(0)          | extended
- new               | cqaggexpr1_mrel(0)          | extended
+ old               | cqaggexpr1(0)               | extended
+ new               | cqaggexpr1(0)               | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
@@ -616,12 +616,12 @@ Indexes:
     "cqaggexpr2_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
-\d+ cqaggexpr2_csrel;
-              Stream "public.cqaggexpr2_csrel"
+\d+ cqaggexpr2_osrel;
+              Stream "public.cqaggexpr2_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr2_mrel(0)          | extended
- new               | cqaggexpr2_mrel(0)          | extended
+ old               | cqaggexpr2(0)               | extended
+ new               | cqaggexpr2(0)               | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
@@ -659,12 +659,12 @@ Indexes:
     "cqaggexpr3_mrel_expr_idx" btree (ls_hash_group(arrival_timestamp, key))
 Options: fillfactor=50
 
-\d+ cqaggexpr3_csrel;
-              Stream "public.cqaggexpr3_csrel"
+\d+ cqaggexpr3_osrel;
+              Stream "public.cqaggexpr3_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr3_mrel(0)          | extended
- new               | cqaggexpr3_mrel(0)          | extended
+ old               | cqaggexpr3(0)               | extended
+ new               | cqaggexpr3(0)               | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
@@ -702,12 +702,12 @@ Indexes:
     "cqaggexpr4_mrel_expr_idx" btree (hash_group(key))
 Options: fillfactor=50
 
-\d+ cqaggexpr4_csrel;
-              Stream "public.cqaggexpr4_csrel"
+\d+ cqaggexpr4_osrel;
+              Stream "public.cqaggexpr4_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr4_mrel(0)          | extended
- new               | cqaggexpr4_mrel(0)          | extended
+ old               | cqaggexpr4(0)               | extended
+ new               | cqaggexpr4(0)               | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
@@ -746,12 +746,12 @@ Indexes:
     "cqgroupby_mrel_expr_idx" btree (hash_group(k0, k1))
 Options: fillfactor=50
 
-\d+ cqgroupby_csrel;
-              Stream "public.cqgroupby_csrel"
+\d+ cqgroupby_osrel;
+              Stream "public.cqgroupby_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqgroupby_mrel(0)           | extended
- new               | cqgroupby_mrel(0)           | extended
+ old               | cqgroupby(0)                | extended
+ new               | cqgroupby(0)                | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqgroupby');
@@ -801,12 +801,12 @@ Indexes:
     "multigroupindex_mrel_expr_idx" btree (hash_group(a, b, c, d, e))
 Options: fillfactor=50
 
-\d+ multigroupindex_csrel;
-           Stream "public.multigroupindex_csrel"
+\d+ multigroupindex_osrel;
+           Stream "public.multigroupindex_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | multigroupindex_mrel(0)     | extended
- new               | multigroupindex_mrel(0)     | extended
+ old               | multigroupindex(0)          | extended
+ new               | multigroupindex(0)          | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('multigroupindex');

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -328,3 +328,71 @@ DETAIL:  continuous view os3_output depends on table os_t0
 HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 DROP CONTINUOUS VIEW os3 CASCADE;
 NOTICE:  drop cascades to continuous view os3_output
+-- Final functions should be applied to output stream tuples where necessary
+CREATE CONTINUOUS VIEW os3 AS SELECT x::integer, avg(y::integer), count(distinct z::integer)
+FROM os_stream GROUP BY x;
+CREATE CONTINUOUS VIEW os3_output AS SELECT
+  arrival_timestamp,
+  CASE WHEN old IS NULL THEN (new).x ELSE (old).x END AS x,
+  old, new
+FROM os3_osrel;
+INSERT INTO os_stream (x, y, z) VALUES (0, 2, 0);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+ x | old |           new            
+---+-----+--------------------------
+ 0 |     | (0,2.0000000000000000,1)
+(1 row)
+
+INSERT INTO os_stream (x, y, z) VALUES (0, 4, 1);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+ x |           old            |           new            
+---+--------------------------+--------------------------
+ 0 | (0,2.0000000000000000,1) | (0,3.0000000000000000,2)
+ 0 |                          | (0,2.0000000000000000,1)
+(2 rows)
+
+INSERT INTO os_stream (x, y, z) VALUES (1, 8, 2);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+ x |           old            |           new            
+---+--------------------------+--------------------------
+ 0 | (0,2.0000000000000000,1) | (0,3.0000000000000000,2)
+ 0 |                          | (0,2.0000000000000000,1)
+ 1 |                          | (1,8.0000000000000000,1)
+(3 rows)
+
+INSERT INTO os_stream (x, y, z) VALUES (1, 16, 2);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+ x |           old            |            new            
+---+--------------------------+---------------------------
+ 0 | (0,2.0000000000000000,1) | (0,3.0000000000000000,2)
+ 0 |                          | (0,2.0000000000000000,1)
+ 1 | (1,8.0000000000000000,1) | (1,12.0000000000000000,1)
+ 1 |                          | (1,8.0000000000000000,1)
+(4 rows)
+
+DROP CONTINUOUS VIEW os3 CASCADE;
+NOTICE:  drop cascades to continuous view os3_output

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -7,7 +7,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
  old_count | new_count 
 -----------+-----------
            |         1
@@ -20,11 +20,11 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
  old_count | new_count 
 -----------+-----------
-           |         1
          1 |         2
+           |         1
 (2 rows)
 
 INSERT INTO os_stream (x) VALUES (0);
@@ -34,12 +34,12 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
  old_count | new_count 
 -----------+-----------
-           |         1
          1 |         2
          2 |         3
+           |         1
 (3 rows)
 
 INSERT INTO os_stream (x) VALUES (0);
@@ -49,13 +49,13 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
  old_count | new_count 
 -----------+-----------
-           |         1
          1 |         2
          2 |         3
          3 |         4
+           |         1
 (4 rows)
 
 -- We shouldn't be able to drop this because os0_output depends on it now
@@ -79,7 +79,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
  10 |           |         1 |         |      10
@@ -92,7 +92,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
  10 |           |         1 |         |      10
@@ -106,7 +106,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
  10 |           |         1 |         |      10
@@ -128,14 +128,14 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
  10 |           |         1 |         |      10
  20 |           |         1 |         |      20
  30 |           |         1 |         |      30
- 40 |           |         1 |         |      40
  40 |         1 |         2 |      40 |       0
+ 40 |           |         1 |         |      40
 (5 rows)
 
 INSERT INTO os_stream (x) VALUES (-30);
@@ -145,15 +145,15 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
  10 |           |         1 |         |      10
  20 |           |         1 |         |      20
- 30 |           |         1 |         |      30
- 40 |           |         1 |         |      40
- 40 |         1 |         2 |      40 |       0
  30 |         1 |         2 |      30 |       0
+ 30 |           |         1 |         |      30
+ 40 |         1 |         2 |      40 |       0
+ 40 |           |         1 |         |      40
 (6 rows)
 
 INSERT INTO os_stream (x) VALUES (-20);
@@ -163,16 +163,16 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
  10 |           |         1 |         |      10
- 20 |           |         1 |         |      20
- 30 |           |         1 |         |      30
- 40 |           |         1 |         |      40
- 40 |         1 |         2 |      40 |       0
- 30 |         1 |         2 |      30 |       0
  20 |         1 |         2 |      20 |       0
+ 20 |           |         1 |         |      20
+ 30 |         1 |         2 |      30 |       0
+ 30 |           |         1 |         |      30
+ 40 |         1 |         2 |      40 |       0
+ 40 |           |         1 |         |      40
 (7 rows)
 
 INSERT INTO os_stream (x) VALUES (-10);
@@ -182,17 +182,17 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
  g  | old_count | new_count | old_sum | new_sum 
 ----+-----------+-----------+---------+---------
- 10 |           |         1 |         |      10
- 20 |           |         1 |         |      20
- 30 |           |         1 |         |      30
- 40 |           |         1 |         |      40
- 40 |         1 |         2 |      40 |       0
- 30 |         1 |         2 |      30 |       0
- 20 |         1 |         2 |      20 |       0
  10 |         1 |         2 |      10 |       0
+ 10 |           |         1 |         |      10
+ 20 |         1 |         2 |      20 |       0
+ 20 |           |         1 |         |      20
+ 30 |         1 |         2 |      30 |       0
+ 30 |           |         1 |         |      30
+ 40 |         1 |         2 |      40 |       0
+ 40 |           |         1 |         |      40
 (8 rows)
 
 DROP CONTINUOUS VIEW os1 CASCADE;
@@ -213,7 +213,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT x, old, new FROM os2_output;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
  x | old |  new  
 ---+-----+-------
  0 |     | (0,1)
@@ -226,7 +226,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT x, old, new FROM os2_output;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
  x | old |  new  
 ---+-----+-------
  0 |     | (0,1)
@@ -240,7 +240,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT x, old, new FROM os2_output;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
  x | old |  new  
 ---+-----+-------
  0 |     | (0,1)
@@ -255,17 +255,17 @@ SELECT pg_sleep(20);
  
 (1 row)
 
-SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
  x |  old  |  new  
 ---+-------+-------
- 0 |       | (0,1)
- 1 |       | (1,1)
- 2 |       | (2,1)
- 3 |       | (3,1)
  0 | (0,1) | 
+ 0 |       | (0,1)
  1 | (1,1) | 
+ 1 |       | (1,1)
  2 | (2,1) | 
+ 2 |       | (2,1)
  3 | (3,1) | 
+ 3 |       | (3,1)
 (8 rows)
 
 DROP CONTINUOUS VIEW os2 CASCADE;
@@ -287,7 +287,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT x, new, y FROM os3_output;
+SELECT x, new, y FROM os3_output ORDER BY x, new, y;
  x |   new   | y  
 ---+---------+----
  0 | (0,1,1) | 42
@@ -300,7 +300,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT x, new, y FROM os3_output;
+SELECT x, new, y FROM os3_output ORDER BY x, new, y;
  x |   new   | y  
 ---+---------+----
  0 | (0,1,1) | 42
@@ -314,7 +314,7 @@ SELECT pg_sleep(2);
  
 (1 row)
 
-SELECT x, new, y FROM os3_output;
+SELECT x, new, y FROM os3_output ORDER BY x, new, y;
  x |   new   | y  
 ---+---------+----
  0 | (0,1,1) | 42

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -58,7 +58,7 @@ SELECT * FROM os0_output;
          3 |         4
 (4 rows)
 
--- Shouldn't be able to drop this because os0_output depends on it now
+-- We shouldn't be able to drop this because os0_output depends on it now
 DROP CONTINUOUS VIEW os0;
 ERROR:  cannot drop continuous view os0 because other objects depend on it
 DETAIL:  continuous view os0_output depends on stream os0_osrel
@@ -197,6 +197,7 @@ SELECT * FROM os1_output;
 
 DROP CONTINUOUS VIEW os1 CASCADE;
 NOTICE:  drop cascades to continuous view os1_output
+-- Verify SW ticking into output streams
 CREATE CONTINUOUS VIEW os2 WITH (max_age = '10 seconds') AS
 SELECT x::integer, COUNT(*)
 FROM os_stream GROUP BY x;
@@ -269,3 +270,61 @@ SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
 
 DROP CONTINUOUS VIEW os2 CASCADE;
 NOTICE:  drop cascades to continuous view os2_output
+-- Stream-table joins on output streams
+CREATE TABLE os_t0 (x integer, y integer);
+INSERT INTO os_t0 (x, y) VALUES (0, 42);
+CREATE CONTINUOUS VIEW os3 AS SELECT x::integer, COUNT(*)
+FROM os_stream GROUP BY x;
+CREATE CONTINUOUS VIEW os3_output AS SELECT
+  CASE WHEN (s.old) IS NULL THEN (s.new).x ELSE (s.old).x END AS x,
+  s.new, t.y
+  FROM os3_osrel s JOIN os_t0 t ON x = t.x;
+NOTICE:  consider creating an index on t.x for improved stream-table join performance
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, new, y FROM os3_output;
+ x |   new   | y  
+---+---------+----
+ 0 | (0,1,1) | 42
+(1 row)
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, new, y FROM os3_output;
+ x |   new   | y  
+---+---------+----
+ 0 | (0,1,1) | 42
+ 0 | (0,2,1) | 42
+(2 rows)
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, new, y FROM os3_output;
+ x |   new   | y  
+---+---------+----
+ 0 | (0,1,1) | 42
+ 0 | (0,2,1) | 42
+ 0 | (0,3,1) | 42
+(3 rows)
+
+DROP TABLE os_t0;
+ERROR:  cannot drop table os_t0 because other objects depend on it
+DETAIL:  continuous view os3_output depends on table os_t0
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+DROP CONTINUOUS VIEW os3 CASCADE;
+NOTICE:  drop cascades to continuous view os3_output

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -1,7 +1,7 @@
 CREATE CONTINUOUS VIEW os0 AS SELECT COUNT(*) FROM os_stream;
 CREATE CONTINUOUS VIEW os0_output AS SELECT (old).count AS old_count, (new).count AS new_count FROM os0_osrel;
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -14,7 +14,7 @@ SELECT * FROM os0_output;
 (1 row)
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -28,7 +28,7 @@ SELECT * FROM os0_output;
 (2 rows)
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -43,7 +43,7 @@ SELECT * FROM os0_output;
 (3 rows)
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -73,7 +73,7 @@ CREATE CONTINUOUS VIEW os1_output AS SELECT
   (old).sum AS old_sum, (new).sum AS new_sum
 FROM os1_osrel;
 INSERT INTO os_stream (x) VALUES (10);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -86,7 +86,7 @@ SELECT * FROM os1_output;
 (1 row)
 
 INSERT INTO os_stream (x) VALUES (20);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -100,7 +100,7 @@ SELECT * FROM os1_output;
 (2 rows)
 
 INSERT INTO os_stream (x) VALUES (30);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -115,14 +115,14 @@ SELECT * FROM os1_output;
 (3 rows)
 
 INSERT INTO os_stream (x) VALUES (40);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
 (1 row)
 
 INSERT INTO os_stream (x) VALUES (-40);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -139,7 +139,7 @@ SELECT * FROM os1_output;
 (5 rows)
 
 INSERT INTO os_stream (x) VALUES (-30);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -157,7 +157,7 @@ SELECT * FROM os1_output;
 (6 rows)
 
 INSERT INTO os_stream (x) VALUES (-20);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -176,11 +176,24 @@ SELECT * FROM os1_output;
 (7 rows)
 
 INSERT INTO os_stream (x) VALUES (-10);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
 (1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+ 20 |           |         1 |         |      20
+ 30 |           |         1 |         |      30
+ 40 |           |         1 |         |      40
+ 40 |         1 |         2 |      40 |       0
+ 30 |         1 |         2 |      30 |       0
+ 20 |         1 |         2 |      20 |       0
+ 10 |         1 |         2 |      10 |       0
+(8 rows)
 
 DROP CONTINUOUS VIEW os1 CASCADE;
 NOTICE:  drop cascades to continuous view os1_output
@@ -193,7 +206,7 @@ CREATE CONTINUOUS VIEW os2_output AS SELECT
   old, new
 FROM os2_osrel;
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -206,7 +219,7 @@ SELECT x, old, new FROM os2_output;
 (1 row)
 
 INSERT INTO os_stream (x) VALUES (1);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -220,7 +233,7 @@ SELECT x, old, new FROM os2_output;
 (2 rows)
 
 INSERT INTO os_stream (x) VALUES (2);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
  pg_sleep 
 ----------
  
@@ -256,3 +269,4 @@ SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
 
 DROP CONTINUOUS VIEW os2 CASCADE;
 NOTICE:  drop cascades to continuous view os2_output
+

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -1,0 +1,258 @@
+CREATE CONTINUOUS VIEW os0 AS SELECT COUNT(*) FROM os_stream;
+CREATE CONTINUOUS VIEW os0_output AS SELECT (old).count AS old_count, (new).count AS new_count FROM os0_osrel;
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os0_output;
+ old_count | new_count 
+-----------+-----------
+           |         1
+(1 row)
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os0_output;
+ old_count | new_count 
+-----------+-----------
+           |         1
+         1 |         2
+(2 rows)
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os0_output;
+ old_count | new_count 
+-----------+-----------
+           |         1
+         1 |         2
+         2 |         3
+(3 rows)
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os0_output;
+ old_count | new_count 
+-----------+-----------
+           |         1
+         1 |         2
+         2 |         3
+         3 |         4
+(4 rows)
+
+-- Shouldn't be able to drop this because os0_output depends on it now
+DROP CONTINUOUS VIEW os0;
+ERROR:  cannot drop continuous view os0 because other objects depend on it
+DETAIL:  continuous view os0_output depends on stream os0_osrel
+HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+DROP CONTINUOUS VIEW os0_output;
+DROP CONTINUOUS VIEW os0;
+CREATE CONTINUOUS VIEW os1 AS SELECT abs(x::integer) AS g, COUNT(*), sum(x)
+FROM os_stream GROUP BY g;
+CREATE CONTINUOUS VIEW os1_output AS SELECT
+  (new).g,
+  (old).count AS old_count, (new).count AS new_count,
+  (old).sum AS old_sum, (new).sum AS new_sum
+FROM os1_osrel;
+INSERT INTO os_stream (x) VALUES (10);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+(1 row)
+
+INSERT INTO os_stream (x) VALUES (20);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+ 20 |           |         1 |         |      20
+(2 rows)
+
+INSERT INTO os_stream (x) VALUES (30);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+ 20 |           |         1 |         |      20
+ 30 |           |         1 |         |      30
+(3 rows)
+
+INSERT INTO os_stream (x) VALUES (40);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+INSERT INTO os_stream (x) VALUES (-40);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+ 20 |           |         1 |         |      20
+ 30 |           |         1 |         |      30
+ 40 |           |         1 |         |      40
+ 40 |         1 |         2 |      40 |       0
+(5 rows)
+
+INSERT INTO os_stream (x) VALUES (-30);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+ 20 |           |         1 |         |      20
+ 30 |           |         1 |         |      30
+ 40 |           |         1 |         |      40
+ 40 |         1 |         2 |      40 |       0
+ 30 |         1 |         2 |      30 |       0
+(6 rows)
+
+INSERT INTO os_stream (x) VALUES (-20);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT * FROM os1_output;
+ g  | old_count | new_count | old_sum | new_sum 
+----+-----------+-----------+---------+---------
+ 10 |           |         1 |         |      10
+ 20 |           |         1 |         |      20
+ 30 |           |         1 |         |      30
+ 40 |           |         1 |         |      40
+ 40 |         1 |         2 |      40 |       0
+ 30 |         1 |         2 |      30 |       0
+ 20 |         1 |         2 |      20 |       0
+(7 rows)
+
+INSERT INTO os_stream (x) VALUES (-10);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+DROP CONTINUOUS VIEW os1 CASCADE;
+NOTICE:  drop cascades to continuous view os1_output
+CREATE CONTINUOUS VIEW os2 WITH (max_age = '10 seconds') AS
+SELECT x::integer, COUNT(*)
+FROM os_stream GROUP BY x;
+CREATE CONTINUOUS VIEW os2_output AS SELECT
+  arrival_timestamp,
+  CASE WHEN old IS NULL THEN (new).x ELSE (old).x END AS x,
+  old, new
+FROM os2_osrel;
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os2_output;
+ x | old |  new  
+---+-----+-------
+ 0 |     | (0,1)
+(1 row)
+
+INSERT INTO os_stream (x) VALUES (1);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os2_output;
+ x | old |  new  
+---+-----+-------
+ 0 |     | (0,1)
+ 1 |     | (1,1)
+(2 rows)
+
+INSERT INTO os_stream (x) VALUES (2);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os2_output;
+ x | old |  new  
+---+-----+-------
+ 0 |     | (0,1)
+ 1 |     | (1,1)
+ 2 |     | (2,1)
+(3 rows)
+
+INSERT INTO os_stream (x) VALUES (3);
+SELECT pg_sleep(20);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
+ x |  old  |  new  
+---+-------+-------
+ 0 |       | (0,1)
+ 1 |       | (1,1)
+ 2 |       | (2,1)
+ 3 |       | (3,1)
+ 0 | (0,1) | 
+ 1 | (1,1) | 
+ 2 | (2,1) | 
+ 3 | (3,1) | 
+(8 rows)
+
+DROP CONTINUOUS VIEW os2 CASCADE;
+NOTICE:  drop cascades to continuous view os2_output

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -269,4 +269,3 @@ SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
 
 DROP CONTINUOUS VIEW os2 CASCADE;
 NOTICE:  drop cascades to continuous view os2_output
-

--- a/src/test/regress/expected/pipeline_stream.out
+++ b/src/test/regress/expected/pipeline_stream.out
@@ -1,17 +1,17 @@
 CREATE CONTINUOUS VIEW ps0 AS SELECT id::integer FROM stream0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |   name    | inferred | queries |                                       tup_desc                                       
---------+-----------+----------+---------+--------------------------------------------------------------------------------------
- public | ps0_csrel | f        |         | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ schema |   name    | inferred | queries |                                  tup_desc                                  
+--------+-----------+----------+---------+----------------------------------------------------------------------------
+ public | ps0_osrel | f        |         | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0}   | {id::numeric,"arrival_timestamp::timestamp(0) with time zone"}
 (2 rows)
 
 CREATE CONTINUOUS VIEW ps1 AS SELECT id::integer, val::text FROM stream0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |   name    | inferred |  queries  |                                       tup_desc                                       
---------+-----------+----------+-----------+--------------------------------------------------------------------------------------
- public | ps0_csrel | f        |           | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_csrel | f        |           | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ schema |   name    | inferred |  queries  |                                  tup_desc                                  
+--------+-----------+----------+-----------+----------------------------------------------------------------------------
+ public | ps0_osrel | f        |           | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |           | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1} | {id::numeric,val::text,"arrival_timestamp::timestamp(0) with time zone"}
 (3 rows)
 
@@ -20,10 +20,10 @@ CREATE CONTINUOUS VIEW ps3 AS SELECT x::integer, y::timestamp FROM stream1;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
 (6 rows)
@@ -33,10 +33,10 @@ ERROR:  type conflict with stream "stream0": types double precision and text can
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
 (6 rows)
@@ -45,10 +45,10 @@ CREATE STREAM stream2 (x INT);
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        |               | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -58,11 +58,11 @@ CREATE CONTINUOUS VIEW ps5 AS SELECT x FROM stream2;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps5_csrel | f        |               | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_osrel | f        |               | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}         | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -72,10 +72,10 @@ DROP CONTINUOUS VIEW ps0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |  queries  |                                            tup_desc                                            
 --------+-----------+----------+-----------+------------------------------------------------------------------------------------------------
- public | ps1_csrel | f        |           | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_csrel | f        |           | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_csrel | f        |           | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps5_csrel | f        |           | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |           | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |           | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |           | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_osrel | f        |           | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}     | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}     | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -85,9 +85,9 @@ DROP CONTINUOUS VIEW ps1;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred | queries |                                            tup_desc                                            
 --------+-----------+----------+---------+------------------------------------------------------------------------------------------------
- public | ps2_csrel | f        |         | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_csrel | f        |         | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps5_csrel | f        |         | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |         | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |         | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_osrel | f        |         | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps2}   | {"id::double precision","arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}   | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -96,9 +96,9 @@ SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER B
 DROP CONTINUOUS VIEW ps2;
 DROP CONTINUOUS VIEW ps3;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |   name    | inferred | queries |                                       tup_desc                                       
---------+-----------+----------+---------+--------------------------------------------------------------------------------------
- public | ps5_csrel | f        |         | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ schema |   name    | inferred | queries |                                  tup_desc                                  
+--------+-----------+----------+---------+----------------------------------------------------------------------------
+ public | ps5_osrel | f        |         | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
 (2 rows)
 

--- a/src/test/regress/expected/pipeline_stream.out
+++ b/src/test/regress/expected/pipeline_stream.out
@@ -1,78 +1,106 @@
 CREATE CONTINUOUS VIEW ps0 AS SELECT id::integer FROM stream0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred | queries |                            tup_desc                            
---------+---------+----------+---------+----------------------------------------------------------------
- public | stream0 | t        | {ps0}   | {id::numeric,"arrival_timestamp::timestamp(0) with time zone"}
-(1 row)
+ schema |   name    | inferred | queries |                                       tup_desc                                       
+--------+-----------+----------+---------+--------------------------------------------------------------------------------------
+ public | ps0_csrel | f        |         | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps0}   | {id::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+(2 rows)
 
 CREATE CONTINUOUS VIEW ps1 AS SELECT id::integer, val::text FROM stream0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred |  queries  |                                 tup_desc                                 
---------+---------+----------+-----------+--------------------------------------------------------------------------
- public | stream0 | t        | {ps0,ps1} | {id::numeric,val::text,"arrival_timestamp::timestamp(0) with time zone"}
-(1 row)
+ schema |   name    | inferred |  queries  |                                       tup_desc                                       
+--------+-----------+----------+-----------+--------------------------------------------------------------------------------------
+ public | ps0_csrel | f        |           | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_csrel | f        |           | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps0,ps1} | {id::numeric,val::text,"arrival_timestamp::timestamp(0) with time zone"}
+(3 rows)
 
 CREATE CONTINUOUS VIEW ps2 AS SELECT id::float FROM stream0;
 CREATE CONTINUOUS VIEW ps3 AS SELECT x::integer, y::timestamp FROM stream1;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred |    queries    |                                            tup_desc                                            
---------+---------+----------+---------------+------------------------------------------------------------------------------------------------
- public | stream0 | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream1 | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
-(2 rows)
+ schema |   name    | inferred |    queries    |                                            tup_desc                                            
+--------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
+ public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+(6 rows)
 
 CREATE CONTINUOUS VIEW ps4 AS SELECT id::text FROM stream0;
 ERROR:  type conflict with stream "stream0": types double precision and text cannot be matched
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred |    queries    |                                            tup_desc                                            
---------+---------+----------+---------------+------------------------------------------------------------------------------------------------
- public | stream0 | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream1 | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
-(2 rows)
+ schema |   name    | inferred |    queries    |                                            tup_desc                                            
+--------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
+ public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+(6 rows)
 
 CREATE STREAM stream2 (x INT);
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred |    queries    |                                            tup_desc                                            
---------+---------+----------+---------------+------------------------------------------------------------------------------------------------
- public | stream0 | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream1 | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream2 | f        |               | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
-(3 rows)
+ schema |   name    | inferred |    queries    |                                            tup_desc                                            
+--------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
+ public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream2   | f        |               | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
+(7 rows)
 
 CREATE CONTINUOUS VIEW ps5 AS SELECT x FROM stream2;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred |    queries    |                                            tup_desc                                            
---------+---------+----------+---------------+------------------------------------------------------------------------------------------------
- public | stream0 | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream1 | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream2 | f        | {ps5}         | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
-(3 rows)
+ schema |   name    | inferred |    queries    |                                            tup_desc                                            
+--------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
+ public | ps0_csrel | f        |               | {old::ps0_mrel(0),new::ps0_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_csrel | f        |               | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_csrel | f        |               | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_csrel | f        |               | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_csrel | f        |               | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream2   | f        | {ps5}         | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
+(8 rows)
 
 DROP CONTINUOUS VIEW ps0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred |  queries  |                                            tup_desc                                            
---------+---------+----------+-----------+------------------------------------------------------------------------------------------------
- public | stream0 | t        | {ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream1 | t        | {ps3}     | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream2 | f        | {ps5}     | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
-(3 rows)
+ schema |   name    | inferred |  queries  |                                            tup_desc                                            
+--------+-----------+----------+-----------+------------------------------------------------------------------------------------------------
+ public | ps1_csrel | f        |           | {old::ps1_mrel(0),new::ps1_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_csrel | f        |           | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_csrel | f        |           | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_csrel | f        |           | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream1   | t        | {ps3}     | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream2   | f        | {ps5}     | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
+(7 rows)
 
 DROP CONTINUOUS VIEW ps1;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred | queries |                                            tup_desc                                            
---------+---------+----------+---------+------------------------------------------------------------------------------------------------
- public | stream0 | t        | {ps2}   | {"id::double precision","arrival_timestamp::timestamp(0) with time zone"}
- public | stream1 | t        | {ps3}   | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
- public | stream2 | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
-(3 rows)
+ schema |   name    | inferred | queries |                                            tup_desc                                            
+--------+-----------+----------+---------+------------------------------------------------------------------------------------------------
+ public | ps2_csrel | f        |         | {old::ps2_mrel(0),new::ps2_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_csrel | f        |         | {old::ps3_mrel(0),new::ps3_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_csrel | f        |         | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream0   | t        | {ps2}   | {"id::double precision","arrival_timestamp::timestamp(0) with time zone"}
+ public | stream1   | t        | {ps3}   | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream2   | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
+(6 rows)
 
 DROP CONTINUOUS VIEW ps2;
 DROP CONTINUOUS VIEW ps3;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |  name   | inferred | queries |                           tup_desc                            
---------+---------+----------+---------+---------------------------------------------------------------
- public | stream2 | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
-(1 row)
+ schema |   name    | inferred | queries |                                       tup_desc                                       
+--------+-----------+----------+---------+--------------------------------------------------------------------------------------
+ public | ps5_csrel | f        |         | {old::ps5_mrel(0),new::ps5_mrel(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | stream2   | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
+(2 rows)
 
 DROP CONTINUOUS VIEW ps5;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -183,7 +183,7 @@ test: create_combinable_agg pipeline_regress cont_fss_agg cont_matrel cont_set_a
 # ----------
 # Another group of parallel tests
 # ----------
-test: cont_transform cont_trigger cont_activate
+test: cont_transform cont_trigger cont_activate output_streams
 
 # ----------
 # Another group of parallel tests

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -5,21 +5,21 @@ CREATE CONTINUOUS VIEW cqcreate0 AS SELECT key::integer FROM create_cont_stream1
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate0';
 \d+ cqcreate0;
 \d+ cqcreate0_mrel;
-\d+ cqcreate0_csrel;
+\d+ cqcreate0_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate0');
 
 CREATE CONTINUOUS VIEW cqcreate1 AS SELECT substring(url::text, 1, 2) FROM create_cont_stream1;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate1';
 \d+ cqcreate1;
 \d+ cqcreate1_mrel;
-\d+ cqcreate1_csrel;
+\d+ cqcreate1_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate1');
 
 CREATE CONTINUOUS VIEW cqcreate2 AS SELECT key::integer, substring(value::text, 1, 2) AS s FROM create_cont_stream1;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate2';
 \d+ cqcreate2;
 \d+ cqcreate2_mrel;
-\d+ cqcreate2_csrel;
+\d+ cqcreate2_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate2');
 
 -- Group by projections
@@ -27,14 +27,14 @@ CREATE CONTINUOUS VIEW cqcreate3 AS SELECT key::text, COUNT(*), SUM(value::int8)
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate3';
 \d+ cqcreate3;
 \d+ cqcreate3_mrel;
-\d+ cqcreate3_csrel;
+\d+ cqcreate3_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate3');
 
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM cont_create_stream2 GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate4';
 \d+ cqcreate4;
 \d+ cqcreate4_mrel;
-\d+ cqcreate4_csrel;
+\d+ cqcreate4_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate4');
 
 -- Sliding window queries
@@ -42,83 +42,83 @@ CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM cont_create_stream2 WH
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate5';
 \d+ cqcreate5;
 \d+ cqcreate5_mrel;
-\d+ cqcreate5_csrel;
+\d+ cqcreate5_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate5');
 
 CREATE CONTINUOUS VIEW cqcreate6 AS SELECT COUNT(*) FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5 seconds') GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate6';
 \d+ cqcreate6;
 \d+ cqcreate6_mrel;
-\d+ cqcreate6_csrel;
+\d+ cqcreate6_osrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate6');
 
 -- These use a combine state column
 CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, AVG(y::integer) AS int_avg, AVG(ts0::timestamp - ts1::timestamp) AS internal_avg FROM cont_create_stream2 GROUP BY key;
 \d+ cvavg;
 \d+ cvavg_mrel;
-\d+ cvavg_csrel;
+\d+ cvavg_osrel;
 SELECT pipeline_get_overlay_viewdef('cvavg');
 
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM create_cont_stream1;
 \d+ cvjson;
 \d+ cvjson_mrel;
-\d+ cvjson_csrel;
+\d+ cvjson_osrel;
 SELECT pipeline_get_overlay_viewdef('cvjson');
 
 CREATE CONTINUOUS VIEW cvjsonobj AS SELECT json_object_agg(key::text, value::integer) FROM cont_create_stream2;
 \d+ cvjsonobj;
 \d+ cvjsonobj_mrel;
-\d+ cvjsonobj_csrel;
+\d+ cvjsonobj_osrel;
 SELECT pipeline_get_overlay_viewdef('cvjsonobj');
 
 -- But these aggregates don't
 CREATE CONTINUOUS VIEW cvcount AS SELECT SUM(x::integer + y::float8) AS sum_col FROM cont_create_stream2;
 \d+ cvcount;
 \d+ cvcount_mrel;
-\d+ cvcount_csrel;
+\d+ cvcount_osrel;
 SELECT pipeline_get_overlay_viewdef('cvcount');
 
 CREATE CONTINUOUS VIEW cvarray AS SELECT COUNT(*) as count_col FROM create_cont_stream1;
 \d+ cvarray;
 \d+ cvarray_mrel;
-\d+ cvarray_csrel;
+\d+ cvarray_osrel;
 SELECT pipeline_get_overlay_viewdef('cvarray');
 
 CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text, 1, 2), ',') FROM cont_create_stream2 GROUP BY key;
 \d+ cvtext;
 \d+ cvtext_mrel;
-\d+ cvtext_csrel;
+\d+ cvtext_osrel;
 SELECT pipeline_get_overlay_viewdef('cvtext');
 
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM cont_create_stream2;
 \d+ cqaggexpr1;
 \d+ cqaggexpr1_mrel;
-\d+ cqaggexpr1_csrel;
+\d+ cqaggexpr1_osrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
 
 CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::integer) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr2;
 \d+ cqaggexpr2_mrel;
-\d+ cqaggexpr2_csrel;
+\d+ cqaggexpr2_osrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
 
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5 seconds') GROUP BY key;
 \d+ cqaggexpr3;
 \d+ cqaggexpr3_mrel;
-\d+ cqaggexpr3_csrel;
+\d+ cqaggexpr3_osrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
 
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr4;
 \d+ cqaggexpr4_mrel;
-\d+ cqaggexpr4_csrel;
+\d+ cqaggexpr4_osrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
 
 CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM create_cont_stream1 GROUP BY k0, k1;
 \d+ cqgroupby
 \d+ cqgroupby_mrel;
-\d+ cqgroupby_csrel;
+\d+ cqgroupby_osrel;
 SELECT pipeline_get_overlay_viewdef('cqgroupby');
 
 CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM create_cont_stream1
@@ -126,7 +126,7 @@ GROUP BY a, b, c, d, e;
 
 \d+ multigroupindex;
 \d+ multigroupindex_mrel;
-\d+ multigroupindex_csrel;
+\d+ multigroupindex_osrel;
 SELECT pipeline_get_overlay_viewdef('multigroupindex');
 
 -- A user-specified fillfactor should override the default

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -5,18 +5,21 @@ CREATE CONTINUOUS VIEW cqcreate0 AS SELECT key::integer FROM create_cont_stream1
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate0';
 \d+ cqcreate0;
 \d+ cqcreate0_mrel;
+\d+ cqcreate0_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate0');
 
 CREATE CONTINUOUS VIEW cqcreate1 AS SELECT substring(url::text, 1, 2) FROM create_cont_stream1;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate1';
 \d+ cqcreate1;
 \d+ cqcreate1_mrel;
+\d+ cqcreate1_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate1');
 
 CREATE CONTINUOUS VIEW cqcreate2 AS SELECT key::integer, substring(value::text, 1, 2) AS s FROM create_cont_stream1;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate2';
 \d+ cqcreate2;
 \d+ cqcreate2_mrel;
+\d+ cqcreate2_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate2');
 
 -- Group by projections
@@ -24,12 +27,14 @@ CREATE CONTINUOUS VIEW cqcreate3 AS SELECT key::text, COUNT(*), SUM(value::int8)
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate3';
 \d+ cqcreate3;
 \d+ cqcreate3_mrel;
+\d+ cqcreate3_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate3');
 
 CREATE CONTINUOUS VIEW cqcreate4 AS SELECT COUNT(*), SUM(value::int8) FROM cont_create_stream2 GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate4';
 \d+ cqcreate4;
 \d+ cqcreate4_mrel;
+\d+ cqcreate4_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate4');
 
 -- Sliding window queries
@@ -37,70 +42,83 @@ CREATE CONTINUOUS VIEW cqcreate5 AS SELECT key::text FROM cont_create_stream2 WH
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate5';
 \d+ cqcreate5;
 \d+ cqcreate5_mrel;
+\d+ cqcreate5_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate5');
 
 CREATE CONTINUOUS VIEW cqcreate6 AS SELECT COUNT(*) FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5 seconds') GROUP BY key::text;
 SELECT COUNT(*) FROM pipeline_views() WHERE name = 'cqcreate6';
 \d+ cqcreate6;
 \d+ cqcreate6_mrel;
+\d+ cqcreate6_csrel;
 SELECT pipeline_get_overlay_viewdef('cqcreate6');
 
 -- These use a combine state column
 CREATE CONTINUOUS VIEW cvavg AS SELECT key::text, AVG(x::float8) AS float_avg, AVG(y::integer) AS int_avg, AVG(ts0::timestamp - ts1::timestamp) AS internal_avg FROM cont_create_stream2 GROUP BY key;
 \d+ cvavg;
 \d+ cvavg_mrel;
+\d+ cvavg_csrel;
 SELECT pipeline_get_overlay_viewdef('cvavg');
 
 CREATE CONTINUOUS VIEW cvjson AS SELECT json_agg(x::text) AS count_col FROM create_cont_stream1;
 \d+ cvjson;
 \d+ cvjson_mrel;
+\d+ cvjson_csrel;
 SELECT pipeline_get_overlay_viewdef('cvjson');
 
 CREATE CONTINUOUS VIEW cvjsonobj AS SELECT json_object_agg(key::text, value::integer) FROM cont_create_stream2;
 \d+ cvjsonobj;
 \d+ cvjsonobj_mrel;
+\d+ cvjsonobj_csrel;
 SELECT pipeline_get_overlay_viewdef('cvjsonobj');
 
 -- But these aggregates don't
 CREATE CONTINUOUS VIEW cvcount AS SELECT SUM(x::integer + y::float8) AS sum_col FROM cont_create_stream2;
 \d+ cvcount;
 \d+ cvcount_mrel;
+\d+ cvcount_csrel;
 SELECT pipeline_get_overlay_viewdef('cvcount');
 
 CREATE CONTINUOUS VIEW cvarray AS SELECT COUNT(*) as count_col FROM create_cont_stream1;
 \d+ cvarray;
 \d+ cvarray_mrel;
+\d+ cvarray_csrel;
 SELECT pipeline_get_overlay_viewdef('cvarray');
 
 CREATE CONTINUOUS VIEW cvtext AS SELECT key::text, string_agg(substring(s::text, 1, 2), ',') FROM cont_create_stream2 GROUP BY key;
 \d+ cvtext;
 \d+ cvtext_mrel;
+\d+ cvtext_csrel;
 SELECT pipeline_get_overlay_viewdef('cvtext');
 
 -- Check for expressions containing aggregates
 CREATE CONTINUOUS VIEW cqaggexpr1 AS SELECT COUNT(*) + SUM(x::int) FROM cont_create_stream2;
 \d+ cqaggexpr1;
 \d+ cqaggexpr1_mrel;
+\d+ cqaggexpr1_csrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
 
 CREATE CONTINUOUS VIEW cqaggexpr2 AS SELECT key::text, AVG(x::float) + MAX(y::integer) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr2;
 \d+ cqaggexpr2_mrel;
+\d+ cqaggexpr2_csrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
 
 CREATE CONTINUOUS VIEW cqaggexpr3 AS SELECT key::text, COUNT(*) AS value FROM cont_create_stream2 WHERE arrival_timestamp > (clock_timestamp() - interval '5 seconds') GROUP BY key;
 \d+ cqaggexpr3;
 \d+ cqaggexpr3_mrel;
+\d+ cqaggexpr3_csrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
 
 CREATE CONTINUOUS VIEW cqaggexpr4 AS SELECT key::text, floor(AVG(x::float)) AS value FROM cont_create_stream2 GROUP BY key;
 \d+ cqaggexpr4;
 \d+ cqaggexpr4_mrel;
+\d+ cqaggexpr4_csrel;
 SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
 
 CREATE CONTINUOUS VIEW cqgroupby AS SELECT k0::text, k1::integer, COUNT(*) FROM create_cont_stream1 GROUP BY k0, k1;
 \d+ cqgroupby
 \d+ cqgroupby_mrel;
+\d+ cqgroupby_csrel;
 SELECT pipeline_get_overlay_viewdef('cqgroupby');
 
 CREATE CONTINUOUS VIEW multigroupindex AS SELECT a::text, b::int8, c::int4, d::int2, e::float8, COUNT(*) FROM create_cont_stream1
@@ -108,6 +126,7 @@ GROUP BY a, b, c, d, e;
 
 \d+ multigroupindex;
 \d+ multigroupindex_mrel;
+\d+ multigroupindex_csrel;
 SELECT pipeline_get_overlay_viewdef('multigroupindex');
 
 -- A user-specified fillfactor should override the default

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -5,22 +5,22 @@ CREATE CONTINUOUS VIEW os0_output AS SELECT (old).count AS old_count, (new).coun
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
 
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
 
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
 
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT * FROM os0_output;
+SELECT * FROM os0_output ORDER BY old_count, new_count;
 
 -- We shouldn't be able to drop this because os0_output depends on it now
 DROP CONTINUOUS VIEW os0;
@@ -40,17 +40,17 @@ FROM os1_osrel;
 INSERT INTO os_stream (x) VALUES (10);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 INSERT INTO os_stream (x) VALUES (20);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 INSERT INTO os_stream (x) VALUES (30);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 INSERT INTO os_stream (x) VALUES (40);
 SELECT pg_sleep(2);
@@ -58,22 +58,22 @@ SELECT pg_sleep(2);
 INSERT INTO os_stream (x) VALUES (-40);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 INSERT INTO os_stream (x) VALUES (-30);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 INSERT INTO os_stream (x) VALUES (-20);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 INSERT INTO os_stream (x) VALUES (-10);
 SELECT pg_sleep(2);
 
-SELECT * FROM os1_output;
+SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 
 DROP CONTINUOUS VIEW os1 CASCADE;
 
@@ -91,22 +91,22 @@ FROM os2_osrel;
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT x, old, new FROM os2_output;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
 
 INSERT INTO os_stream (x) VALUES (1);
 SELECT pg_sleep(2);
 
-SELECT x, old, new FROM os2_output;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
 
 INSERT INTO os_stream (x) VALUES (2);
 SELECT pg_sleep(2);
 
-SELECT x, old, new FROM os2_output;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
 
 INSERT INTO os_stream (x) VALUES (3);
 SELECT pg_sleep(20);
 
-SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
+SELECT x, old, new FROM os2_output ORDER BY x, old, new;
 
 DROP CONTINUOUS VIEW os2 CASCADE;
 
@@ -125,17 +125,17 @@ CREATE CONTINUOUS VIEW os3_output AS SELECT
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT x, new, y FROM os3_output;
+SELECT x, new, y FROM os3_output ORDER BY x, new, y;
 
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT x, new, y FROM os3_output;
+SELECT x, new, y FROM os3_output ORDER BY x, new, y;
 
 INSERT INTO os_stream (x) VALUES (0);
 SELECT pg_sleep(2);
 
-SELECT x, new, y FROM os3_output;
+SELECT x, new, y FROM os3_output ORDER BY x, new, y;
 
 DROP TABLE os_t0;
 DROP CONTINUOUS VIEW os3 CASCADE;

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -3,22 +3,22 @@ CREATE CONTINUOUS VIEW os0 AS SELECT COUNT(*) FROM os_stream;
 CREATE CONTINUOUS VIEW os0_output AS SELECT (old).count AS old_count, (new).count AS new_count FROM os0_osrel;
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os0_output;
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os0_output;
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os0_output;
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os0_output;
 
@@ -38,40 +38,42 @@ CREATE CONTINUOUS VIEW os1_output AS SELECT
 FROM os1_osrel;
 
 INSERT INTO os_stream (x) VALUES (10);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os1_output;
 
 INSERT INTO os_stream (x) VALUES (20);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os1_output;
 
 INSERT INTO os_stream (x) VALUES (30);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os1_output;
 
 INSERT INTO os_stream (x) VALUES (40);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 INSERT INTO os_stream (x) VALUES (-40);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os1_output;
 
 INSERT INTO os_stream (x) VALUES (-30);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os1_output;
 
 INSERT INTO os_stream (x) VALUES (-20);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT * FROM os1_output;
 
 INSERT INTO os_stream (x) VALUES (-10);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
+
+SELECT * FROM os1_output;
 
 DROP CONTINUOUS VIEW os1 CASCADE;
 
@@ -86,17 +88,17 @@ CREATE CONTINUOUS VIEW os2_output AS SELECT
 FROM os2_osrel;
 
 INSERT INTO os_stream (x) VALUES (0);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT x, old, new FROM os2_output;
 
 INSERT INTO os_stream (x) VALUES (1);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT x, old, new FROM os2_output;
 
 INSERT INTO os_stream (x) VALUES (2);
-SELECT pg_sleep(1);
+SELECT pg_sleep(2);
 
 SELECT x, old, new FROM os2_output;
 

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -139,3 +139,36 @@ SELECT x, new, y FROM os3_output ORDER BY x, new, y;
 
 DROP TABLE os_t0;
 DROP CONTINUOUS VIEW os3 CASCADE;
+
+-- Final functions should be applied to output stream tuples where necessary
+CREATE CONTINUOUS VIEW os3 AS SELECT x::integer, avg(y::integer), count(distinct z::integer)
+FROM os_stream GROUP BY x;
+
+CREATE CONTINUOUS VIEW os3_output AS SELECT
+  arrival_timestamp,
+  CASE WHEN old IS NULL THEN (new).x ELSE (old).x END AS x,
+  old, new
+FROM os3_osrel;
+
+INSERT INTO os_stream (x, y, z) VALUES (0, 2, 0);
+SELECT pg_sleep(2);
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+
+INSERT INTO os_stream (x, y, z) VALUES (0, 4, 1);
+SELECT pg_sleep(2);
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+
+INSERT INTO os_stream (x, y, z) VALUES (1, 8, 2);
+SELECT pg_sleep(2);
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+
+INSERT INTO os_stream (x, y, z) VALUES (1, 16, 2);
+SELECT pg_sleep(2);
+
+SELECT x, old, new FROM os3_output ORDER BY x, old, new;
+
+DROP CONTINUOUS VIEW os3 CASCADE;
+

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -1,0 +1,108 @@
+
+CREATE CONTINUOUS VIEW os0 AS SELECT COUNT(*) FROM os_stream;
+CREATE CONTINUOUS VIEW os0_output AS SELECT (old).count AS old_count, (new).count AS new_count FROM os0_osrel;
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+
+SELECT * FROM os0_output;
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+
+SELECT * FROM os0_output;
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+
+SELECT * FROM os0_output;
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+
+SELECT * FROM os0_output;
+
+-- Shouldn't be able to drop this because os0_output depends on it now
+DROP CONTINUOUS VIEW os0;
+
+DROP CONTINUOUS VIEW os0_output;
+DROP CONTINUOUS VIEW os0;
+
+CREATE CONTINUOUS VIEW os1 AS SELECT abs(x::integer) AS g, COUNT(*), sum(x)
+FROM os_stream GROUP BY g;
+
+CREATE CONTINUOUS VIEW os1_output AS SELECT
+  (new).g,
+  (old).count AS old_count, (new).count AS new_count,
+  (old).sum AS old_sum, (new).sum AS new_sum
+FROM os1_osrel;
+
+INSERT INTO os_stream (x) VALUES (10);
+SELECT pg_sleep(1);
+
+SELECT * FROM os1_output;
+
+INSERT INTO os_stream (x) VALUES (20);
+SELECT pg_sleep(1);
+
+SELECT * FROM os1_output;
+
+INSERT INTO os_stream (x) VALUES (30);
+SELECT pg_sleep(1);
+
+SELECT * FROM os1_output;
+
+INSERT INTO os_stream (x) VALUES (40);
+SELECT pg_sleep(1);
+
+INSERT INTO os_stream (x) VALUES (-40);
+SELECT pg_sleep(1);
+
+SELECT * FROM os1_output;
+
+INSERT INTO os_stream (x) VALUES (-30);
+SELECT pg_sleep(1);
+
+SELECT * FROM os1_output;
+
+INSERT INTO os_stream (x) VALUES (-20);
+SELECT pg_sleep(1);
+
+SELECT * FROM os1_output;
+
+INSERT INTO os_stream (x) VALUES (-10);
+SELECT pg_sleep(1);
+
+DROP CONTINUOUS VIEW os1 CASCADE;
+
+CREATE CONTINUOUS VIEW os2 WITH (max_age = '10 seconds') AS
+SELECT x::integer, COUNT(*)
+FROM os_stream GROUP BY x;
+
+CREATE CONTINUOUS VIEW os2_output AS SELECT
+  arrival_timestamp,
+  CASE WHEN old IS NULL THEN (new).x ELSE (old).x END AS x,
+  old, new
+FROM os2_osrel;
+
+INSERT INTO os_stream (x) VALUES (0);
+SELECT pg_sleep(1);
+
+SELECT x, old, new FROM os2_output;
+
+INSERT INTO os_stream (x) VALUES (1);
+SELECT pg_sleep(1);
+
+SELECT x, old, new FROM os2_output;
+
+INSERT INTO os_stream (x) VALUES (2);
+SELECT pg_sleep(1);
+
+SELECT x, old, new FROM os2_output;
+
+INSERT INTO os_stream (x) VALUES (3);
+SELECT pg_sleep(20);
+
+SELECT x, old, new FROM os2_output ORDER BY arrival_timestamp;
+
+DROP CONTINUOUS VIEW os2 CASCADE;


### PR DESCRIPTION
Adds support for output streams, which are turning out to be pretty awesome. Some notes on how this works:

* If anything is reading from an output stream, the combiner will write the old and new tuple to it when syncing, otherwise there's no additional meaningful overhead
* For sliding window queries, output stream writes are done separately by executing the overlay plan on cached in-window tuples
* Sliding-window queries will tick roughly every `step_size_ms` in order to keep writing out values that depend on wall time
* Out-of-window tuples are GC'd and indicated by the output stream tuple of the form: `(<old>, null)`
* Concurrent combiners only cache and process the SW groups that belong to them, so all of this work is distributed evenly across combiners

Note that this diff doesn't include a function wrapper (e.g. `output_of('cv')`) for the output stream yet, so output streams are just referred to literally (`v_osrel`). Doing this the right way isn't too complicated but actually isn't trivial and does require some thought, and I didn't want to go out of scope with this diff.

As soon as this diff is ready to land, I'm going to rip out all legacy trigger stuff. I just didn't want the diff to be unnecessarily large. I think we should rip out the alert server as well.

Also, pytests are on the way.