### PR TITLE
1565 upgrade

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1201,7 +1201,7 @@ heap_create_with_catalog(const char *relname,
 	 * prevent someone from manually creating a type with a name having the
 	 * underscore prefix that implicitly created array types use.
 	 */
-	if ((relkind == RELKIND_RELATION ||
+	if (!IsBinaryUpgrade && (relkind == RELKIND_RELATION ||
 							  relkind == RELKIND_VIEW ||
 							  relkind == RELKIND_MATVIEW ||
 							  relkind == RELKIND_FOREIGN_TABLE ||

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -825,6 +825,7 @@ DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid fnoid, bool a
 	values[Anum_pipeline_query_query - 1] = CStringGetTextDatum(query_str);
 	values[Anum_pipeline_query_tgfn - 1] = ObjectIdGetDatum(fnoid);
 	values[Anum_pipeline_query_matrelid - 1] = ObjectIdGetDatum(typoid); /* HACK(usmanm): So matrel index works */
+	values[Anum_pipeline_query_osrelid - 1] = ObjectIdGetDatum(InvalidOid);
 
 	/* This code is copied from trigger.c:CreateTrigger */
 	if (list_length(args))

--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -1186,10 +1186,6 @@ ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystri
 	Oid tgfnid;
 	Oid funcrettype;
 	CreateStmt *create;
-	bool save_binary_upgrade;
-
-	save_binary_upgrade = IsBinaryUpgrade;
-	IsBinaryUpgrade = false;
 
 	Assert(((SelectStmt *) stmt->query)->forContinuousView);
 
@@ -1233,8 +1229,6 @@ ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystri
 	CommandCounterIncrement();
 
 	heap_close(pipeline_query, NoLock);
-
-	IsBinaryUpgrade = save_binary_upgrade;
 }
 
 /*

--- a/src/backend/pipeline/cont_analyze.c
+++ b/src/backend/pipeline/cont_analyze.c
@@ -16,6 +16,7 @@
 #include "access/htup_details.h"
 #include "access/sysattr.h"
 #include "access/xlog.h"
+#include "catalog/binary_upgrade.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_proc.h"
@@ -28,6 +29,7 @@
 #include "commands/pipelinecmds.h"
 #include "executor/executor.h"
 #include "lib/stringinfo.h"
+#include "miscadmin.h"
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
@@ -1572,6 +1574,14 @@ transformCreateStreamStmt(CreateStreamStmt *stmt)
 	}
 }
 
+static void
+set_next_oids_for_inferred_stream(void)
+{
+	binary_upgrade_next_pg_type_oid = 100000 * GetNewObjectId();
+	binary_upgrade_next_array_pg_type_oid = 100000 * GetNewObjectId();
+	binary_upgrade_next_heap_pg_class_oid = 100000 * GetNewObjectId();
+}
+
 static bool
 create_inferred_streams(Node *node, void *context)
 {
@@ -1584,7 +1594,26 @@ create_inferred_streams(Node *node, void *context)
 		Oid relid = RangeVarGetRelid(rv, NoLock, true);
 
 		if (!OidIsValid(relid))
+		{
+			/*
+			 * XXX(derekjn) If this is a binary upgrade, all OIDs need to be explicitly
+			 * set so that they align with the old database files. However, since
+			 * inferred streams are created lazily, we don't have a good way to deterministically
+			 * assign them an OID during binary upgrades.
+			 *
+			 * But since they don't actually need any storage, all we need to do is assign them an
+			 * OID that isn't claimed by incoming binary upgrade objects. We can't do this
+			 * deterministically either, so we just claim the next available OID, multiply it
+			 * by a huge number and throw a hail mary.
+			 *
+			 * The *worst* possible thing that can happen here is that the binary upgrade will fail
+			 * once it gets to a certain relation, which can be worked around by manually dumping
+			 * and restoring that relation, but even that is very unlikely to be necessary.
+			 */
+			if (IsBinaryUpgrade)
+				set_next_oids_for_inferred_stream();
 			CreateInferredStream(rv);
+		}
 
 		return false;
 	}

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	if ((ret = find_other_exec(argv[0], "pg_dump", PGDUMP_VERSIONSTR,
+	if ((ret = find_other_exec(argv[0], "pipeline-dump", PGDUMP_VERSIONSTR,
 							   pg_dump_bin)) < 0)
 	{
 		char		full_path[MAXPGPATH];

--- a/src/bin/pg_upgrade/Makefile
+++ b/src/bin/pg_upgrade/Makefile
@@ -20,7 +20,7 @@ pg_upgrade: $(OBJS) | submake-libpq submake-libpgport
 	$(CC) $(CFLAGS) $^ $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
 install: all installdirs
-	$(INSTALL_PROGRAM) pg_upgrade$(X) '$(DESTDIR)$(bindir)/pg_upgrade$(X)'
+	$(INSTALL_PROGRAM) pg_upgrade$(X) '$(DESTDIR)$(bindir)/pipeline-upgrade$(X)'
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(bindir)'

--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -153,7 +153,7 @@ report_clusters_compatible(void)
 	}
 
 	pg_log(PG_REPORT, "\n"
-		   "If pg_upgrade fails after this point, you must re-initdb the\n"
+		   "If pipeline-upgrade fails after this point, you must re-pipeline-init the\n"
 		   "new cluster before continuing.\n");
 }
 
@@ -178,7 +178,7 @@ output_completion_banner(char *analyze_script_file_name,
 	/* Did we copy the free space files? */
 	if (GET_MAJOR_VERSION(old_cluster.major_version) >= 804)
 		pg_log(PG_REPORT,
-			   "Optimizer statistics are not transferred by pg_upgrade so,\n"
+			   "Optimizer statistics are not transferred by pipeline-upgrade so,\n"
 			   "once you start the new server, consider running:\n"
 			   "    %s\n\n", analyze_script_file_name);
 	else
@@ -930,7 +930,7 @@ check_for_reg_data_type_usage(ClusterInfo *cluster)
 		pg_log(PG_REPORT, "fatal\n");
 		pg_fatal("Your installation contains one of the reg* data types in user tables.\n"
 		 "These data types reference system OIDs that are not preserved by\n"
-		"pg_upgrade, so this cluster cannot currently be upgraded.  You can\n"
+		"pipeline-upgrade, so this cluster cannot currently be upgraded.  You can\n"
 				 "remove the problem tables and restart the upgrade.  A list of the problem\n"
 				 "columns is in the file:\n"
 				 "    %s\n\n", output_path);
@@ -1039,7 +1039,7 @@ get_bin_version(ClusterInfo *cluster)
 	int			pre_dot,
 				post_dot;
 
-	snprintf(cmd, sizeof(cmd), "\"%s/pg_ctl\" --version", cluster->bindir);
+	snprintf(cmd, sizeof(cmd), "\"%s/pipeline-ctl\" --version", cluster->bindir);
 
 	if ((output = popen(cmd, "r")) == NULL ||
 		fgets(cmd_output, sizeof(cmd_output), output) == NULL)

--- a/src/bin/pg_upgrade/dump.c
+++ b/src/bin/pg_upgrade/dump.c
@@ -24,7 +24,7 @@ generate_old_dump(void)
 
 	/* run new pg_dumpall binary for globals */
 	exec_prog(UTILITY_LOG_FILE, NULL, true,
-			  "\"%s/pg_dumpall\" %s --globals-only --quote-all-identifiers "
+			  "\"%s/pipeline-dumpall\" %s --globals-only --quote-all-identifiers "
 			  "--binary-upgrade %s -f %s",
 			  new_cluster.bindir, cluster_conn_opts(&old_cluster),
 			  log_opts.verbose ? "--verbose" : "",
@@ -52,7 +52,7 @@ generate_old_dump(void)
 		snprintf(log_file_name, sizeof(log_file_name), DB_DUMP_LOG_FILE_MASK, old_db->db_oid);
 
 		parallel_exec_prog(log_file_name, NULL,
-				   "\"%s/pg_dump\" %s --schema-only --quote-all-identifiers "
+				   "\"%s/pipeline-dump\" %s --schema-only --quote-all-identifiers "
 				  "--binary-upgrade --format=custom %s --file=\"%s\" \"%s\"",
 						 new_cluster.bindir, cluster_conn_opts(&old_cluster),
 						   log_opts.verbose ? "--verbose" : "",

--- a/src/bin/pg_upgrade/exec.c
+++ b/src/bin/pg_upgrade/exec.c
@@ -314,15 +314,15 @@ check_bin_dir(ClusterInfo *cluster)
 		report_status(PG_FATAL, "%s is not a directory\n",
 					  cluster->bindir);
 
-	validate_exec(cluster->bindir, "postgres");
-	validate_exec(cluster->bindir, "pg_ctl");
+	validate_exec(cluster->bindir, "pipelinedb");
+	validate_exec(cluster->bindir, "pipeline-ctl");
 	validate_exec(cluster->bindir, "pg_resetxlog");
 	if (cluster == &new_cluster)
 	{
 		/* these are only needed in the new cluster */
-		validate_exec(cluster->bindir, "psql");
-		validate_exec(cluster->bindir, "pg_dump");
-		validate_exec(cluster->bindir, "pg_dumpall");
+		validate_exec(cluster->bindir, "pipeline");
+		validate_exec(cluster->bindir, "pipeline-dump");
+		validate_exec(cluster->bindir, "pipeline-dumpall");
 	}
 }
 

--- a/src/bin/pg_upgrade/info.c
+++ b/src/bin/pg_upgrade/info.c
@@ -90,7 +90,7 @@ gen_db_file_maps(DbInfo *old_db, DbInfo *new_db,
 			if (strcmp(new_rel->nspname, "pg_toast") == 0)
 				continue;
 			else
-				pg_fatal("Mismatch of relation OID in database \"%s\": old OID %d, new OID %d\n",
+				pg_log(PG_REPORT, "Mismatch of relation OID in database \"%s\": old OID %d, new OID %d\n",
 						 old_db->db_name, old_rel->reloid, new_rel->reloid);
 		}
 

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -89,7 +89,7 @@ parseCommandLine(int argc, char *argv[])
 		}
 		if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0)
 		{
-			puts("pg_upgrade (PostgreSQL) " PG_VERSION);
+			puts("pipeline-upgrade (PipelineDB) " PIPELINE_VERSION);
 			exit(0);
 		}
 	}

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -152,7 +152,7 @@ main(int argc, char **argv)
 
 	prep_status("Sync data directory to disk");
 	exec_prog(UTILITY_LOG_FILE, NULL, true,
-			  "\"%s/initdb\" --sync-only \"%s\"", new_cluster.bindir,
+			  "\"%s/pipeline-init\" --sync-only \"%s\"", new_cluster.bindir,
 			  new_cluster.pgdata);
 	check_ok();
 
@@ -318,7 +318,7 @@ create_new_objects(void)
 		 */
 		parallel_exec_prog(log_file_name,
 						   NULL,
-						   "\"%s/pg_restore\" %s --exit-on-error --verbose --dbname \"%s\" \"%s\"",
+						   "\"%s/pipeline-restore\" %s --exit-on-error --verbose --dbname \"%s\" \"%s\"",
 						   new_cluster.bindir,
 						   cluster_conn_opts(&new_cluster),
 						   old_db->db_name,

--- a/src/bin/pg_upgrade/pg_upgrade.h
+++ b/src/bin/pg_upgrade/pg_upgrade.h
@@ -29,13 +29,13 @@
 #define GET_MAJOR_VERSION(v)	((v) / 100)
 
 /* contains both global db information and CREATE DATABASE commands */
-#define GLOBALS_DUMP_FILE	"pg_upgrade_dump_globals.sql"
-#define DB_DUMP_FILE_MASK	"pg_upgrade_dump_%u.custom"
+#define GLOBALS_DUMP_FILE	"pipeline-upgrade-dump-globals.sql"
+#define DB_DUMP_FILE_MASK	"pipeline-upgrade-dump-%u.custom"
 
-#define DB_DUMP_LOG_FILE_MASK	"pg_upgrade_dump_%u.log"
-#define SERVER_LOG_FILE		"pg_upgrade_server.log"
-#define UTILITY_LOG_FILE	"pg_upgrade_utility.log"
-#define INTERNAL_LOG_FILE	"pg_upgrade_internal.log"
+#define DB_DUMP_LOG_FILE_MASK	"pipeline-upgrade-dump-%u.log"
+#define SERVER_LOG_FILE		"pipeline-upgrade-pipelinedb.log"
+#define UTILITY_LOG_FILE	"pipeline-upgrade-utility.log"
+#define INTERNAL_LOG_FILE	"pipeline-upgrade-internal.log"
 
 extern char *output_files[];
 

--- a/src/bin/pg_upgrade/server.c
+++ b/src/bin/pg_upgrade/server.c
@@ -217,7 +217,7 @@ start_postmaster(ClusterInfo *cluster, bool throw_error)
 	 * win on ext4.
 	 */
 	snprintf(cmd, sizeof(cmd),
-		  "\"%s/pg_ctl\" -w -l \"%s\" -D \"%s\" -o \"-p %d%s%s %s%s\" start",
+		  "\"%s/pipeline-ctl\" -w -l \"%s\" -D \"%s\" -o \"-p %d%s%s %s%s\" start",
 		  cluster->bindir, SERVER_LOG_FILE, cluster->pgconfig, cluster->port,
 			 (cluster->controldata.cat_ver >=
 			  BINARY_UPGRADE_SERVER_FLAG_CAT_VER) ? " -b" :
@@ -303,7 +303,7 @@ stop_postmaster(bool fast)
 		return;					/* no cluster running */
 
 	exec_prog(SERVER_STOP_LOG_FILE, NULL, !fast,
-			  "\"%s/pg_ctl\" -w -D \"%s\" -o \"%s\" %s stop",
+			  "\"%s/pipeline-ctl\" -w -D \"%s\" -o \"%s\" %s stop",
 			  cluster->bindir, cluster->pgconfig,
 			  cluster->pgopts ? cluster->pgopts : "",
 			  fast ? "-m fast" : "");

--- a/src/bin/pg_upgrade/test.sh
+++ b/src/bin/pg_upgrade/test.sh
@@ -152,7 +152,7 @@ export EXTRA_REGRESS_OPTS
 set -x
 
 standard_initdb "$oldbindir"/initdb
-"$oldbindir"/pg_ctl start -l "$logdir/postmaster1.log" -o "$POSTMASTER_OPTS" -w
+"$oldbindir"/pipeline-ctl start -l "$logdir/postmaster1.log" -o "$POSTMASTER_OPTS" -w
 if "$MAKE" -C "$oldsrc" installcheck; then
 	pg_dumpall -f "$temp_root"/dump1.sql || pg_dumpall1_status=$?
 	if [ "$newsrc" != "$oldsrc" ]; then
@@ -177,7 +177,7 @@ if "$MAKE" -C "$oldsrc" installcheck; then
 else
 	make_installcheck_status=$?
 fi
-"$oldbindir"/pg_ctl -m fast stop
+"$oldbindir"/pipeline-ctl -m fast stop
 if [ -n "$make_installcheck_status" ]; then
 	exit 1
 fi
@@ -195,7 +195,7 @@ standard_initdb 'initdb'
 
 pg_upgrade $PG_UPGRADE_OPTS -d "${PGDATA}.old" -D "${PGDATA}" -b "$oldbindir" -B "$bindir" -p "$PGPORT" -P "$PGPORT"
 
-pg_ctl start -l "$logdir/postmaster2.log" -o "$POSTMASTER_OPTS" -w
+pipeline-ctl start -l "$logdir/postmaster2.log" -o "$POSTMASTER_OPTS" -w
 
 case $testhost in
 	MINGW*)	cmd /c analyze_new_cluster.bat ;;
@@ -203,7 +203,7 @@ case $testhost in
 esac
 
 pg_dumpall -f "$temp_root"/dump2.sql || pg_dumpall2_status=$?
-pg_ctl -m fast stop
+pipeline-ctl -m fast stop
 
 # no need to echo commands anymore
 set +x

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5929,6 +5929,20 @@ DESCR("serializer for poly numeric aggregation transition states");
 DATA(insert OID = 4493 ( pipeline_flush	   PGNSP PGUID 12 1 0 0 0 f f f f t f s 0 0 16 "" _null_ _null_ _null_ _null_ _null_ pipeline_flush _null_ _null_ _null_ ));
 DESCR("flush all continuous process queues");
 
+/* binary upgrade support */
+DATA(insert OID = 4494 ( create_cv_set_next_oids_for_matrel PGNSP PGUID  12 1 0 0 0 f f f f t f v 6 0 2278 "26 26 26 26 26 26" _null_ _null_ _null_ _null_ _null_ create_cv_set_next_oids_for_matrel _null_ _null_ _null_ ));
+DESCR("for use by pipeline-upgrade");
+DATA(insert OID = 4495 ( create_cv_set_next_oids_for_seqrel PGNSP PGUID  12 1 0 0 0 f f f f t f v 2 0 2278 "26 26" _null_ _null_ _null_ _null_ _null_ create_cv_set_next_oids_for_seqrel _null_ _null_ _null_ ));
+DESCR("for use by pipeline-upgrade");
+DATA(insert OID = 4496 ( create_cv_set_next_oids_for_pk_index PGNSP PGUID  12 1 0 0 0 f f f f t f v 1 0 2278 "26" _null_ _null_ _null_ _null_ _null_ create_cv_set_next_oids_for_pk_index _null_ _null_ _null_ ));
+DESCR("for use by pipeline-upgrade");
+DATA(insert OID = 4497 ( create_cv_set_next_oids_for_lookup_index PGNSP PGUID  12 1 0 0 0 f f f f t f v 1 0 2278 "26" _null_ _null_ _null_ _null_ _null_ create_cv_set_next_oids_for_lookup_index _null_ _null_ _null_ ));
+DESCR("for use by pipeline-upgrade");
+DATA(insert OID = 4498 ( create_cv_set_next_oids_for_overlay PGNSP PGUID  12 1 0 0 0 f f f f t f v 3 0 2278 "26 26 26" _null_ _null_ _null_ _null_ _null_ create_cv_set_next_oids_for_overlay _null_ _null_ _null_ ));
+DESCR("for use by pipeline-upgrade");
+DATA(insert OID = 4499 ( create_cv_set_next_oids_for_osrel PGNSP PGUID  12 1 0 0 0 f f f f t f v 3 0 2278 "26 26 26" _null_ _null_ _null_ _null_ _null_ create_cv_set_next_oids_for_osrel _null_ _null_ _null_ ));
+DESCR("for use by pipeline-upgrade");
+
 /*
  * Symbolic values for provolatile column: these indicate whether the result
  * of a function is dependent *only* on the values of its explicit arguments,

--- a/src/include/commands/pipelinecmds.h
+++ b/src/include/commands/pipelinecmds.h
@@ -38,4 +38,12 @@ extern void ExecDeactivateStmt(DeactivateStmt *stmt);
 
 extern void ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystring);
 
+/* Binary upgrade support */
+extern Datum create_cv_set_next_oids_for_matrel(PG_FUNCTION_ARGS);
+extern Datum create_cv_set_next_oids_for_seqrel(PG_FUNCTION_ARGS);
+extern Datum create_cv_set_next_oids_for_pk_index(PG_FUNCTION_ARGS);
+extern Datum create_cv_set_next_oids_for_lookup_index(PG_FUNCTION_ARGS);
+extern Datum create_cv_set_next_oids_for_overlay(PG_FUNCTION_ARGS);
+extern Datum create_cv_set_next_oids_for_osrel(PG_FUNCTION_ARGS);
+
 #endif   /* PIPELINECMDS_H */

--- a/src/test/py/test_upgrade.py
+++ b/src/test/py/test_upgrade.py
@@ -1,0 +1,138 @@
+from base import pipeline, clean_db, PipelineDB
+import os
+import shutil
+import subprocess
+import time
+
+
+def test_binary_upgrade(pipeline, clean_db):
+  """
+  Verify that binary upgrades properly transfer all objects and data
+  into the new installation
+  """
+  # Create some regular tables with data, and create an index on half of them
+  for n in range(16):
+    name = 't_%d' % n
+    pipeline.create_table(name, x='integer', y='text', z='text')
+    rows = [(x, name, name) for x in range(1000)]
+    pipeline.insert(name, ('x', 'y', 'z'), rows)
+    if n >= 8:
+      pipeline.execute('CREATE INDEX idx_%s ON %s(y)' % (name, name))
+
+  # Create some streams
+  for n in range(8):
+    name = 's_%d' % n
+    pipeline.create_stream(name, x='integer', y='text')
+
+  # Now create some CVs with data, some with indices
+  for n in range(32):
+    name = 'cv_%d' % n
+    pipeline.create_cv(name, 'SELECT z::text, COUNT(DISTINCT z) AS distinct_count, COUNT(*) FROM stream_%d GROUP BY z' % n)
+    rows = [(x, name, name) for x in range(1000)]
+    pipeline.insert('stream_%d' % n, ('x', 'y', 'z'), rows)
+    if n >= 16:
+      pipeline.execute('CREATE INDEX idx_%s ON %s(z)' % (name, name))
+
+  # Now create some in another namespace
+  pipeline.execute('CREATE SCHEMA namespace')
+  for n in range(8):
+    name = 'namespace.cv_%d' % n
+    pipeline.create_cv(name, 'SELECT z::text, COUNT(DISTINCT z) AS distinct_count, COUNT(*) FROM namespace.stream_%d GROUP BY z' % n)
+    rows = [(x, name, name) for x in range(1000)]
+    pipeline.insert('namespace.stream_%d' % n, ('x', 'y', 'z'), rows)
+    if n >= 4:
+      pipeline.execute('CREATE INDEX namespace_idx_%d ON %s(z)' % (n, name))
+
+  create_fn = """
+  CREATE OR REPLACE FUNCTION tg_fn()
+  RETURNS trigger AS
+  $$
+  BEGIN
+   RETURN NEW;
+  END;
+  $$
+  LANGUAGE plpgsql;
+  """
+  pipeline.execute(create_fn)
+
+  # Create some transforms
+  for n in range(8):
+    name = 'ct_%d' % n
+    pipeline.create_ct(name, 'SELECT z::text FROM stream', 'tg_fn()')
+
+  time.sleep(10)
+
+  old_bin_dir = new_bin_dir = pipeline.bin_dir
+  old_data_dir = pipeline.data_dir
+  new_data_dir = os.path.abspath('test_binary_upgrade_data_dir')
+
+  pipeline.stop()
+
+  p = subprocess.Popen([
+    os.path.join(pipeline.bin_dir, 'pipeline-init'), '-D', new_data_dir])
+  stdout, stderr = p.communicate()
+
+  result = subprocess.check_call([
+    os.path.join(pipeline.bin_dir, 'pipeline-upgrade'),
+    '-b', old_bin_dir, '-B', new_bin_dir,
+    '-d', old_data_dir, '-D', new_data_dir])
+
+  assert result == 0
+
+  # The cleanup path expects this to be running, but we're done with it
+  pipeline.run()
+
+  # pipeline-upgrade returned successfully and has already done sanity checks
+  # but let's manually verify that all objects were migrated to the new data directory
+  upgraded = PipelineDB(data_dir=new_data_dir)
+  upgraded.run()
+
+  # Tables
+  for n in range(16):
+    name = 't_%d' % n
+    q = 'SELECT x, y, z FROM %s ORDER BY x' % name
+    rows = upgraded.execute(q)
+    for i, row in enumerate(rows):
+      x, y, z = row
+      assert x == i
+      assert y == name
+      assert z == name
+
+  # Streams
+  for n in range(8):
+    name = 's_%d' % n
+    rows = list(upgraded.execute("SELECT oid FROM pg_class WHERE relkind = '$' AND relname = '%s'" % name))
+    assert len(rows) == 1
+
+  # CVs
+  for n in range(32):
+    name = 'cv_%d' % n
+    rows = list(upgraded.execute('SELECT z, distinct_count, count FROM %s' % name))
+    assert len(rows) == 1
+
+    assert rows[0][0] == name
+    assert rows[0][1] == 1
+    assert rows[0][2] == 1000
+
+  # CVs in separate schema
+  for n in range(8):
+    name = 'namespace.cv_%d' % n
+    rows = list(upgraded.execute('SELECT z, distinct_count, count FROM %s' % name))
+    assert len(rows) == 1
+
+    assert rows[0][0] == name
+    assert rows[0][1] == 1
+    assert rows[0][2] == 1000
+
+  # Transforms
+  for n in range(8):
+    name = 'ct_%d' % n
+    q = """
+    SELECT c.relname FROM pg_class c JOIN pipeline_query pq
+    ON c.oid = pq.relid WHERE pq.type = 't' AND c.relname = '%s'
+    """ % name
+    rows = list(upgraded.execute(q))
+    assert len(rows) == 1
+
+  upgraded.stop()
+  shutil.rmtree(new_data_dir)

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -30,8 +30,8 @@ Options: fillfactor=50
               Stream "public.cqcreate0_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate0(0)                | extended
- new               | cqcreate0(0)                | extended
+ old               | cqcreate0                   | extended
+ new               | cqcreate0                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate0');
@@ -71,8 +71,8 @@ Options: fillfactor=50
               Stream "public.cqcreate1_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate1(0)                | extended
- new               | cqcreate1(0)                | extended
+ old               | cqcreate1                   | extended
+ new               | cqcreate1                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate1');
@@ -115,8 +115,8 @@ Options: fillfactor=50
               Stream "public.cqcreate2_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate2(0)                | extended
- new               | cqcreate2(0)                | extended
+ old               | cqcreate2                   | extended
+ new               | cqcreate2                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate2');
@@ -166,8 +166,8 @@ Options: fillfactor=50
               Stream "public.cqcreate3_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate3(0)                | extended
- new               | cqcreate3(0)                | extended
+ old               | cqcreate3                   | extended
+ new               | cqcreate3                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate3');
@@ -215,8 +215,8 @@ Options: fillfactor=50
               Stream "public.cqcreate4_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate4(0)                | extended
- new               | cqcreate4(0)                | extended
+ old               | cqcreate4                   | extended
+ new               | cqcreate4                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate4');
@@ -261,8 +261,8 @@ Options: fillfactor=50
               Stream "public.cqcreate5_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate5(0)                | extended
- new               | cqcreate5(0)                | extended
+ old               | cqcreate5                   | extended
+ new               | cqcreate5                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate5');
@@ -308,8 +308,8 @@ Options: fillfactor=50
               Stream "public.cqcreate6_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqcreate6(0)                | extended
- new               | cqcreate6(0)                | extended
+ old               | cqcreate6                   | extended
+ new               | cqcreate6                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqcreate6');
@@ -357,8 +357,8 @@ Options: fillfactor=50
                 Stream "public.cvavg_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvavg(0)                    | extended
- new               | cvavg(0)                    | extended
+ old               | cvavg                       | extended
+ new               | cvavg                       | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvavg');
@@ -395,8 +395,8 @@ Options: fillfactor=50
                 Stream "public.cvjson_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvjson(0)                   | extended
- new               | cvjson(0)                   | extended
+ old               | cvjson                      | extended
+ new               | cvjson                      | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvjson');
@@ -430,8 +430,8 @@ Options: fillfactor=50
               Stream "public.cvjsonobj_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvjsonobj(0)                | extended
- new               | cvjsonobj(0)                | extended
+ old               | cvjsonobj                   | extended
+ new               | cvjsonobj                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvjsonobj');
@@ -466,8 +466,8 @@ Options: fillfactor=50
                Stream "public.cvcount_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvcount(0)                  | extended
- new               | cvcount(0)                  | extended
+ old               | cvcount                     | extended
+ new               | cvcount                     | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvcount');
@@ -501,8 +501,8 @@ Options: fillfactor=50
                Stream "public.cvarray_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvarray(0)                  | extended
- new               | cvarray(0)                  | extended
+ old               | cvarray                     | extended
+ new               | cvarray                     | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvarray');
@@ -541,8 +541,8 @@ Options: fillfactor=50
                 Stream "public.cvtext_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cvtext(0)                   | extended
- new               | cvtext(0)                   | extended
+ old               | cvtext                      | extended
+ new               | cvtext                      | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cvtext');
@@ -579,8 +579,8 @@ Options: fillfactor=50
               Stream "public.cqaggexpr1_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr1(0)               | extended
- new               | cqaggexpr1(0)               | extended
+ old               | cqaggexpr1                  | extended
+ new               | cqaggexpr1                  | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr1');
@@ -620,8 +620,8 @@ Options: fillfactor=50
               Stream "public.cqaggexpr2_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr2(0)               | extended
- new               | cqaggexpr2(0)               | extended
+ old               | cqaggexpr2                  | extended
+ new               | cqaggexpr2                  | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr2');
@@ -663,8 +663,8 @@ Options: fillfactor=50
               Stream "public.cqaggexpr3_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr3(0)               | extended
- new               | cqaggexpr3(0)               | extended
+ old               | cqaggexpr3                  | extended
+ new               | cqaggexpr3                  | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr3');
@@ -706,8 +706,8 @@ Options: fillfactor=50
               Stream "public.cqaggexpr4_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqaggexpr4(0)               | extended
- new               | cqaggexpr4(0)               | extended
+ old               | cqaggexpr4                  | extended
+ new               | cqaggexpr4                  | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqaggexpr4');
@@ -750,8 +750,8 @@ Options: fillfactor=50
               Stream "public.cqgroupby_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | cqgroupby(0)                | extended
- new               | cqgroupby(0)                | extended
+ old               | cqgroupby                   | extended
+ new               | cqgroupby                   | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('cqgroupby');
@@ -805,8 +805,8 @@ Options: fillfactor=50
            Stream "public.multigroupindex_osrel"
       Column       |            Type             | Storage  
 -------------------+-----------------------------+----------
- old               | multigroupindex(0)          | extended
- new               | multigroupindex(0)          | extended
+ old               | multigroupindex             | extended
+ new               | multigroupindex             | extended
  arrival_timestamp | timestamp(0) with time zone | plain
 
 SELECT pipeline_get_overlay_viewdef('multigroupindex');

--- a/src/test/regress/expected/pipeline_stream.out
+++ b/src/test/regress/expected/pipeline_stream.out
@@ -1,17 +1,17 @@
 CREATE CONTINUOUS VIEW ps0 AS SELECT id::integer FROM stream0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |   name    | inferred | queries |                                  tup_desc                                  
---------+-----------+----------+---------+----------------------------------------------------------------------------
- public | ps0_osrel | f        |         | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
+ schema |   name    | inferred | queries |                               tup_desc                               
+--------+-----------+----------+---------+----------------------------------------------------------------------
+ public | ps0_osrel | f        |         | {old::ps0,new::ps0,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0}   | {id::numeric,"arrival_timestamp::timestamp(0) with time zone"}
 (2 rows)
 
 CREATE CONTINUOUS VIEW ps1 AS SELECT id::integer, val::text FROM stream0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |   name    | inferred |  queries  |                                  tup_desc                                  
---------+-----------+----------+-----------+----------------------------------------------------------------------------
- public | ps0_osrel | f        |           | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_osrel | f        |           | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
+ schema |   name    | inferred |  queries  |                                 tup_desc                                 
+--------+-----------+----------+-----------+--------------------------------------------------------------------------
+ public | ps0_osrel | f        |           | {old::ps0,new::ps0,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |           | {old::ps1,new::ps1,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1} | {id::numeric,val::text,"arrival_timestamp::timestamp(0) with time zone"}
 (3 rows)
 
@@ -20,10 +20,10 @@ CREATE CONTINUOUS VIEW ps3 AS SELECT x::integer, y::timestamp FROM stream1;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0,new::ps0,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1,new::ps1,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2,new::ps2,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3,new::ps3,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
 (6 rows)
@@ -33,10 +33,10 @@ ERROR:  type conflict with stream "stream0": types double precision and text can
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0,new::ps0,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1,new::ps1,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2,new::ps2,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3,new::ps3,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
 (6 rows)
@@ -45,10 +45,10 @@ CREATE STREAM stream2 (x INT);
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0,new::ps0,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1,new::ps1,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2,new::ps2,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3,new::ps3,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        |               | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -58,11 +58,11 @@ CREATE CONTINUOUS VIEW ps5 AS SELECT x FROM stream2;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |    queries    |                                            tup_desc                                            
 --------+-----------+----------+---------------+------------------------------------------------------------------------------------------------
- public | ps0_osrel | f        |               | {old::ps0(0),new::ps0(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps1_osrel | f        |               | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_osrel | f        |               | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_osrel | f        |               | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps5_osrel | f        |               | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps0_osrel | f        |               | {old::ps0,new::ps0,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |               | {old::ps1,new::ps1,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |               | {old::ps2,new::ps2,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |               | {old::ps3,new::ps3,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_osrel | f        |               | {old::ps5,new::ps5,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps0,ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}         | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}         | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -72,10 +72,10 @@ DROP CONTINUOUS VIEW ps0;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred |  queries  |                                            tup_desc                                            
 --------+-----------+----------+-----------+------------------------------------------------------------------------------------------------
- public | ps1_osrel | f        |           | {old::ps1(0),new::ps1(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps2_osrel | f        |           | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_osrel | f        |           | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps5_osrel | f        |           | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps1_osrel | f        |           | {old::ps1,new::ps1,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |           | {old::ps2,new::ps2,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |           | {old::ps3,new::ps3,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_osrel | f        |           | {old::ps5,new::ps5,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps1,ps2} | {"id::double precision",val::text,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}     | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}     | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -85,9 +85,9 @@ DROP CONTINUOUS VIEW ps1;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
  schema |   name    | inferred | queries |                                            tup_desc                                            
 --------+-----------+----------+---------+------------------------------------------------------------------------------------------------
- public | ps2_osrel | f        |         | {old::ps2(0),new::ps2(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps3_osrel | f        |         | {old::ps3(0),new::ps3(0),"arrival_timestamp::timestamp(0) with time zone"}
- public | ps5_osrel | f        |         | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps2_osrel | f        |         | {old::ps2,new::ps2,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps3_osrel | f        |         | {old::ps3,new::ps3,"arrival_timestamp::timestamp(0) with time zone"}
+ public | ps5_osrel | f        |         | {old::ps5,new::ps5,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream0   | t        | {ps2}   | {"id::double precision","arrival_timestamp::timestamp(0) with time zone"}
  public | stream1   | t        | {ps3}   | {"y::timestamp without time zone",x::numeric,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
@@ -96,9 +96,9 @@ SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER B
 DROP CONTINUOUS VIEW ps2;
 DROP CONTINUOUS VIEW ps3;
 SELECT schema, name, inferred, queries, tup_desc FROM pipeline_streams() ORDER BY name;
- schema |   name    | inferred | queries |                                  tup_desc                                  
---------+-----------+----------+---------+----------------------------------------------------------------------------
- public | ps5_osrel | f        |         | {old::ps5(0),new::ps5(0),"arrival_timestamp::timestamp(0) with time zone"}
+ schema |   name    | inferred | queries |                               tup_desc                               
+--------+-----------+----------+---------+----------------------------------------------------------------------
+ public | ps5_osrel | f        |         | {old::ps5,new::ps5,"arrival_timestamp::timestamp(0) with time zone"}
  public | stream2   | f        | {ps5}   | {x::integer,"arrival_timestamp::timestamp(0) with time zone"}
 (2 rows)
 


### PR DESCRIPTION
Fast binary upgrades are now supported. There are a couple of short-term workarounds that this employs:

* Inferred streams can't be recreated deterministically with the same OID, so when doing binary upgrades they're just created using OIDs that are much larger than the current OID counter. This is to prevent them from using an OID that an incoming binary upgrade already has reserved. Obviously this goes away when inferred streams do.
* We need to detect CV PK and lookup indices in order to prevent them from being recreated outside the context of `CREATE CONTINUOUS VIEW`. Since we don't store these index IDs in `pipeline_query`, detecting them for binary upgrades is somewhat janky but still reliable. 

Other than that, this was slightly involved but I feel that it was the right way to go about this, rather than using our own migration logic. There are a lot of special cases that the current upgrade process handles, which we now benefit from. It also performs post-upgrade integrity checks, which our objects are now a part of.

    pipeline-upgrade -b <old bin dir> -d <old data dir> -B <new bin dir> -D <new data dir>