### PR TITLE
Restarts DB after a config file loaded via /docker-entrypoint.d/

### DIFF
--- a/pkg/docker/docker-entrypoint.sh
+++ b/pkg/docker/docker-entrypoint.sh
@@ -65,6 +65,10 @@ EOSQL
         if [ -f /docker-entrypoint-init.d/pipelinedb.conf ]; then
             echo "$0: installing pipelinedb.conf"
             cp /docker-entrypoint-init.d/pipelinedb.conf "${PIPELINEDB_DATA}"
+            gosu pipeline pipeline-ctl \
+                -D "${PIPELINEDB_DATA}" \
+                -o "-c listen_addresses='localhost'" \
+                -w restart
         fi
 
         for f in /docker-entrypoint-init.d/*; do


### PR DESCRIPTION
is installed.

Some extensions have to be loaded via 'shared_preload_libraries',
like the kafka extension. If one requires views to be set up
when the container starts up via /docker-entrypoint-init.d/ with
the config being installed the same way, if the DB is not restarted
then these extensions are not available when the .sql files are run.