### PR TITLE
1662 ttl

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -35,9 +35,9 @@
 #include "catalog/pg_namespace.h"
 #include "commands/cluster.h"
 #include "commands/vacuum.h"
+#include "pipeline/ttl_vacuum.h"
 #include "miscadmin.h"
 #include "pgstat.h"
-#include "pipeline/sw_vacuum.h"
 #include "postmaster/autovacuum.h"
 #include "storage/bufmgr.h"
 #include "storage/lmgr.h"
@@ -1180,8 +1180,8 @@ vacuum_rel(Oid relid, RangeVar *relation, int options, VacuumParams *params)
 
 	Assert(params != NULL);
 
-	/* If this is a matrel for a SW continuous view, delete all expired tuples */
-	DeleteSWExpiredTuples(relid);
+	/* If this is a matrel for a continuous view with a TTL, delete all expired tuples */
+	DeleteTTLExpiredTuples(relid);
 
 	/* Begin a transaction for vacuuming this relation */
 	StartTransactionCommand();

--- a/src/backend/pipeline/Makefile
+++ b/src/backend/pipeline/Makefile
@@ -15,7 +15,7 @@ top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
 OBJS = combinerReceiver.o cont_plan.o update.o stream.o \
-			 cqmatrel.o sw_vacuum.o tdigest.o miscutils.o bloom.o hll.o cmsketch.o \
+			 cqmatrel.o ttl_vacuum.o tdigest.o miscutils.o bloom.o hll.o cmsketch.o \
 			 cont_analyze.o cont_scheduler.o cont_worker.o cont_combiner.o \
 			 fss.o stream_fdw.o cont_execute.o transformReceiver.o
 

--- a/src/backend/pipeline/cont_combiner.c
+++ b/src/backend/pipeline/cont_combiner.c
@@ -10,6 +10,7 @@
  *-------------------------------------------------------------------------
  */
 
+#include "../../include/pipeline/ttl_vacuum.h"
 #include "postgres.h"
 
 #include "access/htup_details.h"
@@ -42,7 +43,6 @@
 #include "pipeline/miscutils.h"
 #include "pipeline/stream.h"
 #include "pipeline/stream_fdw.h"
-#include "pipeline/sw_vacuum.h"
 #include "storage/ipc.h"
 #include "tcop/dest.h"
 #include "tcop/pquery.h"

--- a/src/backend/pipeline/ttl_vacuum.c
+++ b/src/backend/pipeline/ttl_vacuum.c
@@ -1,16 +1,17 @@
 /*-------------------------------------------------------------------------
  *
- * sw_vacuum.c
+ * ttl_vacuum.c
  *
- *   Support for vacuuming discarded tuples for sliding window
- *   continuous views.
+ *   Support for vacuuming discarded tuples for continuous views with TTLs.
  *
- * Copyright (c) 2013-2015, PipelineDB
+ * Copyright (c) 2013-2016, PipelineDB
  *
- * src/backend/pipeline/sw_vacuum.c
+ * src/backend/pipeline/ttl_vacuum.c
  *
  *-------------------------------------------------------------------------
  */
+#include "pipeline/ttl_vacuum.h"
+
 #include "postgres.h"
 #include "access/htup_details.h"
 #include "access/xact.h"
@@ -25,7 +26,6 @@
 #include "parser/parse_expr.h"
 #include "pipeline/cont_analyze.h"
 #include "pipeline/cqmatrel.h"
-#include "pipeline/sw_vacuum.h"
 #include "storage/lmgr.h"
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"
@@ -43,12 +43,17 @@ get_sw_vacuum_expr(RangeVar *rv)
 	return (Node *) make_notclause((Expr *) expr);
 }
 
+static Node *
+get_ttl_vacuum_expr(RangeVar *rv)
+{
+	return GetTTLExpiredExpr(rv);
+}
 
 /*
- * DeleteSWExpiredTuples
+ * DeleteTTLExpiredTuples
  */
 void
-DeleteSWExpiredTuples(Oid relid)
+DeleteTTLExpiredTuples(Oid relid)
 {
 	char *relname;
 	char *namespace;
@@ -89,25 +94,30 @@ DeleteSWExpiredTuples(Oid relid)
 	if (!cvname)
 		goto end;
 
-	if (!IsSWContView(cvname))
+	if (!IsTTLContView(cvname))
 		goto end;
 
-	/* Now we're certain relid is for a SW continuous view's matrel */
+	/* Now we're certain relid is for a TTL continuous view's matrel */
 
 	/*
 	 * TODO(usmanm): Use lock contention free strategy here. See https://news.ycombinator.com/item?id=9018129
 	 */
 	stmt = makeNode(DeleteStmt);
 	stmt->relation = matrel;
-	stmt->whereClause = get_sw_vacuum_expr(cvname);
 
+	if (IsSWContView(cvname))
+		stmt->whereClause = get_sw_vacuum_expr(cvname);
+	else
+		stmt->whereClause = get_ttl_vacuum_expr(cvname);
+
+	Assert(stmt->whereClause);
 	PushActiveSnapshot(GetTransactionSnapshot());
 
 	querytree_list = pg_analyze_and_rewrite((Node *) stmt, "DELETE",
 			NULL, 0);
 	plan = pg_plan_query((Query *) linitial(querytree_list), 0, NULL);
 
-	portal = CreatePortal("__sw_delete_expired__", true, true);
+	portal = CreatePortal("__delete_expired__", true, true);
 	portal->visible = false;
 	PortalDefineQuery(portal,
 			NULL,
@@ -141,10 +151,10 @@ end:
 }
 
 /*
- * NumSWVacuumTuples
+ * NumTTLExpiredTuples
  */
 uint64_t
-NumSWExpiredTuples(Oid relid)
+NumTTLExpiredTuples(Oid relid)
 {
 	uint64_t count;
 	char *relname = get_rel_name(relid);
@@ -181,7 +191,7 @@ NumSWExpiredTuples(Oid relid)
 	if (!cvname)
 		return 0;
 
-	if (!IsSWContView(cvname))
+	if (!IsTTLContView(cvname))
 		return 0;
 
 	runctx = AllocSetContextCreate(CurrentMemoryContext,
@@ -200,15 +210,20 @@ NumSWExpiredTuples(Oid relid)
 	resetStringInfo(&sql);
 
 	stmt = (SelectStmt *) linitial(parsetree_list);
-	stmt->whereClause = get_sw_vacuum_expr(cvname);
 
+	if (IsSWContView(cvname))
+		stmt->whereClause = get_sw_vacuum_expr(cvname);
+	else
+		stmt->whereClause = get_ttl_vacuum_expr(cvname);
+
+	Assert(stmt->whereClause);
 	PushActiveSnapshot(GetTransactionSnapshot());
 
 	querytree_list = pg_analyze_and_rewrite((Node *) stmt, sql.data,
 			NULL, 0);
 	plan = pg_plan_query((Query *) linitial(querytree_list), 0, NULL);
 
-	portal = CreatePortal("__sw_num_expired__", true, true);
+	portal = CreatePortal("__num_expired__", true, true);
 	portal->visible = false;
 	PortalDefineQuery(portal,
 			NULL,

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -82,7 +82,7 @@
 #include "miscadmin.h"
 #include "nodes/print.h"
 #include "pgstat.h"
-#include "pipeline/sw_vacuum.h"
+#include "pipeline/ttl_vacuum.h"
 #include "postmaster/autovacuum.h"
 #include "postmaster/fork_process.h"
 #include "postmaster/postmaster.h"
@@ -2764,7 +2764,7 @@ relation_needs_vacanalyze(Oid relid,
 		/*
 		 * All expired tuples in a SW continuous view should be considered as *dead*.
 		 */
-		uint64_t swvactuples = NumSWExpiredTuples(relid);
+		uint64_t swvactuples = NumTTLExpiredTuples(relid);
 		reltuples = classForm->reltuples;
 		vactuples = tabentry->n_dead_tuples + swvactuples;
 		anltuples = tabentry->changes_since_analyze + swvactuples;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1415,11 +1415,11 @@ ProcessUtilitySlow(Node *parsetree,
 			case T_ViewStmt:	/* CREATE VIEW */
 				{
 					ViewStmt *vstmt = (ViewStmt *) parsetree;
-					DefElem *max_age = GetContinuousViewOption(vstmt->options, OPTION_MAX_AGE);
-					if (max_age)
+					DefElem *sw = GetContinuousViewOption(vstmt->options, OPTION_SLIDING_WINDOW);
+					if (sw)
 					{
-						ApplyMaxAge((SelectStmt *) vstmt->query, max_age);
-						vstmt->options = list_delete(vstmt->options, max_age);
+						ApplySlidingWindow((SelectStmt *) vstmt->query, sw);
+						vstmt->options = list_delete(vstmt->options, sw);
 					}
 
 					EventTriggerAlterTableStart(parsetree);

--- a/src/include/catalog/pipeline_query.h
+++ b/src/include/catalog/pipeline_query.h
@@ -40,9 +40,11 @@ CATALOG(pipeline_query,4242)
 	Oid  	    seqrelid;
 	Oid  	    pkidxid;
 	Oid 	    lookupidxid;
-	Oid			sw_attno;
+	int16			sw_attno;
 	bool 		adhoc;
 	int16 		step_factor;
+	int32				ttl;
+	int16			ttl_attno;
 
 	/* valid for transforms only */
 	Oid			tgfn;
@@ -65,7 +67,7 @@ typedef FormData_pipeline_query *Form_pipeline_query;
  *		compiler constants for pipeline_query
  * ----------------
  */
-#define Natts_pipeline_query             16
+#define Natts_pipeline_query             18
 #define Anum_pipeline_query_id           1
 #define Anum_pipeline_query_type         2
 #define Anum_pipeline_query_relid	     3
@@ -78,10 +80,12 @@ typedef FormData_pipeline_query *Form_pipeline_query;
 #define Anum_pipeline_query_sw_attno      10
 #define Anum_pipeline_query_adhoc        11
 #define Anum_pipeline_query_step_factor  12
-#define Anum_pipeline_query_tgfn         13
-#define Anum_pipeline_query_tgnargs	     14
-#define Anum_pipeline_query_tgargs       15
-#define Anum_pipeline_query_query        16
+#define Anum_pipeline_query_ttl  					13
+#define Anum_pipeline_query_ttl_attno  		14
+#define Anum_pipeline_query_tgfn         15
+#define Anum_pipeline_query_tgnargs	     16
+#define Anum_pipeline_query_tgargs       17
+#define Anum_pipeline_query_query        18
 
 #define PIPELINE_QUERY_VIEW 		'v'
 #define PIPELINE_QUERY_TRANSFORM 	't'

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -60,7 +60,8 @@ typedef struct ContQuery
 extern HeapTuple GetPipelineQueryTuple(RangeVar *name);
 extern void RemovePipelineQueryById(Oid oid);
 
-extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid seqrel, int sw_attno, bool adhoc, Oid *pq_id);
+extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid seqrel,
+		int ttl, AttrNumber ttl_attno, AttrNumber sw_attno, bool adhoc, Oid *pq_id);
 extern void UpdateContViewRelIds(Oid cvid, Oid cvrelid, Oid osrelid);
 extern void UpdateContViewIndexIds(Oid cvid, Oid pkindid, Oid lookupindid);
 extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, Oid fnoid, bool adhoc, List *args);
@@ -71,6 +72,7 @@ extern RangeVar *GetSWContinuousViewRangeVar(List *nodes);
 extern bool IsAMatRel(RangeVar *name, RangeVar **cvname);
 extern bool RelIdIsForMatRel(Oid relid, Oid *id);
 extern bool IsSWContView(RangeVar *name);
+extern bool IsTTLContView(RangeVar *name);
 extern RangeVar *GetMatRelName(RangeVar *cv);
 extern RangeVar *GetCVNameFromMatRelName(RangeVar *matrel);
 

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -44,7 +44,7 @@ typedef struct ContAnalyzeContext
 #define MATREL_FINALIZE "finalize"
 
 #define OPTION_FILLFACTOR "fillfactor"
-#define OPTION_MAX_AGE "max_age"
+#define OPTION_SLIDING_WINDOW "sw"
 #define OPTION_PK "pk"
 #define OPTION_STEP_FACTOR "step_factor"
 #define OPTION_TTL "ttl"
@@ -94,7 +94,7 @@ extern ColumnRef *GetWindowTimeColumn(RangeVar *cv);
 extern Node *CreateOuterSWTimeColumnRef(ParseState *pstate, ColumnRef *cref, Node *var);
 
 extern DefElem *GetContinuousViewOption(List *options, char *name);
-extern void ApplyMaxAge(SelectStmt *stmt, DefElem *max_age);
+extern void ApplySlidingWindow(SelectStmt *stmt, DefElem *max_age);
 extern void ApplyStorageOptions(CreateContViewStmt *stmt, bool *has_max_age);
 
 /* Deparsing */

--- a/src/include/pipeline/cont_analyze.h
+++ b/src/include/pipeline/cont_analyze.h
@@ -47,6 +47,9 @@ typedef struct ContAnalyzeContext
 #define OPTION_MAX_AGE "max_age"
 #define OPTION_PK "pk"
 #define OPTION_STEP_FACTOR "step_factor"
+#define OPTION_TTL "ttl"
+#define OPTION_TTL_COLUMN "ttl_column"
+
 
 #define SW_TIMESTAMP_REF 65100
 #define IS_SW_TIMESTAMP_REF(var) (IsA((var), Var) && ((Var *) (var))->varno >= SW_TIMESTAMP_REF)
@@ -82,7 +85,9 @@ extern Query *GetContWorkerQuery(RangeVar *rv);
 extern Query *GetContCombinerQuery(RangeVar *rv);
 
 extern AttrNumber FindSWTimeColumnAttrNo(SelectStmt *viewselect, Oid matrel);
+extern AttrNumber FindTTLColumnAttrNo(char *colname, Oid matrelid);
 extern Node *GetSWExpr(RangeVar *rv);
+extern Node *GetTTLExpiredExpr(RangeVar *cv);
 extern ColumnRef *GetSWTimeColumn(RangeVar *rv);
 extern Interval *GetSWInterval(RangeVar *rv);
 extern ColumnRef *GetWindowTimeColumn(RangeVar *cv);
@@ -90,7 +95,7 @@ extern Node *CreateOuterSWTimeColumnRef(ParseState *pstate, ColumnRef *cref, Nod
 
 extern DefElem *GetContinuousViewOption(List *options, char *name);
 extern void ApplyMaxAge(SelectStmt *stmt, DefElem *max_age);
-extern void ApplyStorageOptions(CreateContViewStmt *stmt);
+extern void ApplyStorageOptions(CreateContViewStmt *stmt, bool *has_max_age);
 
 /* Deparsing */
 extern char *deparse_query_def(Query *query);

--- a/src/include/pipeline/ttl_vacuum.h
+++ b/src/include/pipeline/ttl_vacuum.h
@@ -2,17 +2,16 @@
  *
  * sw_vacuum.h
  *
- *   Support for vacuuming discarded tuples for sliding window
- *   continuous views.
+ *   Support for vacuuming discarded tuples for continuous views with TTLs.
  *
- * Copyright (c) 2013-2015, PipelineDB
+ * Copyright (c) 2013-2016, PipelineDB
  *
  * src/include/pipeline/sw_vacuum.h
  *
  *-------------------------------------------------------------------------
  */
-#ifndef SW_VACUUM_H
-#define SW_VACUUM_H
+#ifndef TTL_VACUUM_H
+#define TTL_VACUUM_H
 
 #include "postgres.h"
 #include "catalog/pg_class.h"
@@ -20,7 +19,7 @@
 #include "pgstat.h"
 #include "utils/relcache.h"
 
-extern uint64_t NumSWExpiredTuples(Oid relid);
-extern void DeleteSWExpiredTuples(Oid relid);
+extern uint64_t NumTTLExpiredTuples(Oid relid);
+extern void DeleteTTLExpiredTuples(Oid relid);
 
-#endif /* SW_VACUUM_H */
+#endif /* TTL_VACUUM_H */

--- a/src/test/py/test_dump_restore.py
+++ b/src/test/py/test_dump_restore.py
@@ -68,7 +68,7 @@ def test_sliding_windows(pipeline, clean_db):
   Verify that sliding window queries are properly dumped and restored
   """
   pipeline.create_stream('stream', x='int')
-  pipeline.execute('CREATE CONTINUOUS VIEW sw_v WITH (max_age = \'20 seconds\') AS SELECT count(*) FROM stream')
+  pipeline.execute('CREATE CONTINUOUS VIEW sw_v WITH (sw = \'20 seconds\') AS SELECT count(*) FROM stream')
   pipeline.insert('stream', ('x',), [(x,) for x in range(10)])
 
   result = pipeline.execute('SELECT count FROM sw_v').first()

--- a/src/test/py/test_output_streams.py
+++ b/src/test/py/test_output_streams.py
@@ -63,7 +63,7 @@ def test_concurrent_sw_ticking(pipeline, clean_db):
   output_names = []
   for n in range(10):
     name = 'sw%d' % n
-    pipeline.create_cv(name, 'SELECT x::integer, count(*) FROM stream GROUP BY x', max_age='%d seconds' % (n + 10))
+    pipeline.create_cv(name, 'SELECT x::integer, count(*) FROM stream GROUP BY x', sw='%d seconds' % (n + 10))
     output_name = name + '_output'
 
     q = """
@@ -100,7 +100,7 @@ def test_transforms(pipeline, clean_db):
   """
   pipeline.create_stream('stream', x='int')
   pipeline.create_cv('sw', 'SELECT x::integer, COUNT(*) FROM stream GROUP BY x',
-                     max_age='5 seconds')
+                     sw='5 seconds')
 
   # Write a row to a stream each time a row goes out of window
   q = 'SELECT (old).x FROM sw_osrel WHERE old IS NOT NULL AND new IS NULL'

--- a/src/test/regress/expected/cont_grouping_sets.out
+++ b/src/test/regress/expected/cont_grouping_sets.out
@@ -95,7 +95,7 @@ SELECT pipeline_get_overlay_viewdef('test_gs2');
     FROM ONLY test_gs2_mrel;
 (1 row)
 
-CREATE CONTINUOUS VIEW test_gs3 WITH (max_age = '5 seconds') AS SELECT x::integer, y::integer, z::integer, COUNT(*) FROM test_gs_stream
+CREATE CONTINUOUS VIEW test_gs3 WITH (sw = '5 seconds') AS SELECT x::integer, y::integer, z::integer, COUNT(*) FROM test_gs_stream
 	GROUP BY GROUPING SETS (x, y, z);
 SELECT pipeline_get_worker_querydef('test_gs3');
                                   pipeline_get_worker_querydef                                  

--- a/src/test/regress/expected/cont_index.out
+++ b/src/test/regress/expected/cont_index.out
@@ -49,7 +49,7 @@ Indexes:
 Options: fillfactor=50
 
 DROP CONTINUOUS VIEW test_cont_index0;
-CREATE CONTINUOUS VIEW test_cont_index1 WITH (max_age = '1 hour') AS SELECT x::integer, y::integer, COUNT(*), AVG(x) FROM cont_idx_stream GROUP BY x, y;
+CREATE CONTINUOUS VIEW test_cont_index1 WITH (sw = '1 hour') AS SELECT x::integer, y::integer, COUNT(*), AVG(x) FROM cont_idx_stream GROUP BY x, y;
 CREATE INDEX test_ci_idx0 ON test_cont_index1 (x);
 \d+ test_cont_index1_mrel
                                Table "public.test_cont_index1_mrel"

--- a/src/test/regress/expected/cont_multiple_sw.out
+++ b/src/test/regress/expected/cont_multiple_sw.out
@@ -13,8 +13,8 @@ CREATE CONTINUOUS VIEW msw0 AS SELECT x::integer, COUNT(*), avg(x) FROM msw_stre
 WHERE arrival_timestamp > clock_timestamp() - interval '10 second' GROUP BY x;
 CREATE VIEW msw1 AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0
 WHERE arrival_timestamp > clock_timestamp() - interval '2 seconds';
--- Verify that we can use max_age on views that read from SW CVs
-CREATE VIEW msw1_ma WITH (max_age = '2 seconds') AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0;
+-- Verify that we can use sw on views that read from SW CVs
+CREATE VIEW msw1_ma WITH (sw = '2 seconds') AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0;
 \d+ msw1_ma;
                 View "public.msw1_ma"
  Column |  Type   | Modifiers | Storage | Description 
@@ -486,7 +486,7 @@ View definition:
    FROM ONLY msw_stream
   WHERE arrival_timestamp > (clock_timestamp() - '00:10:00'::interval);
 
-CREATE VIEW msw6 WITH (max_age = '1 minute') AS SELECT * FROM msw5;
+CREATE VIEW msw6 WITH (sw = '1 minute') AS SELECT * FROM msw5;
 \d+ msw6
                            View "public.msw6"
  Column  |           Type           | Modifiers | Storage | Description 
@@ -522,13 +522,13 @@ DROP CONTINUOUS VIEW msw5 CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to view msw6
 drop cascades to view msw7
--- max_age of view vs step_size
-CREATE CONTINUOUS VIEW msw8 WITH (max_age='10 minute', step_factor='10') AS SELECT count(*) FROM msw_stream;
-CREATE VIEW msw9 WITH (max_age='5 minute') AS SELECT * FROM msw8;
-CREATE VIEW msw10 WITH (max_age='2 minute') AS SELECT * FROM msw8;
-CREATE VIEW msw11 WITH (max_age='1 minute') AS SELECT * FROM msw8;
-ERROR:  "max_age" value is too small
-HINT:  "max_age" must be at least twice as much as the step size of the base continuous view.
+-- sw of view vs step_size
+CREATE CONTINUOUS VIEW msw8 WITH (sw='10 minute', step_factor='10') AS SELECT count(*) FROM msw_stream;
+CREATE VIEW msw9 WITH (sw='5 minute') AS SELECT * FROM msw8;
+CREATE VIEW msw10 WITH (sw='2 minute') AS SELECT * FROM msw8;
+CREATE VIEW msw11 WITH (sw='1 minute') AS SELECT * FROM msw8;
+ERROR:  "sw" value is too small
+HINT:  "sw" must be at least twice as much as the step size of the base continuous view.
 DROP CONTINUOUS VIEW msw8 CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to view msw9

--- a/src/test/regress/expected/create_cont_view.out
+++ b/src/test/regress/expected/create_cont_view.out
@@ -881,8 +881,8 @@ CREATE CONTINUOUS VIEW arrts AS SELECT x AS arrival_timestamp FROM create_cont_s
 ERROR:  arrival_timestamp is a reserved column name
 CREATE CONTINUOUS VIEW arrts AS SELECT arrival_timestamp AS arrival_timestamp FROM create_cont_stream;
 DROP CONTINUOUS VIEW arrts;
--- WITH max_age
-CREATE CONTINUOUS VIEW ma0 WITH (max_age = '1 day') AS SELECT COUNT(*) FROM create_cont_stream;
+-- WITH sw
+CREATE CONTINUOUS VIEW ma0 WITH (sw = '1 day') AS SELECT COUNT(*) FROM create_cont_stream;
 \d+ ma0;
             Continuous view "public.ma0"
  Column |  Type  | Modifiers | Storage | Description 
@@ -893,7 +893,7 @@ View definition:
    FROM ONLY create_cont_stream
   WHERE arrival_timestamp > (clock_timestamp() - '1 day'::interval);
 
-CREATE VIEW ma1 WITH (max_age = '10 hours') AS SELECT COUNT(*) FROM ma0;
+CREATE VIEW ma1 WITH (sw = '10 hours') AS SELECT COUNT(*) FROM ma0;
 \d+ ma1;
                   View "public.ma1"
  Column |  Type  | Modifiers | Storage | Description 
@@ -904,18 +904,18 @@ View definition:
    FROM ma0
   WHERE arrival_timestamp > (clock_timestamp() - '10:00:00'::interval);
 
--- max_age must be a valid interval string
-CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42) AS SELECT COUNT(*) FROM create_cont_stream;
-ERROR:  "max_age" must be a valid interval string
-HINT:  For example, ... WITH (max_age = '1 hour') ...
-CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42.1) AS SELECT COUNT(*) FROM create_cont_stream;
-ERROR:  "max_age" must be a valid interval string
-HINT:  For example, ... WITH (max_age = '1 hour') ...
-CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT COUNT(*) FROM create_cont_stream;
+-- sw must be a valid interval string
+CREATE CONTINUOUS VIEW mainvalid WITH (sw = 42) AS SELECT COUNT(*) FROM create_cont_stream;
+ERROR:  "sw" must be a valid interval string
+HINT:  For example, ... WITH (sw = '1 hour') ...
+CREATE CONTINUOUS VIEW mainvalid WITH (sw = 42.1) AS SELECT COUNT(*) FROM create_cont_stream;
+ERROR:  "sw" must be a valid interval string
+HINT:  For example, ... WITH (sw = '1 hour') ...
+CREATE CONTINUOUS VIEW mainvalid WITH (sw = 'not an interval') AS SELECT COUNT(*) FROM create_cont_stream;
 ERROR:  invalid input syntax for type interval: "not an interval"
-LINE 1: CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an int...
+LINE 1: CREATE CONTINUOUS VIEW mainvalid WITH (sw = 'not an interval...
         ^
-CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
+CREATE CONTINUOUS VIEW mawhere WITH (sw = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
 WHERE x::integer = 1;
 \d+ mawhere;
           Continuous view "public.mawhere"
@@ -928,13 +928,13 @@ View definition:
   WHERE arrival_timestamp > (clock_timestamp() - '1 day'::interval) AND x = 1;
 
 DROP CONTINUOUS VIEW mawhere;
--- max_age can't be used on non-sliding window continuous views
-CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
-ERROR:  "max_age" can only be specified when reading from a stream or continuous view
+-- sw can't be used on non-sliding window continuous views
+CREATE VIEW manosw WITH (sw = '1 day') AS SELECT COUNT(*) FROM withff;
+ERROR:  "sw" can only be specified when reading from a stream or continuous view
 -- or in conjunction with another sliding-window predicate
-CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
+CREATE VIEW manosw WITH (sw = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
 WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
-ERROR:  cannot specify both "max_age" and a sliding window expression in the WHERE clause
+ERROR:  cannot specify both "sw" and a sliding window expression in the WHERE clause
 DROP STREAM create_cont_stream CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to continuous view withff

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -127,7 +127,7 @@ SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 DROP CONTINUOUS VIEW os1 CASCADE;
 NOTICE:  drop cascades to continuous view os1_output
 -- Verify SW ticking into output streams
-CREATE CONTINUOUS VIEW os2 WITH (max_age = '10 seconds') AS
+CREATE CONTINUOUS VIEW os2 WITH (sw = '10 seconds') AS
 SELECT x::integer, COUNT(*)
 FROM os_stream GROUP BY x;
 CREATE CONTINUOUS VIEW os2_output AS SELECT

--- a/src/test/regress/expected/ttl_vacuum.out
+++ b/src/test/regress/expected/ttl_vacuum.out
@@ -28,11 +28,12 @@ CREATE CONTINUOUS VIEW ttl0 WITH (ttl='3 seconds', ttl_column='ts')
 CREATE CONTINUOUS VIEW ttl1 WITH (ttl='1 month', ttl_column='ts')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
 SELECT ttl, ttl_attno FROM pipeline_query pq
-JOIN pg_class c ON c.oid = pq.relid WHERE c.relname = 'ttl0';
- ttl | ttl_attno 
------+-----------
-   3 |         1
-(1 row)
+JOIN pg_class c ON c.oid = pq.relid WHERE c.relname IN ('ttl0', 'ttl1');
+   ttl   | ttl_attno 
+---------+-----------
+       3 |         1
+ 2592000 |         1
+(2 rows)
 
 INSERT INTO ttl_stream (x) VALUES (0);
 INSERT INTO ttl_stream (x) VALUES (1);

--- a/src/test/regress/expected/ttl_vacuum.out
+++ b/src/test/regress/expected/ttl_vacuum.out
@@ -19,6 +19,10 @@ ERROR:  ttl_column must be expressed as a column name
 CREATE CONTINUOUS VIEW ttl0 WITH (ttl=10000, ttl_column='ts')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
 ERROR:  ttl must be expressed as an interval
+-- TTL column isn't a timestamp or timestamptz
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='x')
+	AS SELECT x FROM ttl_stream;
+ERROR:  ttl_column must refer to a timestamp or timestamptz column
 -- Can't specify TTLs with SWs
 CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', max_age='2 days')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;

--- a/src/test/regress/expected/ttl_vacuum.out
+++ b/src/test/regress/expected/ttl_vacuum.out
@@ -24,7 +24,7 @@ CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='x')
 	AS SELECT x FROM ttl_stream;
 ERROR:  ttl_column must refer to a timestamp or timestamptz column
 -- Can't specify TTLs with SWs
-CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', max_age='2 days')
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', sw='2 days')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
 ERROR:  TTLs cannot be specified in conjunction with sliding windows
 CREATE CONTINUOUS VIEW ttl0 WITH (ttl='3 seconds', ttl_column='ts')

--- a/src/test/regress/expected/ttl_vacuum.out
+++ b/src/test/regress/expected/ttl_vacuum.out
@@ -1,0 +1,96 @@
+-- Test errors/invalid inputs
+CREATE STREAM ttl_stream (x integer);
+-- Invalid interval
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='not an interval', ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+ERROR:  invalid input syntax for type interval: "not an interval"
+-- No ttl_column
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='4 days')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+ERROR:  ttl_column must be specified in conjunction with ttl
+-- No ttl
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+ERROR:  ttl must be specified in conjunction with ttl_column
+-- Wrong types
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column=1)
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+ERROR:  ttl_column must be expressed as a column name
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl=10000, ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+ERROR:  ttl must be expressed as an interval
+-- Can't specify TTLs with SWs
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', max_age='2 days')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+ERROR:  TTLs cannot be specified in conjunction with sliding windows
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='3 seconds', ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+CREATE CONTINUOUS VIEW ttl1 WITH (ttl='1 month', ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+SELECT ttl, ttl_attno FROM pipeline_query pq
+JOIN pg_class c ON c.oid = pq.relid WHERE c.relname = 'ttl0';
+ ttl | ttl_attno 
+-----+-----------
+   3 |         1
+(1 row)
+
+INSERT INTO ttl_stream (x) VALUES (0);
+INSERT INTO ttl_stream (x) VALUES (1);
+INSERT INTO ttl_stream (x) VALUES (2);
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+ x | $pk 
+---+-----
+ 0 |   1
+ 1 |   2
+ 2 |   3
+(3 rows)
+
+SELECT pg_sleep(3);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+VACUUM ttl0;
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+ x | $pk 
+---+-----
+(0 rows)
+
+INSERT INTO ttl_stream (x) VALUES (0);
+INSERT INTO ttl_stream (x) VALUES (1);
+INSERT INTO ttl_stream (x) VALUES (2);
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+ x | $pk 
+---+-----
+ 0 |   4
+ 1 |   5
+ 2 |   6
+(3 rows)
+
+SELECT pg_sleep(3);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+VACUUM FULL ttl0;
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+ x | $pk 
+---+-----
+(0 rows)
+
+SELECT x, "$pk" FROM ttl1_mrel ORDER BY ts;
+ x | $pk 
+---+-----
+ 0 |   1
+ 1 |   2
+ 2 |   3
+ 0 |   4
+ 1 |   5
+ 2 |   6
+(6 rows)
+
+DROP CONTINUOUS VIEW ttl0;
+DROP CONTINUOUS VIEW ttl1;
+DROP STREAM ttl_stream;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -119,7 +119,7 @@ test: pipeline_stream
 # ----------
 # Another group of parallel tests
 # ----------
-test: sw_vacuum
+test: sw_vacuum ttl_vacuum
 
 # ----------
 # Another group of parallel tests

--- a/src/test/regress/sql/cont_grouping_sets.sql
+++ b/src/test/regress/sql/cont_grouping_sets.sql
@@ -21,7 +21,7 @@ SELECT pipeline_get_worker_querydef('test_gs2');
 SELECT pipeline_get_combiner_querydef('test_gs2');
 SELECT pipeline_get_overlay_viewdef('test_gs2');
 
-CREATE CONTINUOUS VIEW test_gs3 WITH (max_age = '5 seconds') AS SELECT x::integer, y::integer, z::integer, COUNT(*) FROM test_gs_stream
+CREATE CONTINUOUS VIEW test_gs3 WITH (sw = '5 seconds') AS SELECT x::integer, y::integer, z::integer, COUNT(*) FROM test_gs_stream
 	GROUP BY GROUPING SETS (x, y, z);
 
 SELECT pipeline_get_worker_querydef('test_gs3');

--- a/src/test/regress/sql/cont_index.sql
+++ b/src/test/regress/sql/cont_index.sql
@@ -13,7 +13,7 @@ CREATE INDEX test_ci_idx2 ON test_cont_index0 (x, avg);
 
 DROP CONTINUOUS VIEW test_cont_index0;
 
-CREATE CONTINUOUS VIEW test_cont_index1 WITH (max_age = '1 hour') AS SELECT x::integer, y::integer, COUNT(*), AVG(x) FROM cont_idx_stream GROUP BY x, y;
+CREATE CONTINUOUS VIEW test_cont_index1 WITH (sw = '1 hour') AS SELECT x::integer, y::integer, COUNT(*), AVG(x) FROM cont_idx_stream GROUP BY x, y;
 
 CREATE INDEX test_ci_idx0 ON test_cont_index1 (x);
 \d+ test_cont_index1_mrel

--- a/src/test/regress/sql/cont_multiple_sw.sql
+++ b/src/test/regress/sql/cont_multiple_sw.sql
@@ -17,8 +17,8 @@ WHERE arrival_timestamp > clock_timestamp() - interval '10 second' GROUP BY x;
 CREATE VIEW msw1 AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0
 WHERE arrival_timestamp > clock_timestamp() - interval '2 seconds';
 
--- Verify that we can use max_age on views that read from SW CVs
-CREATE VIEW msw1_ma WITH (max_age = '2 seconds') AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0;
+-- Verify that we can use sw on views that read from SW CVs
+CREATE VIEW msw1_ma WITH (sw = '2 seconds') AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0;
 \d+ msw1_ma;
 
 CREATE VIEW msw2 AS SELECT combine(count) AS count, combine(avg) AS avg FROM msw0
@@ -80,7 +80,7 @@ FROM msw_stream
 WHERE arrival_timestamp > clock_timestamp() - INTERVAL '10 minute';
 \d+ msw5
 
-CREATE VIEW msw6 WITH (max_age = '1 minute') AS SELECT * FROM msw5;
+CREATE VIEW msw6 WITH (sw = '1 minute') AS SELECT * FROM msw5;
 \d+ msw6
 SELECT * FROM msw6;
 
@@ -90,11 +90,11 @@ SELECT * FROM msw7;
 
 DROP CONTINUOUS VIEW msw5 CASCADE;
 
--- max_age of view vs step_size
-CREATE CONTINUOUS VIEW msw8 WITH (max_age='10 minute', step_factor='10') AS SELECT count(*) FROM msw_stream;
-CREATE VIEW msw9 WITH (max_age='5 minute') AS SELECT * FROM msw8;
-CREATE VIEW msw10 WITH (max_age='2 minute') AS SELECT * FROM msw8;
-CREATE VIEW msw11 WITH (max_age='1 minute') AS SELECT * FROM msw8;
+-- sw of view vs step_size
+CREATE CONTINUOUS VIEW msw8 WITH (sw='10 minute', step_factor='10') AS SELECT count(*) FROM msw_stream;
+CREATE VIEW msw9 WITH (sw='5 minute') AS SELECT * FROM msw8;
+CREATE VIEW msw10 WITH (sw='2 minute') AS SELECT * FROM msw8;
+CREATE VIEW msw11 WITH (sw='1 minute') AS SELECT * FROM msw8;
 
 DROP CONTINUOUS VIEW msw8 CASCADE;
 

--- a/src/test/regress/sql/create_cont_view.sql
+++ b/src/test/regress/sql/create_cont_view.sql
@@ -160,28 +160,28 @@ CREATE CONTINUOUS VIEW arrts AS SELECT x AS arrival_timestamp FROM create_cont_s
 CREATE CONTINUOUS VIEW arrts AS SELECT arrival_timestamp AS arrival_timestamp FROM create_cont_stream;
 DROP CONTINUOUS VIEW arrts;
 
--- WITH max_age
-CREATE CONTINUOUS VIEW ma0 WITH (max_age = '1 day') AS SELECT COUNT(*) FROM create_cont_stream;
+-- WITH sw
+CREATE CONTINUOUS VIEW ma0 WITH (sw = '1 day') AS SELECT COUNT(*) FROM create_cont_stream;
 \d+ ma0;
-CREATE VIEW ma1 WITH (max_age = '10 hours') AS SELECT COUNT(*) FROM ma0;
+CREATE VIEW ma1 WITH (sw = '10 hours') AS SELECT COUNT(*) FROM ma0;
 \d+ ma1;
 
--- max_age must be a valid interval string
-CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42) AS SELECT COUNT(*) FROM create_cont_stream;
-CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 42.1) AS SELECT COUNT(*) FROM create_cont_stream;
-CREATE CONTINUOUS VIEW mainvalid WITH (max_age = 'not an interval') AS SELECT COUNT(*) FROM create_cont_stream;
+-- sw must be a valid interval string
+CREATE CONTINUOUS VIEW mainvalid WITH (sw = 42) AS SELECT COUNT(*) FROM create_cont_stream;
+CREATE CONTINUOUS VIEW mainvalid WITH (sw = 42.1) AS SELECT COUNT(*) FROM create_cont_stream;
+CREATE CONTINUOUS VIEW mainvalid WITH (sw = 'not an interval') AS SELECT COUNT(*) FROM create_cont_stream;
 
-CREATE CONTINUOUS VIEW mawhere WITH (max_age = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
+CREATE CONTINUOUS VIEW mawhere WITH (sw = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
 WHERE x::integer = 1;
 \d+ mawhere;
 
 DROP CONTINUOUS VIEW mawhere;
 
--- max_age can't be used on non-sliding window continuous views
-CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM withff;
+-- sw can't be used on non-sliding window continuous views
+CREATE VIEW manosw WITH (sw = '1 day') AS SELECT COUNT(*) FROM withff;
 
 -- or in conjunction with another sliding-window predicate
-CREATE VIEW manosw WITH (max_age = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
+CREATE VIEW manosw WITH (sw = '1 day') AS SELECT COUNT(*) FROM create_cont_stream
 WHERE arrival_timestamp > clock_timestamp() - interval '1 day';
 
 DROP STREAM create_cont_stream CASCADE;

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -67,7 +67,7 @@ SELECT * FROM os1_output ORDER BY g, old_count, new_count, old_sum, new_sum;
 DROP CONTINUOUS VIEW os1 CASCADE;
 
 -- Verify SW ticking into output streams
-CREATE CONTINUOUS VIEW os2 WITH (max_age = '10 seconds') AS
+CREATE CONTINUOUS VIEW os2 WITH (sw = '10 seconds') AS
 SELECT x::integer, COUNT(*)
 FROM os_stream GROUP BY x;
 

--- a/src/test/regress/sql/ttl_vacuum.sql
+++ b/src/test/regress/sql/ttl_vacuum.sql
@@ -1,0 +1,61 @@
+-- Test errors/invalid inputs
+CREATE STREAM ttl_stream (x integer);
+
+-- Invalid interval
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='not an interval', ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+-- No ttl_column
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='4 days')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+-- No ttl
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+-- Wrong types
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column=1)
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl=10000, ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+-- Can't specify TTLs with SWs
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', max_age='2 days')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='3 seconds', ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+CREATE CONTINUOUS VIEW ttl1 WITH (ttl='1 month', ttl_column='ts')
+	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
+
+SELECT ttl, ttl_attno FROM pipeline_query pq
+JOIN pg_class c ON c.oid = pq.relid WHERE c.relname = 'ttl0';
+
+INSERT INTO ttl_stream (x) VALUES (0);
+INSERT INTO ttl_stream (x) VALUES (1);
+INSERT INTO ttl_stream (x) VALUES (2);
+
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+
+SELECT pg_sleep(3);
+VACUUM ttl0;
+
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+
+INSERT INTO ttl_stream (x) VALUES (0);
+INSERT INTO ttl_stream (x) VALUES (1);
+INSERT INTO ttl_stream (x) VALUES (2);
+
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+
+SELECT pg_sleep(3);
+VACUUM FULL ttl0;
+
+SELECT x, "$pk" FROM ttl0_mrel ORDER BY ts;
+SELECT x, "$pk" FROM ttl1_mrel ORDER BY ts;
+
+DROP CONTINUOUS VIEW ttl0;
+DROP CONTINUOUS VIEW ttl1;
+DROP STREAM ttl_stream;

--- a/src/test/regress/sql/ttl_vacuum.sql
+++ b/src/test/regress/sql/ttl_vacuum.sql
@@ -25,7 +25,7 @@ CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='x')
 	AS SELECT x FROM ttl_stream;
 
 -- Can't specify TTLs with SWs
-CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', max_age='2 days')
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', sw='2 days')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
 
 CREATE CONTINUOUS VIEW ttl0 WITH (ttl='3 seconds', ttl_column='ts')

--- a/src/test/regress/sql/ttl_vacuum.sql
+++ b/src/test/regress/sql/ttl_vacuum.sql
@@ -31,7 +31,7 @@ CREATE CONTINUOUS VIEW ttl1 WITH (ttl='1 month', ttl_column='ts')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
 
 SELECT ttl, ttl_attno FROM pipeline_query pq
-JOIN pg_class c ON c.oid = pq.relid WHERE c.relname = 'ttl0';
+JOIN pg_class c ON c.oid = pq.relid WHERE c.relname IN ('ttl0', 'ttl1');
 
 INSERT INTO ttl_stream (x) VALUES (0);
 INSERT INTO ttl_stream (x) VALUES (1);

--- a/src/test/regress/sql/ttl_vacuum.sql
+++ b/src/test/regress/sql/ttl_vacuum.sql
@@ -20,6 +20,10 @@ CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column=1)
 CREATE CONTINUOUS VIEW ttl0 WITH (ttl=10000, ttl_column='ts')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;
 
+-- TTL column isn't a timestamp or timestamptz
+CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='x')
+	AS SELECT x FROM ttl_stream;
+
 -- Can't specify TTLs with SWs
 CREATE CONTINUOUS VIEW ttl0 WITH (ttl='1 day', ttl_column='ts', max_age='2 days')
 	AS SELECT arrival_timestamp AS ts, x FROM ttl_stream;


### PR DESCRIPTION
Adds support for TTLs on non-SW CVs. How it works

* TTL and TTL column stored in `pipeline_query`
* Vacuuming logic made slightly more generic to pull TTL expression if there is one
* Otherwise uses exact same logic as previous SW vacuuming
* `max_age` renamed to `sw` for better distinction