### PR TITLE
Tweaks to CQ proc startup timing

### DIFF
--- a/src/backend/pipeline/cont_scheduler.c
+++ b/src/backend/pipeline/cont_scheduler.c
@@ -51,7 +51,7 @@
 #define NUM_BG_WORKERS_PER_DB (continuous_query_num_workers + continuous_query_num_combiners)
 #define NUM_LOCKS_PER_DB NUM_BG_WORKERS_PER_DB
 
-#define BG_PROC_STATUS_TIMEOUT 1000
+#define BG_PROC_STATUS_TIMEOUT 10000
 #define CQ_STATE_CHANGE_TIMEOUT 5000
 
 typedef struct DatabaseEntry

--- a/src/test/py/.gitignore
+++ b/src/test/py/.gitignore
@@ -5,3 +5,4 @@
 /analyze_new_cluster.sh
 /delete_old_cluster.sh
 test_binary_upgrade_data_dir/
+.cache

--- a/src/test/py/base.py
+++ b/src/test/py/base.py
@@ -132,7 +132,7 @@ class PipelineDB(object):
           raise Exception('Failed to connect to PipelineDB')
 
         # Wait for bgworkers to start
-        for i in xrange(10):
+        for i in xrange(30):
           try:
             out = subprocess.check_output('ps aux | grep "\[pipeline\]" | grep -e "worker[0-9]" -e "combiner[0-9]"',
                                           shell=True).split('\n')
@@ -148,7 +148,7 @@ class PipelineDB(object):
           if len(out) == (default_params['continuous_query_num_workers'] +
                           default_params['continuous_query_num_combiners']):
             break
-          time.sleep(0.5)
+          time.sleep(1)
         else:
           raise Exception('Background workers failed to start up')
 

--- a/src/test/py/test_cont_transform.py
+++ b/src/test/py/test_cont_transform.py
@@ -13,7 +13,7 @@ def test_multiple_insert(pipeline, clean_db):
   pipeline.create_cv('cv1', 'SELECT count(*) FROM stream2')
   pipeline.create_ct('ct1', 'SELECT x::int FROM stream WHERE mod(x, 2) = 0', "pipeline_stream_insert('stream1', 'stream2')")
 
-  pipeline.insert('stream', ('x', ), [(n, ) for n in range(1000)])
+  pipeline.insert('stream', ('x',), [(n,) for n in range(1000)])
 
   count = pipeline.execute('SELECT count FROM cv0').first()['count']
   assert count == 500
@@ -33,7 +33,7 @@ def test_nested_transforms(pipeline, clean_db):
   pipeline.create_ct('ct1', 'SELECT x::int FROM stream WHERE mod(x, 2) = 0',
                      "pipeline_stream_insert('stream2')")
 
-  pipeline.insert('stream', ('x', ), [(n, ) for n in range(1000)])
+  pipeline.insert('stream', ('x',), [(n,) for n in range(1000)])
 
   count = pipeline.execute('SELECT count FROM cv0').first()['count']
   assert count == 250


### PR DESCRIPTION
These started appearing after 310bce430db9a3a9e67e638c4e5b2a3c8319b9fa:

```
WARNING:  timed out waiting for continuous query process "worker0 [pipeline]" to reach state 0
WARNING:  timed out waiting for continuous query process "worker1 [pipeline]" to reach state 0
WARNING:  timed out waiting for continuous query process "combiner0 [pipeline]" to reach state 0
```

After doing some digging, it seems that the [additional adhoc vacuumer bgworker](https://github.com/pipelinedb/pipelinedb/blob/df02b66c2b35711b96fc5ca02866ec4d69e1670b/src/backend/pipeline/cont_scheduler.c#L594) changed proc startup timing just enough to cause these issues. They did not appear before this commit.


