### PR TITLE
Hll union

### DIFF
--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -1262,24 +1262,23 @@ HLLCardinality(HyperLogLog *hll)
 }
 
 static HyperLogLog *
-hll_dense_union(HyperLogLog *result, HyperLogLog *incoming)
+hll_dense_union(HyperLogLog *hllu, HyperLogLog *incoming)
 {
 	int reg;
-	int m = (1 << result->p);
+	int m = (1 << hllu->p);
 
-	Assert(HLL_IS_DENSE(result));
+	Assert(HLL_IS_UNION(hllu));
 
 	if (HLL_IS_DENSE(incoming))
 	{
 		/* easy, just take the max of each HLL's registers */
 		for (reg=0; reg<m; reg++)
 		{
-			uint8 r0;
-			uint8 r1;
+			uint8 v;
 
-			HLL_DENSE_GET_REGISTER(r0, result->M, reg);
-			HLL_DENSE_GET_REGISTER(r1, incoming->M, reg);
-			HLL_DENSE_SET_REGISTER(result->M, reg, Max(r0, r1));
+			HLL_DENSE_GET_REGISTER(v, incoming->M, reg);
+			if (v > hllu->M[reg])
+				hllu->M[reg] = v;
 		}
 	}
 	else if (HLL_IS_SPARSE(incoming))
@@ -1311,10 +1310,8 @@ hll_dense_union(HyperLogLog *result, HyperLogLog *incoming)
 				regval = HLL_SPARSE_VAL_VALUE(pos);
 				while (runlen--)
 				{
-					uint8 resval;
-
-					HLL_DENSE_GET_REGISTER(resval, result->M, reg);
-					HLL_DENSE_SET_REGISTER(result->M, reg, Max(resval, regval));
+					if (regval > hllu->M[reg])
+						hllu->M[reg] = regval;
 					reg++;
 				}
 				pos++;
@@ -1331,18 +1328,17 @@ hll_dense_union(HyperLogLog *result, HyperLogLog *incoming)
 		{
 			int reg = HLL_EXPLICIT_GET_REGISTER(pos);
 			uint8 r0 = HLL_EXPLICIT_GET_NUM_LEADING(pos);
-			uint8 r1;
 
-			HLL_DENSE_GET_REGISTER(r1, result->M, reg);
-			HLL_DENSE_SET_REGISTER(result->M, reg, Max(r0, r1));
+			if (r0 > hllu->M[reg])
+				hllu->M[reg] = r0;
 
 			pos += HLL_EXPLICIT_ENTRY_SIZE;
 		}
 	}
 
-	result->encoding = HLL_DENSE_DIRTY;
+	SET_VARSIZE(hllu, HLLSize(hllu));
 
-	return result;
+	return hllu;
 }
 
 static HyperLogLog *
@@ -1417,6 +1413,8 @@ hll_sparse_union(HyperLogLog *result, HyperLogLog *incoming)
 HyperLogLog *
 HLLUnion(HyperLogLog *result, HyperLogLog *incoming)
 {
+	HyperLogLog *hllu;
+
 	/* EXPLICIT + EXPLICIT */
 	if (HLL_IS_EXPLICIT(result) && HLL_IS_EXPLICIT(incoming))
 	{
@@ -1436,18 +1434,87 @@ HLLUnion(HyperLogLog *result, HyperLogLog *incoming)
 		return result;
 	}
 
+	hllu = HLLCreateUnion(result);
+
+	/* DENSE + (DENSE | SPARSE | EXPLICIT) */
+	hllu = HLLUnionAdd(hllu, incoming);
+	result = HLLGetUnionResult(hllu);
+
+	return result;
+}
+
+
+
+
+
+
+
+
+
+/*
+ * HLLCreateUnion
+ */
+HyperLogLog *
+HLLCreateUnion(HyperLogLog *initial)
+{
+	int reg;
+	int m = (1 << initial->p);
+	HyperLogLog *result = palloc0(sizeof(HyperLogLog) + m);
+
 	/*
 	 * We don't support any other unions for now, so just upgrade result
 	 * to the DENSE representation.
 	 */
-	if (HLL_IS_EXPLICIT(result))
-		result = hll_explicit_to_sparse(result);
-	if (HLL_IS_SPARSE(result))
-		result = hll_sparse_to_dense(result);
+	if (HLL_IS_EXPLICIT(initial))
+		initial = hll_explicit_to_sparse(initial);
+	if (HLL_IS_SPARSE(initial))
+		initial = hll_sparse_to_dense(initial);
 
-	/* DENSE + (DENSE | SPARSE | EXPLICIT) */
-	result = hll_dense_union(result, incoming);
+	result->encoding = HLL_UNION;
+	result->mlen = m;
+	result->p = initial->p;
+
+	for (reg = 0; reg < m; reg++)
+	{
+		uint8 v;
+		HLL_DENSE_GET_REGISTER(v, initial->M, reg);
+		result->M[reg] = v;
+	}
+
 	SET_VARSIZE(result, HLLSize(result));
 
 	return result;
+}
+
+/*
+ * HLLGetUnionResult
+ */
+HyperLogLog *
+HLLGetUnionResult(HyperLogLog *hllu)
+{
+	int reg;
+	int m = (((1 << hllu->p) * HLL_BITS_PER_REGISTER) / 8);
+	HyperLogLog *result = palloc0(sizeof(HyperLogLog) + m);
+
+	result->encoding = HLL_DENSE_DIRTY;
+	result->p = hllu->p;
+	result->mlen = m;
+
+	for (reg = 0; reg < hllu->mlen; reg++)
+	{
+		HLL_DENSE_SET_REGISTER(result->M, reg, hllu->M[reg]);
+	}
+
+	SET_VARSIZE(result, HLLSize(result));
+
+	return result;
+}
+
+/*
+ * HLLUnionAdd
+ */
+HyperLogLog *
+HLLUnionAdd(HyperLogLog *hllu, HyperLogLog *incoming)
+{
+	return hll_dense_union(hllu, incoming);
 }

--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -1198,7 +1198,7 @@ HLLCardinality(HyperLogLog *hll)
 		initialized = true;
   }
 
-  if (HLL_IS_UNION(hll))
+  if (HLL_IS_UNPACKED(hll))
 		hll = HLLGetUnionResult(hll);
 
   /*
@@ -1270,7 +1270,7 @@ hll_dense_union(HyperLogLog *hllu, HyperLogLog *incoming)
 	int reg;
 	int m = (1 << hllu->p);
 
-	Assert(HLL_IS_UNION(hllu));
+	Assert(HLL_IS_UNPACKED(hllu));
 
 	if (HLL_IS_DENSE(incoming))
 	{
@@ -1465,7 +1465,7 @@ HLLCreateUnion(HyperLogLog *initial)
 	if (HLL_IS_SPARSE(initial))
 		initial = hll_sparse_to_dense(initial);
 
-	result->encoding = HLL_UNION;
+	result->encoding = HLL_UNPACKED;
 	result->mlen = m;
 	result->p = initial->p;
 

--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -1446,14 +1446,6 @@ HLLUnion(HyperLogLog *result, HyperLogLog *incoming)
 	return result;
 }
 
-
-
-
-
-
-
-
-
 /*
  * HLLCreateUnion
  */

--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -1180,6 +1180,9 @@ HLLCardinality(HyperLogLog *hll)
   int j;
   int ez; /* Number of registers equal to 0. */
 
+  if (HLL_IS_UNION(hll))
+		hll = HLLGetUnionResult(hll);
+
   /*
    * Precompute 2^(-reg[j]) in order to speedup the
    * computation of SUM(2^-register[0..i])

--- a/src/backend/pipeline/hll.c
+++ b/src/backend/pipeline/hll.c
@@ -1180,9 +1180,6 @@ HLLCardinality(HyperLogLog *hll)
   int j;
   int ez; /* Number of registers equal to 0. */
 
-  if (HLL_IS_UNION(hll))
-		hll = HLLGetUnionResult(hll);
-
   /*
    * Precompute 2^(-reg[j]) in order to speedup the
    * computation of SUM(2^-register[0..i])
@@ -1200,6 +1197,9 @@ HLLCardinality(HyperLogLog *hll)
 		}
 		initialized = true;
   }
+
+  if (HLL_IS_UNION(hll))
+		hll = HLLGetUnionResult(hll);
 
   /*
    * If nothing has changed since the last cardinality computation,

--- a/src/include/pipeline/hll.h
+++ b/src/include/pipeline/hll.h
@@ -29,12 +29,12 @@
 #define HLL_DENSE_CLEAN 'D'
 #define HLL_EXPLICIT_DIRTY 'e'
 #define HLL_EXPLICIT_CLEAN 'E'
-#define HLL_UNION 'u'
+#define HLL_UNPACKED 'u'
 
 #define HLL_IS_SPARSE(hll) ((hll)->encoding == HLL_SPARSE_DIRTY || (hll)->encoding == HLL_SPARSE_CLEAN)
 #define HLL_IS_EXPLICIT(hll) ((hll)->encoding == HLL_EXPLICIT_DIRTY || (hll)->encoding == HLL_EXPLICIT_CLEAN)
 #define HLL_IS_DENSE(hll) ((hll)->encoding == HLL_DENSE_DIRTY || (hll)->encoding == HLL_DENSE_CLEAN)
-#define HLL_IS_UNION(hll) ((hll)->encoding == HLL_UNION)
+#define HLL_IS_UNPACKED(hll) ((hll)->encoding == HLL_UNPACKED)
 
 #define HLL_EXPLICIT_GET_NUM_REGISTERS(hll) ((hll)->mlen / 4)
 

--- a/src/include/pipeline/hll.h
+++ b/src/include/pipeline/hll.h
@@ -29,10 +29,12 @@
 #define HLL_DENSE_CLEAN 'D'
 #define HLL_EXPLICIT_DIRTY 'e'
 #define HLL_EXPLICIT_CLEAN 'E'
+#define HLL_UNION 'u'
 
 #define HLL_IS_SPARSE(hll) ((hll)->encoding == HLL_SPARSE_DIRTY || (hll)->encoding == HLL_SPARSE_CLEAN)
 #define HLL_IS_EXPLICIT(hll) ((hll)->encoding == HLL_EXPLICIT_DIRTY || (hll)->encoding == HLL_EXPLICIT_CLEAN)
 #define HLL_IS_DENSE(hll) ((hll)->encoding == HLL_DENSE_DIRTY || (hll)->encoding == HLL_DENSE_CLEAN)
+#define HLL_IS_UNION(hll) ((hll)->encoding == HLL_UNION)
 
 #define HLL_EXPLICIT_GET_NUM_REGISTERS(hll) ((hll)->mlen / 4)
 
@@ -62,5 +64,9 @@ HyperLogLog *HLLAdd(HyperLogLog *hll, void *elem, Size len, int *result);
 HyperLogLog *HLLCopy(HyperLogLog *src);
 uint64 HLLCardinality(HyperLogLog *hll);
 HyperLogLog *HLLUnion(HyperLogLog *result, HyperLogLog *incoming);
+
+HyperLogLog *HLLCreateUnion(HyperLogLog *initial);
+HyperLogLog *HLLGetUnionResult(HyperLogLog *hllu);
+HyperLogLog *HLLUnionAdd(HyperLogLog *hllu, HyperLogLog *incoming);
 
 #endif

--- a/src/test/regress/expected/cont_hll_agg.out
+++ b/src/test/regress/expected/cont_hll_agg.out
@@ -152,18 +152,18 @@ SELECT * FROM test_hll_agg2 ORDER BY k;
 (10 rows)
 
 SELECT * FROM test_sw_hll_agg0 ORDER BY k;
- k |                hll_print                 
----+------------------------------------------
- 0 | { p = 14, cardinality = 10, size = 0kB }
- 1 | { p = 14, cardinality = 10, size = 0kB }
- 2 | { p = 14, cardinality = 10, size = 0kB }
- 3 | { p = 14, cardinality = 10, size = 0kB }
- 4 | { p = 14, cardinality = 10, size = 0kB }
- 5 | { p = 14, cardinality = 10, size = 0kB }
- 6 | { p = 14, cardinality = 10, size = 0kB }
- 7 | { p = 14, cardinality = 10, size = 0kB }
- 8 | { p = 14, cardinality = 10, size = 0kB }
- 9 | { p = 14, cardinality = 10, size = 0kB }
+ k |                 hll_print                 
+---+-------------------------------------------
+ 0 | { p = 14, cardinality = 10, size = 16kB }
+ 1 | { p = 14, cardinality = 10, size = 16kB }
+ 2 | { p = 14, cardinality = 10, size = 16kB }
+ 3 | { p = 14, cardinality = 10, size = 16kB }
+ 4 | { p = 14, cardinality = 10, size = 16kB }
+ 5 | { p = 14, cardinality = 10, size = 16kB }
+ 6 | { p = 14, cardinality = 10, size = 16kB }
+ 7 | { p = 14, cardinality = 10, size = 16kB }
+ 8 | { p = 14, cardinality = 10, size = 16kB }
+ 9 | { p = 14, cardinality = 10, size = 16kB }
 (10 rows)
 
 SELECT * FROM test_sw_hll_agg1 ORDER BY k;
@@ -197,9 +197,9 @@ SELECT * FROM test_sw_hll_agg2 ORDER BY k;
 (10 rows)
 
 SELECT hll_print(combine(hll_agg)) FROM test_hll_agg0;
-                 hll_print                 
--------------------------------------------
- { p = 14, cardinality = 100, size = 0kB }
+                 hll_print                  
+--------------------------------------------
+ { p = 14, cardinality = 100, size = 16kB }
 (1 row)
 
 SELECT hll_cardinality(combine(hll_agg)) FROM test_hll_agg0;


### PR DESCRIPTION
This adds an `HLL_UNION` HLL representation that enables optimization for batch `combines`. e.g.,

```sql
select combine(uniques) from v0;
```
```sql
create continuous view v0 as
  select x, count(*), count(distinct y) as uniques from s group by x;
```

It works by loading the union's registers into a `uint8` array rather than performing bit packing/unpacking, when taking the max of registers, which ends up costing a lot of CPU. 

For `select combine(uniques) from v0` run on 100,000 dense HLLs in the above CV, this optimization results in a ~2.5x performance increase.


