### PR TITLE
Fixes #1473: Fix possible deadlocks between combiner and DROP CONTINU…

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -827,6 +827,14 @@ ExecOpenScanRelation(EState *estate, Index scanrelid, int eflags)
 	if ((eflags & EXEC_NO_STREAM_LOCKING) && is_stream_relid(reloid))
 		lockmode = NoLock;
 
+	/*
+	 * Similarly to the above, combiners manage matrel locks themselves and
+	 * so the relation is already locked. Acquiring an extraneous lock here
+	 * can then ultimately cause deadlocks when CVs are being dropped.
+	 */
+	if ((eflags & EXEC_NO_MATREL_LOCKING))
+		lockmode = NoLock;
+
 	rel = heap_open(reloid, lockmode);
 
 	/*

--- a/src/backend/pipeline/cont_execute.c
+++ b/src/backend/pipeline/cont_execute.c
@@ -226,6 +226,7 @@ get_query_state(ContExecutor *exec)
 			MemoryContextDelete(state->state_cxt);
 			exec->states[exec->curr_query_id] = NULL;
 			state = NULL;
+			commit = true;
 		}
 		else
 		{

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -67,7 +67,8 @@
 #define EXEC_FLAG_WITHOUT_OIDS	0x0040	/* force no OIDs in returned tuples */
 #define EXEC_FLAG_WITH_NO_DATA	0x0080	/* rel scannability doesn't matter */
 #define EXEC_FLAG_COMBINE 		0x0100	/* executing a combine query */
-#define EXEC_NO_STREAM_LOCKING 0x0200		/* worker don't need to lock streams */
+#define EXEC_NO_STREAM_LOCKING 0x0200		/* workers don't need to lock streams */
+#define EXEC_NO_MATREL_LOCKING 0x0400		/* combiners manage matrel locks */
 
 
 /*


### PR DESCRIPTION
There were several things going on here that made it possible for drop/combiner deadlocks. Basically we were just acquiring too many locks and not releasing them aggressively enough:

* In some places we were closing relations with `heap_close(rel, NoLock)` which is problematic when multiple syncs happen in the same transaction
* `select_existing_groups` already has a read lock on the matrel, but the `SELECT` query that runs also acquired a read lock. This one wasn't released until commit, so now we just have a  `EXEC_NO_MATREL_LOCKING` flag that is analagous to `EXEC_NO_STREAM_LOCKING` to prevent multiple locks from being acquired.
* The order in which we acquired osrel and matrel locks was incongruent with the order in which they're ultimately dropped.