### PR TITLE
Allow connecting the database in docker image from the other host

### DIFF
--- a/pkg/docker/docker-entrypoint.sh
+++ b/pkg/docker/docker-entrypoint.sh
@@ -79,7 +79,7 @@ EOSQL
 
         gosu pipeline pipeline-ctl -D ${PIPELINEDB_DATA} -m fast -w stop
 
-        sed -i -e "s/^listen_addresses =.*$/listen_addresses = '*'/g" "${PIPELINEDB_DATA}/pipelinedb.conf"
+        sed -i -e "s/^\(#listen_addresses.*\)$/listen_addresses = '*'\n\1/g" "${PIPELINEDB_DATA}/pipelinedb.conf"
 
         chmod 640       "${PIPELINEDB_DATA}/pipelinedb.conf"
         chown pipeline  "${PIPELINEDB_DATA}/pipelinedb.conf"


### PR DESCRIPTION
We cannot connect to pipelinedb/pipelinedb:0.9.7 from the other host.

```
$ docker run -i -d -p 5432:5432 pipelinedb/pipelinedb:0.9.7
$ psql -h 127.0.0.1 -p 5432 -U pipeline
psql: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```

After this PR is merged, `listen_addresses` will be set "all", like this.

```
listen_addresses = '*'
#listen_addresses = 'localhost'         # what IP address(es) to listen on;
```