### PR TITLE
1700 transform2

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -866,9 +866,6 @@ extractRelOptions(HeapTuple tuple, TupleDesc tupdesc, Oid amoptions)
 		case RELKIND_FOREIGN_TABLE:
 			options = NULL;
 			break;
-//		case RELKIND_CONTTRANSFORM:
-//			options = NULL;
-//			break;
 		default:
 			Assert(false);		/* can't get here */
 			options = NULL;		/* keep compiler quiet */

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -866,9 +866,9 @@ extractRelOptions(HeapTuple tuple, TupleDesc tupdesc, Oid amoptions)
 		case RELKIND_FOREIGN_TABLE:
 			options = NULL;
 			break;
-		case RELKIND_CONTTRANSFORM:
-			options = NULL;
-			break;
+//		case RELKIND_CONTTRANSFORM:
+//			options = NULL;
+//			break;
 		default:
 			Assert(false);		/* can't get here */
 			options = NULL;		/* keep compiler quiet */

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -759,8 +759,8 @@ objectsInSchemaToOids(GrantObjectType objtype, List *nspnames)
 				objects = list_concat(objects, objs);
 				objs = getRelationsInNamespace(namespaceId, RELKIND_CONTVIEW);
 				objects = list_concat(objects, objs);
-				objs = getRelationsInNamespace(namespaceId, RELKIND_CONTTRANSFORM);
-				objects = list_concat(objects, objs);
+//				objs = getRelationsInNamespace(namespaceId, RELKIND_CONTTRANSFORM);
+//				objects = list_concat(objects, objs);
 				break;
 			case ACL_OBJECT_SEQUENCE:
 				objs = getRelationsInNamespace(namespaceId, RELKIND_SEQUENCE);

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -759,8 +759,6 @@ objectsInSchemaToOids(GrantObjectType objtype, List *nspnames)
 				objects = list_concat(objects, objs);
 				objs = getRelationsInNamespace(namespaceId, RELKIND_CONTVIEW);
 				objects = list_concat(objects, objs);
-//				objs = getRelationsInNamespace(namespaceId, RELKIND_CONTTRANSFORM);
-//				objects = list_concat(objects, objs);
 				break;
 			case ACL_OBJECT_SEQUENCE:
 				objs = getRelationsInNamespace(namespaceId, RELKIND_SEQUENCE);

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -289,7 +289,7 @@ heap_create(const char *relname,
 		case RELKIND_COMPOSITE_TYPE:
 		case RELKIND_FOREIGN_TABLE:
 		case RELKIND_CONTVIEW:
-		case RELKIND_CONTTRANSFORM:
+//		case RELKIND_CONTTRANSFORM:
 			create_storage = false;
 
 			/*
@@ -1110,8 +1110,7 @@ heap_create_with_catalog(const char *relname,
 			(relkind == RELKIND_RELATION || relkind == RELKIND_SEQUENCE ||
 			 relkind == RELKIND_VIEW || relkind == RELKIND_MATVIEW ||
 			 relkind == RELKIND_COMPOSITE_TYPE || relkind == RELKIND_FOREIGN_TABLE ||
-			 relkind == RELKIND_CONTVIEW ||
-			 relkind == RELKIND_CONTTRANSFORM))
+			 relkind == RELKIND_CONTVIEW))
 		{
 			if (!OidIsValid(binary_upgrade_next_heap_pg_class_oid))
 				ereport(ERROR,
@@ -1146,7 +1145,7 @@ heap_create_with_catalog(const char *relname,
 			case RELKIND_MATVIEW:
 			case RELKIND_FOREIGN_TABLE:
 			case RELKIND_CONTVIEW:
-			case RELKIND_CONTTRANSFORM:
+//			case RELKIND_CONTTRANSFORM:
 				relacl = get_user_default_acl(ACL_OBJECT_RELATION, ownerid,
 											  relnamespace);
 				break;
@@ -1204,8 +1203,7 @@ heap_create_with_catalog(const char *relname,
 							  relkind == RELKIND_MATVIEW ||
 							  relkind == RELKIND_FOREIGN_TABLE ||
 							  relkind == RELKIND_COMPOSITE_TYPE ||
-							  relkind == RELKIND_CONTVIEW ||
-							  relkind == RELKIND_CONTTRANSFORM))
+							  relkind == RELKIND_CONTVIEW))
 		new_array_oid = AssignTypeArrayOid();
 
 	/*
@@ -1829,8 +1827,7 @@ heap_drop_with_catalog(Oid relid)
 	if (rel->rd_rel->relkind != RELKIND_VIEW &&
 		rel->rd_rel->relkind != RELKIND_COMPOSITE_TYPE &&
 		rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
-		rel->rd_rel->relkind != RELKIND_CONTVIEW &&
-		rel->rd_rel->relkind != RELKIND_CONTTRANSFORM)
+		rel->rd_rel->relkind != RELKIND_CONTVIEW)
 	{
 		RelationDropStorage(rel);
 	}

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -289,7 +289,6 @@ heap_create(const char *relname,
 		case RELKIND_COMPOSITE_TYPE:
 		case RELKIND_FOREIGN_TABLE:
 		case RELKIND_CONTVIEW:
-//		case RELKIND_CONTTRANSFORM:
 			create_storage = false;
 
 			/*
@@ -1145,7 +1144,6 @@ heap_create_with_catalog(const char *relname,
 			case RELKIND_MATVIEW:
 			case RELKIND_FOREIGN_TABLE:
 			case RELKIND_CONTVIEW:
-//			case RELKIND_CONTTRANSFORM:
 				relacl = get_user_default_acl(ACL_OBJECT_RELATION, ownerid,
 											  relnamespace);
 				break;

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -749,7 +749,6 @@ get_object_address(ObjectType objtype, List *objname, List *objargs,
 			case OBJECT_MATVIEW:
 			case OBJECT_FOREIGN_TABLE:
 			case OBJECT_CONTVIEW:
-			case OBJECT_CONTTRANSFORM:
 				address =
 					get_relation_by_qualified_name(objtype, objname,
 												   &relation, lockmode,
@@ -1190,13 +1189,6 @@ get_relation_by_qualified_name(ObjectType objtype, List *objname,
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 						 errmsg("\"%s\" is not a foreign table",
-								RelationGetRelationName(relation))));
-			break;
-		case OBJECT_CONTTRANSFORM:
-			if (relation->rd_rel->relkind != RELKIND_CONTTRANSFORM)
-				ereport(ERROR,
-						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-						 errmsg("\"%s\" is not a continuous transform",
 								RelationGetRelationName(relation))));
 			break;
 		default:
@@ -3252,10 +3244,6 @@ getRelationDescription(StringInfo buffer, Oid relid)
 			appendStringInfo(buffer, _("continuous view %s"),
 							 relname);
 			break;
-		case RELKIND_CONTTRANSFORM:
-			appendStringInfo(buffer, _("continuous transform %s"),
-							 relname);
-			break;
 		default:
 			/* shouldn't get here */
 			appendStringInfo(buffer, _("relation %s"),
@@ -3708,9 +3696,6 @@ getRelationTypeDescription(StringInfo buffer, Oid relid, int32 objectSubId)
 			break;
 		case RELKIND_CONTVIEW:
 			appendStringInfoString(buffer, "continuous view");
-			break;
-		case RELKIND_CONTTRANSFORM:
-			appendStringInfoString(buffer, "continuous transform");
 			break;
 		default:
 			/* shouldn't get here */

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -813,7 +813,7 @@ GetContQueryId(RangeVar *name)
 }
 
 Oid
-DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List *options)
+DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List *options, Oid *ptgfnid)
 {
 	Relation pipeline_query;
 	HeapTuple tup;
@@ -870,6 +870,9 @@ DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List
 	atypeid = get_array_type(typeid);
 	options = lappend(options, makeDefElem(OPTION_OSRELATYPE, (Node *) makeInteger(atypeid)));
 
+	if (ptgfnid)
+		*ptgfnid = InvalidOid;
+
 	if (GetOptionAsString(options, OPTION_TGFN, &funcname))
 	{
 		Oid fargtypes[1];
@@ -877,6 +880,7 @@ DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List
 
 		tgfnoid = LookupFuncName(textToQualifiedNameList((text *) CStringGetTextDatum(funcname)), 0, fargtypes, false);
 		values[Anum_pipeline_query_tgfn - 1] = ObjectIdGetDatum(tgfnoid);
+		*ptgfnid = tgfnoid;
 	}
 	else
 	{

--- a/src/backend/catalog/pipeline_query.c
+++ b/src/backend/catalog/pipeline_query.c
@@ -16,6 +16,7 @@
 
 #include "access/heapam.h"
 #include "access/htup_details.h"
+#include "access/reloptions.h"
 #include "access/xact.h"
 #include "catalog/indexing.h"
 #include "catalog/pipeline_query.h"
@@ -26,6 +27,7 @@
 #include "catalog/namespace.h"
 #include "nodes/makefuncs.h"
 #include "parser/analyze.h"
+#include "parser/parse_func.h"
 #include "pipeline/analyzer.h"
 #include "pipeline/miscutils.h"
 #include "pipeline/scheduler.h"
@@ -811,7 +813,7 @@ GetContQueryId(RangeVar *name)
 }
 
 Oid
-DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, Oid fnoid, List *args)
+DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List *options)
 {
 	Relation pipeline_query;
 	HeapTuple tup;
@@ -820,6 +822,18 @@ DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, Oid 
 	Oid id;
 	Oid result;
 	char *query_str;
+	char *tgs;
+	int nargs;
+	Datum classopts;
+	HeapTuple classtup;
+	HeapTuple newtup;
+	Relation pgclass;
+	Datum class_values[Natts_pg_class];
+	bool class_null[Natts_pg_class];
+	bool class_repl[Natts_pg_class];
+	Oid typeid;
+	Oid atypeid;
+	char *funcname;
 
 	if (!query)
 		ereport(ERROR,
@@ -842,57 +856,42 @@ DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, Oid 
 	values[Anum_pipeline_query_relid - 1] = ObjectIdGetDatum(relid);
 	values[Anum_pipeline_query_active - 1] = BoolGetDatum(continuous_queries_enabled);
 	values[Anum_pipeline_query_query - 1] = CStringGetTextDatum(query_str);
-	values[Anum_pipeline_query_tgfn - 1] = ObjectIdGetDatum(fnoid);
 	values[Anum_pipeline_query_matrelid - 1] = ObjectIdGetDatum(typoid); /* HACK(usmanm): So matrel index works */
 	values[Anum_pipeline_query_osrelid - 1] = ObjectIdGetDatum(osrelid);
 	values[Anum_pipeline_query_pkidxid - 1] = ObjectIdGetDatum(InvalidOid);
 	values[Anum_pipeline_query_lookupidxid - 1] = ObjectIdGetDatum(InvalidOid);
 
-	/* This code is copied from trigger.c:CreateTrigger */
-	if (list_length(args))
+	options = lappend(options, makeDefElem(OPTION_ACTION, (Node *) makeString(ACTION_TRANSFORM)));
+	options = lappend(options, makeDefElem(OPTION_OSRELID, (Node *) makeInteger(osrelid)));
+
+	typeid = get_rel_type_id(osrelid);
+	options = lappend(options, makeDefElem(OPTION_OSRELTYPE, (Node *) makeInteger(typeid)));
+
+	atypeid = get_array_type(typeid);
+	options = lappend(options, makeDefElem(OPTION_OSRELATYPE, (Node *) makeInteger(atypeid)));
+
+	if (GetOptionAsString(options, OPTION_TGFN, &funcname))
 	{
-		ListCell *lc;
-		char *argsbytes;
-		int16 nargs = list_length(args);
-		int	len = 0;
+		Oid fargtypes[1];
+		Oid tgfnoid = InvalidOid;
 
-		foreach(lc, args)
-		{
-			char *ar = strVal(lfirst(lc));
-
-			len += strlen(ar) + 4;
-			for (; *ar; ar++)
-			{
-				if (*ar == '\\')
-					len++;
-			}
-		}
-
-		argsbytes = (char *) palloc(len + 1);
-		argsbytes[0] = '\0';
-
-		foreach(lc, args)
-		{
-			char *s = strVal(lfirst(lc));
-			char *d = argsbytes + strlen(argsbytes);
-
-			while (*s)
-			{
-				if (*s == '\\')
-					*d++ = '\\';
-				*d++ = *s++;
-			}
-			strcpy(d, "\\000");
-		}
-
-		values[Anum_pipeline_query_tgnargs - 1] = Int16GetDatum(nargs);
-		values[Anum_pipeline_query_tgargs - 1] = DirectFunctionCall1(byteain, CStringGetDatum(argsbytes));
+		tgfnoid = LookupFuncName(textToQualifiedNameList((text *) CStringGetTextDatum(funcname)), 0, fargtypes, false);
+		values[Anum_pipeline_query_tgfn - 1] = ObjectIdGetDatum(tgfnoid);
 	}
 	else
 	{
-		values[Anum_pipeline_query_tgnargs - 1] = Int16GetDatum(0);
-		values[Anum_pipeline_query_tgargs - 1] = DirectFunctionCall1(byteain, CStringGetDatum(""));
+		values[Anum_pipeline_query_tgfn - 1] = ObjectIdGetDatum(InvalidOid);
 	}
+
+	if (GetOptionAsString(options, OPTION_TGARGS, &tgs))
+		values[Anum_pipeline_query_tgargs - 1] = DirectFunctionCall1(byteain, CStringGetDatum(tgs));
+	else
+		values[Anum_pipeline_query_tgargs - 1] = DirectFunctionCall1(byteain, CStringGetDatum(""));
+
+	if (GetOptionAsInteger(options, OPTION_TGNARGS, &nargs))
+		values[Anum_pipeline_query_tgnargs - 1] = Int16GetDatum(nargs);
+	else
+		values[Anum_pipeline_query_tgnargs - 1] = Int16GetDatum(0);
 
 	/* unused */
 	values[Anum_pipeline_query_seqrelid - 1] = ObjectIdGetDatum(InvalidOid);
@@ -911,6 +910,34 @@ DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, Oid 
 	UpdatePipelineStreamCatalog();
 
 	heap_close(pipeline_query, NoLock);
+
+	CommandCounterIncrement();
+
+	// comments
+	// put all this in its own function?
+	pgclass = heap_open(RelationRelationId, RowExclusiveLock);
+	classtup = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+
+	if (!HeapTupleIsValid(classtup))
+		elog(ERROR, "cache lookup failed for OID %u", relid);
+
+	classopts = transformRelOptions((Datum) 0, options, NULL, NULL, false, false);
+	view_reloptions(classopts, false);
+
+	MemSet(class_values, 0, sizeof(class_values));
+	MemSet(class_null, 0, sizeof(class_null));
+	MemSet(class_repl, 0, sizeof(class_repl));
+
+	class_values[Anum_pg_class_reloptions - 1] = classopts;
+	class_repl[Anum_pg_class_reloptions - 1] = true;
+
+	newtup = heap_modify_tuple(classtup, RelationGetDescr(pgclass), class_values, class_null, class_repl);
+	simple_heap_update(pgclass, &newtup->t_self, newtup);
+	CatalogUpdateIndexes(pgclass, newtup);
+
+	heap_freetuple(newtup);
+	heap_close(pgclass, NoLock);
+	ReleaseSysCache(classtup);
 
 	return result;
 }

--- a/src/backend/commands/comment.c
+++ b/src/backend/commands/comment.c
@@ -97,8 +97,7 @@ CommentObject(CommentStmt *stmt)
 				relation->rd_rel->relkind != RELKIND_MATVIEW &&
 				relation->rd_rel->relkind != RELKIND_COMPOSITE_TYPE &&
 				relation->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
-				relation->rd_rel->relkind != RELKIND_CONTVIEW &&
-				relation->rd_rel->relkind != RELKIND_CONTTRANSFORM)
+				relation->rd_rel->relkind != RELKIND_CONTVIEW)
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 						 errmsg("\"%s\" is not a table, view, materialized view, composite type, or foreign table",

--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -1081,7 +1081,6 @@ EventTriggerSupportsObjectType(ObjectType obtype)
 			/* no support for event triggers on event triggers */
 			return false;
 		case OBJECT_CONTVIEW:
-		case OBJECT_CONTTRANSFORM:
 			/* no support for continuous views & streams (for now) */
 			return false;
 		case OBJECT_AGGREGATE:

--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -35,6 +35,7 @@
 #include "catalog/pipeline_stream_fn.h"
 #include "catalog/toasting.h"
 #include "executor/execdesc.h"
+#include "executor/spi.h"
 #include "executor/tstoreReceiver.h"
 #include "libpq/libpq-be.h"
 #include "miscadmin.h"
@@ -57,6 +58,7 @@
 #include "tcop/pquery.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
+#include "utils/bytea.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/palloc.h"
@@ -939,18 +941,11 @@ record_ct_dependencies(Oid pqoid, Oid relid, Oid osrelid, Oid fnoid, SelectStmt 
 	}
 
 	/*
-	 * Record a dependency between the type its pipeline_query entry so that when
-	 * the view is dropped the pipeline_query meta data cleanup hook is invoked.
+	 * Record a dependency between the transform and its output stream
 	 */
 	referenced.classId = RelationRelationId;
 	referenced.objectId = relid;
 	referenced.objectSubId = 0;
-
-	dependent.classId = PipelineQueryRelationOid;
-	dependent.objectId = pqoid;
-	dependent.objectSubId = 0;
-
-	recordDependencyOn(&dependent, &referenced, DEPENDENCY_INTERNAL);
 
 	/* Record dependency with output stream */
 	dependent.classId = RelationRelationId;
@@ -1038,62 +1033,106 @@ record_ct_dependencies(Oid pqoid, Oid relid, Oid osrelid, Oid fnoid, SelectStmt 
 	}
 }
 
-void
-ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystring)
+/*
+ * parse_outputfunc_args
+ */
+static void
+parse_outputfunc_args(List *options, Oid *tgfnoid, List **args)
 {
-	RangeVar *transform;
+	DefElem *def = GetContinuousViewOption(options, OPTION_TGFN);
+
+	*tgfnoid = InvalidOid;
+	*args = NIL;
+
+	if (def && IsA(def->arg, Integer))
+		*tgfnoid = intVal(def->arg);
+
+	def = GetContinuousViewOption(options, OPTION_TGNARGS);
+
+	// we need to handle integer and string
+	if (def && IsA(def->arg, Integer))
+	{
+		int nargs = intVal(def->arg);
+		if (nargs <= 0)
+			return;
+		def = GetContinuousViewOption(options, OPTION_TGARGS);
+		if (def && IsA(def->arg, String))
+		{
+			bytea *val = (bytea *) DirectFunctionCall1(byteain, (Datum) CStringGetDatum(strVal(def->arg)));
+			char *p = (char *) VARDATA(val);
+			int i;
+
+			/* Trigger function arguments will always be an array of strings */
+			for (i = 0; i < nargs; i++)
+			{
+				*args = lappend(*args, makeString(pstrdup(p)));
+				p += strlen(p) + 1;
+			}
+		}
+	}
+}
+
+/*
+ * set_next_oids_for_transform_osrel
+ */
+static void
+set_next_oids_for_transform_osrel(List *options)
+{
+	int relid;
+	int typid;
+	int atypeid;
+
+	reset_next_oids();
+
+	if (!GetOptionAsInteger(options, OPTION_OSRELID, &relid))
+		elog(ERROR, "integer expected for option \"%s\"", OPTION_OSRELID);
+
+	binary_upgrade_next_heap_pg_class_oid = (Oid) relid;
+
+	if (!GetOptionAsInteger(options, OPTION_OSRELTYPE, &typid))
+		elog(ERROR, "integer expected for option \"%s\"", OPTION_OSRELTYPE);
+
+	binary_upgrade_next_pg_type_oid = (Oid) typid;
+
+	if (!GetOptionAsInteger(options, OPTION_OSRELATYPE, &atypeid))
+		elog(ERROR, "integer expected for option \"%s\"", OPTION_OSRELATYPE);
+
+	binary_upgrade_next_array_pg_type_oid = (Oid) atypeid;
+}
+
+/*
+ * ExecCreateContTransformStmt
+ */
+void
+ExecCreateContTransformStmt(RangeVar *transform, Node *stmt, List *options, const char *querystring)
+{
 	Relation pipeline_query;
 	Query *query;
 	Oid pqoid;
 	ObjectAddress address;
 	Oid relid;
-	Oid fargtypes[1];	/* dummy */
 	Oid tgfnid = InvalidOid;
-	Oid funcrettype = InvalidOid;
-	CreateStmt *create;
 	CreateForeignTableStmt *create_osrel;
 	Oid osrelid;
+	ViewStmt *vstmt;
+	List *args = NIL;
 
-	transform = stmt->into->rel;
 	check_relation_already_exists(transform);
-
-	/* Find and validate the transform output function. */
-	if (stmt->funcname)
-	{
-		tgfnid = LookupFuncName(stmt->funcname, 0, fargtypes, false);
-		funcrettype = get_func_rettype(tgfnid);
-		if (funcrettype != TRIGGEROID)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-					errmsg("function %s must return type \"trigger\"",
-					NameListToString(stmt->funcname))));
-	}
 
 	pipeline_query = heap_open(PipelineQueryRelationOid, ExclusiveLock);
 
-	RewriteFromClause((SelectStmt *) stmt->query);
+	RewriteFromClause((SelectStmt *) stmt);
 
-	ValidateParsedContQuery(stmt->into->rel, stmt->query, querystring);
-	ValidateSubselect(stmt->query, "continuous transforms");
+	ValidateParsedContQuery(transform, stmt, querystring);
+	ValidateSubselect(stmt, "continuous transforms");
 
-	query = parse_analyze(copyObject(stmt->query), querystring, NULL, 0);
+	query = parse_analyze(copyObject(stmt), querystring, NULL, 0);
 	ValidateContQuery(query);
 
-	create = makeNode(CreateStmt);
-	create->relation = stmt->into->rel;
-	create->tableElts = create_coldefs_from_tlist(query);
-	create->tablespacename = stmt->into->tableSpaceName;
-	create->oncommit = stmt->into->onCommit;
-	create->options = stmt->into->options;
+	vstmt = makeNode(ViewStmt);
+	vstmt->view = transform;
+	vstmt->query = stmt;
 
-	if (IsBinaryUpgrade)
-		set_next_oids_for_matrel();
-
-	ViewStmt *vstmt = makeNode(ViewStmt);
-	vstmt->view = create->relation;
-	vstmt->query = stmt->query;
-
-//	address = DefineRelation(create, RELKIND_VIEW, InvalidOid, NULL);
 	address = DefineView(vstmt, querystring);
 	relid = address.objectId;
 	CommandCounterIncrement();
@@ -1106,23 +1145,94 @@ ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystri
 	transformCreateStreamStmt(create_osrel);
 
 	if (IsBinaryUpgrade)
-		set_next_oids_for_osrel();
+		set_next_oids_for_transform_osrel(options);
+
 	address = DefineRelation((CreateStmt *) create_osrel, RELKIND_FOREIGN_TABLE, InvalidOid, NULL);
 	osrelid = address.objectId;
 	CommandCounterIncrement();
 
-	pqoid = DefineContinuousTransform(relid, query, relid, osrelid, tgfnid, stmt->args);
+	pqoid = DefineContinuousTransform(relid, query, relid, osrelid, options);
 	CommandCounterIncrement();
 
 	CreateForeignTable(create_osrel, address.objectId);
 	CreatePipelineStreamEntry(create_osrel, address.objectId);
 	CommandCounterIncrement();
 
-	record_ct_dependencies(pqoid, relid, osrelid, tgfnid, (SelectStmt *) stmt->query, query, stmt->args);
+	parse_outputfunc_args(options, &tgfnid, &args);
+	record_ct_dependencies(pqoid, relid, osrelid, tgfnid, (SelectStmt *) stmt, query, args);
+
 	CommandCounterIncrement();
 
 	heap_close(pipeline_query, NoLock);
 }
+
+static void
+reconcile_pipeline_query(void)
+{
+	HeapTuple tup;
+	Relation pipeline_query;
+	HeapScanDesc scan_desc;
+
+	if (pg_class_aclcheck(PipelineQueryRelationOid, GetUserId(), ACL_DELETE) != ACLCHECK_OK)
+		return;
+
+	pipeline_query = heap_open(PipelineQueryRelationOid, NoLock);
+	scan_desc = heap_beginscan_catalog(pipeline_query, 0, NULL);
+
+	while ((tup = heap_getnext(scan_desc, ForwardScanDirection)) != NULL)
+	{
+		Form_pipeline_query row = (Form_pipeline_query) GETSTRUCT(tup);
+		if (row->type == PIPELINE_QUERY_TRANSFORM && !OidIsValid(get_rel_name(row->relid)))
+			simple_heap_delete(pipeline_query, &tup->t_self);
+	}
+
+	heap_endscan(scan_desc);
+	heap_close(pipeline_query, NoLock);
+}
+
+static void
+reconcile_pipeline_stream(void)
+{
+	HeapTuple tup;
+	Relation pipeline_stream;
+	HeapScanDesc scan_desc;
+
+	if (pg_class_aclcheck(PipelineStreamRelationOid, GetUserId(), ACL_DELETE) != ACLCHECK_OK)
+		return;
+
+	pipeline_stream = heap_open(PipelineStreamRelationOid, NoLock);
+	scan_desc = heap_beginscan_catalog(pipeline_stream, 0, NULL);
+
+	while ((tup = heap_getnext(scan_desc, ForwardScanDirection)) != NULL)
+	{
+		Form_pipeline_stream row = (Form_pipeline_stream) GETSTRUCT(tup);
+		if (!OidIsValid(get_rel_name(row->relid)))
+			simple_heap_delete(pipeline_stream, &tup->t_self);
+	}
+
+	heap_endscan(scan_desc);
+	heap_close(pipeline_stream, NoLock);
+}
+
+/*
+ * ReconcilePipelineObjects
+ *
+ * DELETE any pipeline_stream and pipeline_query rows that no longer have a corresponding relation
+ */
+void
+ReconcilePipelineObjects(void)
+{
+	PushActiveSnapshot(GetTransactionSnapshot());
+
+	reconcile_pipeline_query();
+
+	reconcile_pipeline_stream();
+
+	CommandCounterIncrement();
+
+	PopActiveSnapshot();
+}
+
 
 /*
  * create_cq_set_next_oids_for_matrel

--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -761,8 +761,7 @@ ExecCreateContViewStmt(CreateContViewStmt *stmt, const char *querystring)
 	toast_options = transformRelOptions((Datum) 0, create_stmt->options, "toast",
 			validnsps, true, false);
 
-	(void) heap_reloptions(RELKIND_TOASTVALUE, toast_options,
-						   true);
+	(void) heap_reloptions(RELKIND_TOASTVALUE, toast_options, true);
 	AlterTableCreateToastTable(matrelid, toast_options, AccessExclusiveLock);
 
 	/* Create the sequence for primary keys */
@@ -1089,7 +1088,13 @@ ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystri
 
 	if (IsBinaryUpgrade)
 		set_next_oids_for_matrel();
-	address = DefineRelation(create, RELKIND_VIEW, InvalidOid, NULL);
+
+	ViewStmt *vstmt = makeNode(ViewStmt);
+	vstmt->view = create->relation;
+	vstmt->query = stmt->query;
+
+//	address = DefineRelation(create, RELKIND_VIEW, InvalidOid, NULL);
+	address = DefineView(vstmt, querystring);
 	relid = address.objectId;
 	CommandCounterIncrement();
 

--- a/src/backend/commands/pipelinecmds.c
+++ b/src/backend/commands/pipelinecmds.c
@@ -1089,7 +1089,7 @@ ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystri
 
 	if (IsBinaryUpgrade)
 		set_next_oids_for_matrel();
-	address = DefineRelation(create, RELKIND_CONTTRANSFORM, InvalidOid, NULL);
+	address = DefineRelation(create, RELKIND_VIEW, InvalidOid, NULL);
 	relid = address.objectId;
 	CommandCounterIncrement();
 

--- a/src/backend/commands/seclabel.c
+++ b/src/backend/commands/seclabel.c
@@ -112,8 +112,7 @@ ExecSecLabelStmt(SecLabelStmt *stmt)
 				relation->rd_rel->relkind != RELKIND_MATVIEW &&
 				relation->rd_rel->relkind != RELKIND_COMPOSITE_TYPE &&
 				relation->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
-				relation->rd_rel->relkind != RELKIND_CONTVIEW &&
-				relation->rd_rel->relkind != RELKIND_CONTTRANSFORM)
+				relation->rd_rel->relkind != RELKIND_CONTVIEW)
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 						 errmsg("\"%s\" is not a table, view, materialized view, composite type, or foreign table",

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7992,7 +7992,6 @@ ATPrepAlterColumnType(List **wqueue,
 	if (tab->relkind == RELKIND_COMPOSITE_TYPE ||
 		tab->relkind == RELKIND_FOREIGN_TABLE)
 	{
-		// we were previously handling transforms here too
 		/*
 		 * For composite types, do this check now.  Tables will check it later
 		 * when the table is being rewritten.

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -259,12 +259,6 @@ static const struct dropmsgstrings dropmsgstringarray[] = {
 		gettext_noop("continuous view  \"%s\" does not exist, skipping"),
 		gettext_noop("\"%s\" is not a continuous view "),
 	gettext_noop("Use DROP CONTINUOUS VIEW to remove a continuous view.")},
-	{RELKIND_CONTTRANSFORM,
-		ERRCODE_UNDEFINED_OBJECT,
-		gettext_noop("continuous transform \"%s\" does not exist"),
-		gettext_noop("continuous transform \"%s\" does not exist, skipping"),
-		gettext_noop("\"%s\" is not a continuous transform"),
-	gettext_noop("Use DROP CONTINUOUS TRANSFORM to remove a continuous transform.")},
 	{'\0', 0, NULL, NULL, NULL, NULL}
 };
 
@@ -502,11 +496,6 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 				 errmsg("ON COMMIT can only be used on temporary tables")));
-
-	if (stmt->constraints != NIL && relkind == RELKIND_CONTTRANSFORM)
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("constraints are not supported on continuous transforms")));
 
 	/*
 	 * Look up the namespace in which we are supposed to create the relation,
@@ -876,10 +865,6 @@ RemoveRelations(DropStmt *drop)
 
 		case OBJECT_CONTVIEW:
 			relkind = RELKIND_CONTVIEW;
-			break;
-
-		case OBJECT_CONTTRANSFORM:
-			relkind = RELKIND_CONTTRANSFORM;
 			break;
 
 		default:
@@ -2201,8 +2186,7 @@ renameatt_check(Oid myrelid, Form_pg_class classform, bool recursing)
 		relkind != RELKIND_COMPOSITE_TYPE &&
 		relkind != RELKIND_INDEX &&
 		relkind != RELKIND_FOREIGN_TABLE &&
-		relkind != RELKIND_CONTVIEW &&
-		relkind != RELKIND_CONTTRANSFORM)
+		relkind != RELKIND_CONTVIEW)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a table, view, materialized view, composite type, index, or foreign table",
@@ -3142,15 +3126,6 @@ ATController(AlterTableStmt *parsetree,
 	foreach(lcmd, cmds)
 	{
 		AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lcmd);
-
-		if ((rel->rd_rel->relkind == RELKIND_CONTVIEW || rel->rd_rel->relkind == RELKIND_CONTTRANSFORM) &&
-				cmd->subtype != AT_ChangeOwner)
-		{
-			char *name = rel->rd_rel->relkind == RELKIND_CONTVIEW ? "view" : "transform";
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					(errmsg("continuous %ss only support OWNER TO actions", name))));
-		}
 
 		ATPrepCmd(&wqueue, rel, cmd, recurse, false, lockmode);
 	}
@@ -4987,8 +4962,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 	 */
 	if (relkind != RELKIND_VIEW && relkind != RELKIND_COMPOSITE_TYPE
 		&& relkind != RELKIND_FOREIGN_TABLE && relkind != RELKIND_CONTVIEW
-		&& relkind != RELKIND_CONTTRANSFORM &&
-		attribute.attnum > 0)
+		&& attribute.attnum > 0)
 	{
 		defval = (Expr *) build_column_default(rel, attribute.attnum);
 
@@ -5457,8 +5431,7 @@ ATPrepSetStatistics(Relation rel, const char *colName, Node *newValue, LOCKMODE 
 		rel->rd_rel->relkind != RELKIND_MATVIEW &&
 		rel->rd_rel->relkind != RELKIND_INDEX &&
 		rel->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
-		rel->rd_rel->relkind != RELKIND_CONTVIEW &&
-		rel->rd_rel->relkind != RELKIND_CONTTRANSFORM)
+		rel->rd_rel->relkind != RELKIND_CONTVIEW)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a table, materialized view, index, or foreign table",
@@ -8017,9 +7990,9 @@ ATPrepAlterColumnType(List **wqueue,
 						RelationGetRelationName(rel))));
 
 	if (tab->relkind == RELKIND_COMPOSITE_TYPE ||
-		tab->relkind == RELKIND_FOREIGN_TABLE ||
-		tab->relkind == RELKIND_CONTTRANSFORM)
+		tab->relkind == RELKIND_FOREIGN_TABLE)
 	{
+		// we were previously handling transforms here too
 		/*
 		 * For composite types, do this check now.  Tables will check it later
 		 * when the table is being rewritten.
@@ -8978,7 +8951,6 @@ ATExecChangeOwner(Oid relationOid, Oid newOwnerId, bool recursing, LOCKMODE lock
 		case RELKIND_MATVIEW:
 		case RELKIND_FOREIGN_TABLE:
 		case RELKIND_CONTVIEW:
-		case RELKIND_CONTTRANSFORM:
 			/* ok to change owner */
 			break;
 		case RELKIND_INDEX:
@@ -12089,8 +12061,7 @@ RangeVarCallbackForAlterRelation(const RangeVar *rv, Oid relid, Oid oldrelid,
 		relkind != RELKIND_MATVIEW &&
 		relkind != RELKIND_SEQUENCE &&
 		relkind != RELKIND_FOREIGN_TABLE &&
-		relkind != RELKIND_CONTVIEW &&
-		relkind != RELKIND_CONTTRANSFORM)
+		relkind != RELKIND_CONTVIEW)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a table, view, materialized view, sequence, or foreign table",

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -232,12 +232,6 @@ CreateTrigger(CreateTrigStmt *stmt, const char *queryString,
 							RelationGetRelationName(rel)),
 			  errdetail("Foreign tables cannot have constraint triggers.")));
 	}
-	else if (rel->rd_rel->relkind == RELKIND_CONTTRANSFORM)
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("\"%s\" is a continuous transform",
-						RelationGetRelationName(rel)),
-		  errdetail("Continuous transforms don't support triggers.")));
 	else
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1095,12 +1095,6 @@ CheckValidResultRel(Relation resultRel, CmdType operation)
 					errmsg("cannot change continuous view \"%s\"",
 							RelationGetRelationName(resultRel))));
 			break;
-		case RELKIND_CONTTRANSFORM:
-			ereport(ERROR,
-					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-					errmsg("cannot change continuous transform \"%s\"",
-							RelationGetRelationName(resultRel))));
-			break;
 		case RELKIND_FOREIGN_TABLE:
 			/* Okay only if the FDW supports it */
 			fdwroutine = GetFdwRoutineForRelation(resultRel, false);

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -468,11 +468,6 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 {
 	Relids		required_outer;
 
-	if (rte->relkind == RELKIND_CONTTRANSFORM)
-		ereport(ERROR,
-				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-				 errmsg("\"%s\" is a continuous transform", get_rel_name(rte->relid)),
-				 errhint("Continuous transforms don't support SELECTs.")));
 	/*
 	 * We don't support pushing join clauses into the quals of a seqscan, but
 	 * it could still have required parameterization due to LATERAL refs in

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -5693,7 +5693,7 @@ DropStmt: DROP drop_type IF_P EXISTS any_name_list opt_drop_behavior
 drop_type:  TABLE                 { $$ = OBJECT_TABLE; }
       | CONTINUOUS VIEW           { $$ = OBJECT_CONTVIEW; }
       | STREAM                    { $$ = OBJECT_FOREIGN_TABLE; }
-      | CONTINUOUS TRANSFORM      { $$ = OBJECT_CONTTRANSFORM; }
+      | CONTINUOUS TRANSFORM      { $$ = OBJECT_VIEW; }
       | SEQUENCE                { $$ = OBJECT_SEQUENCE; }
       | VIEW                  { $$ = OBJECT_VIEW; }
       | MATERIALIZED VIEW           { $$ = OBJECT_MATVIEW; }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -2866,7 +2866,6 @@ CreateContTransformStmt:
           vstmt->query = $7;
           vstmt->view = $4;
           vstmt->options = $5;
-          
           vstmt->options = lappend(vstmt->options, makeDefElem(OPTION_ACTION, (Node *) makeString(ACTION_TRANSFORM)));
           vstmt->options = lappend(vstmt->options, makeDefElem(OPTION_TGFN, (Node *) makeString(NameListToString($11))));
 		  if (list_length($13))
@@ -2882,7 +2881,6 @@ CreateContTransformStmt:
           vstmt->query = $7;
           vstmt->view = $4;
           vstmt->options = $5;
-          
           vstmt->options = lappend(vstmt->options, makeDefElem(OPTION_ACTION, (Node *) makeString(ACTION_TRANSFORM)));
           $$ = (Node *) vstmt;
         }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -2868,7 +2868,6 @@ CreateContTransformStmt:
           vstmt->options = $5;
           
           vstmt->options = lappend(vstmt->options, makeDefElem(OPTION_ACTION, (Node *) makeString(ACTION_TRANSFORM)));
-          //vstmt->options = lappend(vstmt->options, makeDefElem(OPTION_TGFNID, (Node *) makeInteger(LookupOutputFunc($11))));
           vstmt->options = lappend(vstmt->options, makeDefElem(OPTION_TGFN, (Node *) makeString(NameListToString($11))));
 		  if (list_length($13))
 		  {

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -723,8 +723,7 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 		relation->rd_rel->relkind != RELKIND_MATVIEW &&
 		relation->rd_rel->relkind != RELKIND_COMPOSITE_TYPE &&
 		relation->rd_rel->relkind != RELKIND_FOREIGN_TABLE &&
-		relation->rd_rel->relkind != RELKIND_CONTVIEW &&
-		relation->rd_rel->relkind != RELKIND_CONTTRANSFORM)
+		relation->rd_rel->relkind != RELKIND_CONTVIEW)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("\"%s\" is not a table, view, materialized view, composite type, or foreign table",

--- a/src/backend/pipeline/analyzer.c
+++ b/src/backend/pipeline/analyzer.c
@@ -3982,17 +3982,11 @@ GetOptionAsInteger(List *options, char *option, int *result)
 		return false;
 
 	if (IsA(def->arg, String))
-	{
 		*result = atoi(strVal(def->arg));
-	}
 	else if (IsA(def->arg, Integer))
-	{
 		*result = intVal(def->arg);
-	}
 	else
-	{
 		return false;
-	}
 
 	return true;
 }

--- a/src/backend/pipeline/planner.c
+++ b/src/backend/pipeline/planner.c
@@ -750,7 +750,7 @@ ProcessUtilityOnContView(Node *parsetree, const char *sql, ProcessUtilityContext
 			VacuumStmt *vstmt = (VacuumStmt *) parsetree;
 			/*
 			 * If the user is trying to vacuum a CV, what they're really
-			 * trying to do is create it on the CV's materialization table, so rewrite
+			 * trying to do vacuum the CV's materialization table, so rewrite
 			 * the name of the target relation if we need to.
 			 */
 			if (vstmt->relation && IsAContinuousView(vstmt->relation))

--- a/src/backend/pipeline/planner.c
+++ b/src/backend/pipeline/planner.c
@@ -862,13 +862,6 @@ PipelineProcessUtility(Node *parsetree, const char *sql, ProcessUtilityContext c
 				}
 			}
 		}
-		else if (IsA(parsetree, SelectStmt))
-		{
-			// if transform anywhere in FROM, error!
-			// we should probably start breaking this up into smaller functions :)
-		}
-
-		// we handle create cont transform ourselves here
 
 		if (SaveUtilityHook != NULL)
 			(*SaveUtilityHook) (parsetree, sql, context, params, dest, tag);
@@ -900,11 +893,6 @@ done:
 		 */
 		if (IsA(parsetree, DropStmt))
 			ReconcilePipelineObjects();
-
-		// don't we need a reconcile pipeline_query
-		// i know we've tried this in the past but why isn't it being done yet?
-		// maybe it just wasn't time yet?
-		// we basically just want to remove any pipeline_query rows for which there is no relid
 
 		/*
 		 * Clear analyzer/planner context flags

--- a/src/backend/pipeline/planner.c
+++ b/src/backend/pipeline/planner.c
@@ -722,6 +722,7 @@ ProcessUtilityOnContView(Node *parsetree, const char *sql, ProcessUtilityContext
 	{
 		if (IsA(parsetree, CreateContViewStmt) || IsA(parsetree, CreateContTransformStmt))
 		{
+			// if transform, verify no constraints
 			Node *node;
 
 			if (IsA(parsetree, CreateContViewStmt))
@@ -818,6 +819,11 @@ ProcessUtilityOnContView(Node *parsetree, const char *sql, ProcessUtilityContext
 					}
 				}
 			}
+		}
+		else if (IsA(parsetree, SelectStmt))
+		{
+			// if transform anywhere in FROM, error!
+			// we should probably start breaking this up into smaller functions :)
 		}
 
 		if (SaveUtilityHook != NULL)

--- a/src/backend/pipeline/planner.c
+++ b/src/backend/pipeline/planner.c
@@ -768,8 +768,6 @@ PipelineProcessUtility(Node *parsetree, const char *sql, ProcessUtilityContext c
 				PipelineContextSetIsDDL();
 				ddl_lock = AcquirePipelineDDLLock();
 
-				// verify no constraints
-
 				AnalyzeCreateViewForTransform(stmt);
 				ExecCreateContTransformStmt(stmt->view, stmt->query, stmt->options, sql);
 				goto done;

--- a/src/backend/pipeline/transform_receiver.c
+++ b/src/backend/pipeline/transform_receiver.c
@@ -170,6 +170,8 @@ insert_into_rel(TransformReceiver *t, Relation rel, TupleTableSlot *event_slot)
 	sis = (StreamInsertState *) rinfo->ri_FdwState;
 	Assert(sis);
 
+
+	elog(LOG, "inserting into %s", rel->rd_rel->relname.data);
 	if (sis->queries)
 	{
 		TupleDesc osreldesc = RelationGetDescr(rel);

--- a/src/backend/pipeline/transform_receiver.c
+++ b/src/backend/pipeline/transform_receiver.c
@@ -170,8 +170,6 @@ insert_into_rel(TransformReceiver *t, Relation rel, TupleTableSlot *event_slot)
 	sis = (StreamInsertState *) rinfo->ri_FdwState;
 	Assert(sis);
 
-
-	elog(LOG, "inserting into %s", rel->rd_rel->relname.data);
 	if (sis->queries)
 	{
 		TupleDesc osreldesc = RelationGetDescr(rel);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1606,7 +1606,6 @@ ExecDropStmt(DropStmt *stmt, bool isTopLevel)
 		case OBJECT_MATVIEW:
 		case OBJECT_FOREIGN_TABLE:
 		case OBJECT_CONTVIEW:
-		case OBJECT_CONTTRANSFORM:
 			RemoveRelations(stmt);
 			break;
 		default:
@@ -2116,6 +2115,7 @@ CreateCommandTag(Node *parsetree)
 					tag = "DROP SEQUENCE";
 					break;
 				case OBJECT_VIEW:
+					// if it was a transform, DROP CONTINUOUS TRANSFORM
 					tag = "DROP VIEW";
 					break;
 				case OBJECT_CONTVIEW:
@@ -2215,9 +2215,6 @@ CreateCommandTag(Node *parsetree)
 					break;
 				case OBJECT_TRANSFORM:
 					tag = "DROP TRANSFORM";
-					break;
-				case OBJECT_CONTTRANSFORM:
-					tag = "DROP CONTINUOUS TRANSFORM";
 					break;
 				default:
 					tag = "???";

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -530,10 +530,6 @@ standard_ProcessUtility(Node *parsetree,
 			ExecCreateContViewStmt((CreateContViewStmt *) parsetree, queryString);
 			break;
 
-		case T_CreateContTransformStmt:
-			ExecCreateContTransformStmt((CreateContTransformStmt *) parsetree, queryString);
-			break;
-
 		case T_DropTableSpaceStmt:
 			/* no event triggers for global objects */
 			PreventTransactionChain(isTopLevel, "DROP TABLESPACE");

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -2091,10 +2091,7 @@ CreateCommandTag(Node *parsetree)
 			break;
 
 		case T_CreateForeignTableStmt:
-			if (pg_strcasecmp((((CreateForeignTableStmt *) parsetree)->servername), PIPELINEDB_SERVER) == 0)
-				tag = "CREATE STREAM";
-			else
-				tag = "CREATE FOREIGN TABLE";
+			tag = "CREATE FOREIGN TABLE";
 			break;
 
 		case T_ImportForeignSchemaStmt:
@@ -2111,7 +2108,6 @@ CreateCommandTag(Node *parsetree)
 					tag = "DROP SEQUENCE";
 					break;
 				case OBJECT_VIEW:
-					// if it was a transform, DROP CONTINUOUS TRANSFORM
 					tag = "DROP VIEW";
 					break;
 				case OBJECT_CONTVIEW:
@@ -2151,21 +2147,7 @@ CreateCommandTag(Node *parsetree)
 					tag = "DROP TEXT SEARCH CONFIGURATION";
 					break;
 				case OBJECT_FOREIGN_TABLE:
-					{
-						DropStmt *stmt = (DropStmt *) parsetree;
-
-						tag = "DROP FOREIGN TABLE";
-						if (list_length(stmt->objects) == 1)
-						{
-							Node *n = linitial(stmt->objects);
-							if (IsA(n, List))
-							{
-								RangeVar *rv = makeRangeVarFromNameList((List *) n);
-								if (RangeVarIsForStream(rv, true))
-									tag = "DROP STREAM";
-							}
-						}
-					}
+					tag = "DROP FOREIGN TABLE";
 					break;
 				case OBJECT_EXTENSION:
 					tag = "DROP EXTENSION";
@@ -2588,10 +2570,6 @@ CreateCommandTag(Node *parsetree)
 				else
 					tag = "DEALLOCATE";
 			}
-			break;
-
-		case T_CreateContTransformStmt:
-			tag = "CREATE CONTINUOUS TRANSFORM";
 			break;
 
 			/* already-planned queries */
@@ -3191,7 +3169,6 @@ GetCommandLogLevel(Node *parsetree)
 
 			/* PipelineDB */
 			case T_CreateContViewStmt:
-			case T_CreateContTransformStmt:
 				lev = LOGSTMT_DDL;
 				break;
 

--- a/src/backend/utils/init/pipelineinit.c
+++ b/src/backend/utils/init/pipelineinit.c
@@ -44,7 +44,7 @@ PipelineInstallHooks()
 {
 	InitPipelineSysCache();
 	SaveUtilityHook = ProcessUtility_hook;
-	ProcessUtility_hook = ProcessUtilityOnContView;
+	ProcessUtility_hook = PipelineProcessUtility;
 
 	SavePostParseAnalyzeHook = post_parse_analyze_hook;
 	post_parse_analyze_hook = PostParseAnalyzeHook;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -14382,11 +14382,13 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			return;
 		}
 
-//		if (tbinfo->relkind == RELKIND_CONTTRANSFORM)
-//		{
-//			dumpContinuousTransform(fout, tbinfo, delq);
-//			return;
-//		}
+		// if it's a transform
+		// relkind will just be 'v' now
+		if (tbinfo->relkind == 'x')
+		{
+			dumpContinuousTransform(fout, tbinfo, delq);
+			return;
+		}
 
 		if (dopt->binary_upgrade)
 			binary_upgrade_set_pg_class_oids(fout, q,

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -1605,10 +1605,10 @@ expand_table_name_patterns(Archive *fout,
 						  "SELECT c.oid"
 						  "\nFROM pg_catalog.pg_class c"
 		"\n     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
-					 "\nWHERE c.relkind in ('%c', '%c', '%c', '%c', '%c', '%c', '%c')\n",
+					 "\nWHERE c.relkind in ('%c', '%c', '%c', '%c', '%c', '%c')\n",
 						  RELKIND_RELATION, RELKIND_SEQUENCE, RELKIND_VIEW,
 						  RELKIND_MATVIEW, RELKIND_FOREIGN_TABLE,
-						  RELKIND_CONTVIEW, RELKIND_CONTTRANSFORM);
+						  RELKIND_CONTVIEW);
 		processSQLNamePattern(GetConnection(fout), query, cell->val, true,
 							  false, "n.nspname", "c.relname", NULL,
 							  "pg_catalog.pg_table_is_visible(c.oid)");
@@ -2379,8 +2379,6 @@ makeTableDataInfo(DumpOptions *dopt, TableInfo *tbinfo, bool oids)
 	if (tbinfo->relkind == RELKIND_FOREIGN_TABLE)
 		return;
 	if (tbinfo->relkind == RELKIND_CONTVIEW)
-		return;
-	if (tbinfo->relkind == RELKIND_CONTTRANSFORM)
 		return;
 
 	/* Don't dump data in unlogged tables, if so requested */
@@ -5088,14 +5086,14 @@ getTables(Archive *fout, int *numTables)
 						  "d.objsubid = 0 AND "
 						  "d.refclassid = c.tableoid AND d.deptype = 'a') "
 					   "LEFT JOIN pg_class tc ON (c.reltoastrelid = tc.oid) "
-				   "WHERE c.relkind in ('%c', '%c', '%c', '%c', '%c', '%c', '%c', '%c') "
+				   "WHERE c.relkind in ('%c', '%c', '%c', '%c', '%c', '%c', '%c') "
 						  "ORDER BY c.oid",
 						  username_subquery,
 						  RELKIND_SEQUENCE,
 						  RELKIND_RELATION, RELKIND_SEQUENCE,
 						  RELKIND_VIEW, RELKIND_COMPOSITE_TYPE,
 						  RELKIND_MATVIEW, RELKIND_FOREIGN_TABLE,
-						  RELKIND_CONTVIEW, RELKIND_CONTTRANSFORM);
+						  RELKIND_CONTVIEW);
 	}
 	else if (fout->remoteVersion >= 90400)
 	{
@@ -5131,14 +5129,14 @@ getTables(Archive *fout, int *numTables)
 						  "d.objsubid = 0 AND "
 						  "d.refclassid = c.tableoid AND d.deptype = 'a') "
 					   "LEFT JOIN pg_class tc ON (c.reltoastrelid = tc.oid) "
-				   "WHERE c.relkind in ('%c', '%c', '%c', '%c', '%c', '%c', '%c', '%c') "
+				   "WHERE c.relkind in ('%c', '%c', '%c', '%c', '%c', '%c', '%c') "
 						  "ORDER BY c.oid",
 						  username_subquery,
 						  RELKIND_SEQUENCE,
 						  RELKIND_RELATION, RELKIND_SEQUENCE,
 						  RELKIND_VIEW, RELKIND_COMPOSITE_TYPE,
 						  RELKIND_MATVIEW, RELKIND_FOREIGN_TABLE,
-						  RELKIND_CONTVIEW, RELKIND_CONTTRANSFORM);
+						  RELKIND_CONTVIEW);
 	}
 	else if (fout->remoteVersion >= 90300)
 	{
@@ -14353,11 +14351,6 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				srvname = NULL;
 				ftoptions = NULL;
 				break;
-			case (RELKIND_CONTTRANSFORM):
-				reltypename = "CONTINUOUS TRANSFORM";
-				srvname = NULL;
-				ftoptions = NULL;
-				break;
 			default:
 				reltypename = "TABLE";
 				srvname = NULL;
@@ -14389,11 +14382,11 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			return;
 		}
 
-		if (tbinfo->relkind == RELKIND_CONTTRANSFORM)
-		{
-			dumpContinuousTransform(fout, tbinfo, delq);
-			return;
-		}
+//		if (tbinfo->relkind == RELKIND_CONTTRANSFORM)
+//		{
+//			dumpContinuousTransform(fout, tbinfo, delq);
+//			return;
+//		}
 
 		if (dopt->binary_upgrade)
 			binary_upgrade_set_pg_class_oids(fout, q,

--- a/src/include/catalog/pg_class.h
+++ b/src/include/catalog/pg_class.h
@@ -162,7 +162,6 @@ DESCR("");
 #define		  RELKIND_FOREIGN_TABLE   'f'		/* foreign table */
 #define		  RELKIND_MATVIEW		  'm'		/* materialized view */
 #define		  RELKIND_CONTVIEW		  'C'		/* continuous view */
-#define       RELKIND_CONTTRANSFORM   'X'       /* continuous transform */
 
 #define		  RELPERSISTENCE_PERMANENT	'p'		/* regular table */
 #define		  RELPERSISTENCE_UNLOGGED	'u'		/* unlogged permanent table */

--- a/src/include/catalog/pipeline_query.h
+++ b/src/include/catalog/pipeline_query.h
@@ -88,4 +88,18 @@ typedef FormData_pipeline_query *Form_pipeline_query;
 #define PIPELINE_QUERY_VIEW 		'v'
 #define PIPELINE_QUERY_TRANSFORM 	't'
 
+#define OPTION_ACTION "action"
+#define OPTION_OUTPUTFUNC "outputfunc"
+#define OPTION_MATRELID "matrelid"
+#define OPTION_OSRELID "osrelid"
+#define OPTION_OSRELTYPE "osreltype"
+#define OPTION_OSRELATYPE "osrelatype"
+#define OPTION_TGFNID "tgfnid"
+#define OPTION_TGFN "tgfn"
+#define OPTION_TGNARGS "tgnargs"
+#define OPTION_TGARGS "tgargs"
+
+#define ACTION_TRANSFORM "transform"
+#define ACTION_MATERIALIZE "materialize"
+
 #endif   /* PIPELINE_QUERIES_H */

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -71,7 +71,7 @@ extern void RemovePipelineQueryById(Oid oid);
 extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid seqrel, int ttl, AttrNumber ttl_attno, Oid *pq_id);
 extern void UpdateContViewRelIds(Oid cvid, Oid cvrelid, Oid osrelid);
 extern void UpdateContViewIndexIds(Oid cvid, Oid pkindid, Oid lookupindid);
-extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, Oid fnoid, List *args);
+extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List *options);
 
 extern Relation OpenCVRelFromMatRel(Relation matrel, LOCKMODE lockmode);
 extern bool IsAContinuousView(RangeVar *name);

--- a/src/include/catalog/pipeline_query_fn.h
+++ b/src/include/catalog/pipeline_query_fn.h
@@ -71,7 +71,7 @@ extern void RemovePipelineQueryById(Oid oid);
 extern Oid DefineContinuousView(Oid relid, Query *query, Oid matrel, Oid seqrel, int ttl, AttrNumber ttl_attno, Oid *pq_id);
 extern void UpdateContViewRelIds(Oid cvid, Oid cvrelid, Oid osrelid);
 extern void UpdateContViewIndexIds(Oid cvid, Oid pkindid, Oid lookupindid);
-extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List *options);
+extern Oid DefineContinuousTransform(Oid relid, Query *query, Oid typoid, Oid osrelid, List *options, Oid *ptgfnid);
 
 extern Relation OpenCVRelFromMatRel(Relation matrel, LOCKMODE lockmode);
 extern bool IsAContinuousView(RangeVar *name);

--- a/src/include/catalog/pipeline_stream_fn.h
+++ b/src/include/catalog/pipeline_stream_fn.h
@@ -37,7 +37,6 @@ extern bool RangeVarIsForStream(RangeVar *rv, bool missing_ok);
 extern bool IsStream(Oid relid);
 
 extern void CreatePipelineStreamEntry(CreateForeignTableStmt *stmt, Oid relid);
-extern void ReconcilePipelineStreams(void);
 extern bool RelIdIsForOutputStream(Oid id, Oid *cqid);
 
 #endif

--- a/src/include/commands/pipelinecmds.h
+++ b/src/include/commands/pipelinecmds.h
@@ -24,7 +24,8 @@
 extern int continuous_view_fillfactor;
 
 extern void ExecCreateContViewStmt(CreateContViewStmt *stmt, const char *querystring);
-extern void ExecCreateContTransformStmt(CreateContTransformStmt *stmt, const char *querystring);
+extern void ExecCreateContTransformStmt(RangeVar *transform, Node *stmt, List *options, const char *querystring);
+extern void ReconcilePipelineObjects(void);
 
 /* Binary upgrade support */
 extern Datum create_cq_set_next_oids_for_matrel(PG_FUNCTION_ARGS);

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -456,8 +456,7 @@ typedef enum NodeTag
 	/*
 	 * TAGS FOR PIPELINEDB
 	 */
-	T_CreateContViewStmt,
-	T_CreateContTransformStmt
+	T_CreateContViewStmt
 } NodeTag;
 
 /*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3063,13 +3063,4 @@ typedef struct CreateContViewStmt
 	Node 		*query;
 } CreateContViewStmt;
 
-typedef struct CreateContTransformStmt
-{
-	NodeTag		type;
-	IntoClause 	*into;
-	Node 		*query;
-	List	    *funcname;
-	List	    *args;
-} CreateContTransformStmt;
-
 #endif   /* PARSENODES_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1418,8 +1418,7 @@ typedef enum ObjectType
 	OBJECT_TYPE,
 	OBJECT_USER_MAPPING,
 	OBJECT_VIEW,
-	OBJECT_CONTVIEW,
-	OBJECT_CONTTRANSFORM
+	OBJECT_CONTVIEW
 } ObjectType;
 
 /* ----------------------

--- a/src/include/pipeline/analyzer.h
+++ b/src/include/pipeline/analyzer.h
@@ -111,7 +111,13 @@ extern ColumnRef *GetSWTimeColumn(RangeVar *rv);
 extern Interval *GetSWInterval(RangeVar *rv);
 extern ColumnRef *GetWindowTimeColumn(RangeVar *cv);
 
+extern void AnalyzeCreateViewForTransform(ViewStmt *stmt);
+extern Oid LookupOutputFunc(List *name);
+extern char *DeparseOutputFuncArgs(List *args);
+
 extern DefElem *GetContinuousViewOption(List *options, char *name);
+extern bool GetOptionAsString(List *options, char *option, char **result);
+extern bool GetOptionAsInteger(List *options, char *option, int *result);
 extern void ApplySlidingWindow(SelectStmt *stmt, DefElem *max_age, int *ttl);
 extern int IntervalToEpoch(Interval *i);
 extern void ApplyStorageOptions(CreateContViewStmt *stmt, bool *has_max_age, int *ttl, char **ttl_column);

--- a/src/include/pipeline/planner.h
+++ b/src/include/pipeline/planner.h
@@ -44,7 +44,7 @@ extern EState *CreateEState(QueryDesc *query_desc);
 extern void SetEStateSnapshot(EState *estate);
 extern void UnsetEStateSnapshot(EState *estate);
 
-extern void ProcessUtilityOnContView(Node *parsetree, const char *sql, ProcessUtilityContext context,
+extern void PipelineProcessUtility(Node *parsetree, const char *sql, ProcessUtilityContext context,
 													  ParamListInfo params, DestReceiver *dest, char *tag);
 
 #endif

--- a/src/pl/plpgsql/src/pl_comp.c
+++ b/src/pl/plpgsql/src/pl_comp.c
@@ -2001,8 +2001,7 @@ build_row_from_class(Oid classOid)
 		classStruct->relkind != RELKIND_MATVIEW &&
 		classStruct->relkind != RELKIND_COMPOSITE_TYPE &&
 		classStruct->relkind != RELKIND_FOREIGN_TABLE &&
-		classStruct->relkind != RELKIND_CONTVIEW &&
-		classStruct->relkind != RELKIND_CONTTRANSFORM)
+		classStruct->relkind != RELKIND_CONTVIEW)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("relation \"%s\" is not a table", relname)));

--- a/src/test/py/base.py
+++ b/src/test/py/base.py
@@ -215,10 +215,11 @@ class PipelineDB(object):
         """
         Create a continuous transform
         """
+        options = 'action=transform'
         if trigfn:
-            trigfn = ' THEN EXECUTE PROCEDURE %s' % trigfn
+            options += ', outputfunc=%s' % trigfn
         result = self.execute(
-          'CREATE CONTINUOUS TRANSFORM %s AS %s%s' % (name, stmt, trigfn))
+          'CREATE VIEW %s WITH (%s) AS %s' % (name, options, stmt))
         return result
 
     def create_table(self, name, **cols):

--- a/src/test/py/test_dump_restore.py
+++ b/src/test/py/test_dump_restore.py
@@ -199,7 +199,7 @@ def test_cont_transforms(pipeline, clean_db):
   LANGUAGE plpgsql;
   ''')
   pipeline.create_ct('test_ct2', 'SELECT x::int, y::text FROM ct_stream',
-                     'test_tg()')
+                     'test_tg')
 
   pipeline.insert('ct_stream', ('x', 'y'), [(1, 'hello'), (2, 'world')])
   time.sleep(1)

--- a/src/test/py/test_upgrade.py
+++ b/src/test/py/test_upgrade.py
@@ -62,7 +62,7 @@ def test_binary_upgrade(pipeline, clean_db):
   # Create some transforms with trigger functions
   for n in range(8):
     name = 'ct_%d' % n
-    pipeline.create_ct(name, 'SELECT z::text FROM stream0', 'tg_fn()')
+    pipeline.create_ct(name, 'SELECT z::text FROM stream0', 'tg_fn')
 
   # Create some transforms without trigger functions
   for n in range(8):

--- a/src/test/regress/expected/analyze_cont_view.out
+++ b/src/test/regress/expected/analyze_cont_view.out
@@ -208,10 +208,17 @@ View definition:
  SELECT combine(cqregress6.avg) AS combine
    FROM cqregress6;
 
+CREATE CONTINUOUS TRANSFORM cqregress8 AS SELECT id FROM analyze_cont_stream;
 DROP STREAM analyze_cont_stream CASCADE;
-NOTICE:  drop cascades to 5 other objects
-DETAIL:  drop cascades to continuous view cqregress1
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to view cqregress8
+drop cascades to continuous view cqregress1
 drop cascades to continuous view cqregress2
 drop cascades to continuous view cqregress5
 drop cascades to continuous view cqregress6
 drop cascades to view cqregress7
+SELECT * FROM pipeline_query;
+ id | type | relid | active | osrelid | matrelid | seqrelid | pkidxid | lookupidxid | step_factor | ttl | ttl_attno | tgfn | tgnargs | tgargs | query 
+----+------+-------+--------+---------+----------+----------+---------+-------------+-------------+-----+-----------+------+---------+--------+-------
+(0 rows)
+

--- a/src/test/regress/expected/analyze_cont_view.out
+++ b/src/test/regress/expected/analyze_cont_view.out
@@ -208,7 +208,7 @@ View definition:
  SELECT combine(cqregress6.avg) AS combine
    FROM cqregress6;
 
-CREATE CONTINUOUS TRANSFORM cqregress8 AS SELECT id FROM analyze_cont_stream;
+CREATE VIEW cqregress8 WITH (action=transform) AS SELECT id FROM analyze_cont_stream;
 DROP STREAM analyze_cont_stream CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to view cqregress8

--- a/src/test/regress/expected/cont_transform.out
+++ b/src/test/regress/expected/cont_transform.out
@@ -1,7 +1,7 @@
 CREATE STREAM ct_stream0 (x int);
 CREATE STREAM ct_stream1 (x int);
 CREATE CONTINUOUS VIEW ct0 AS SELECT x::int, count(*) FROM ct_stream0 GROUP BY x;
-CREATE CONTINUOUS TRANSFORM ct1 AS SELECT x::int % 4 AS x FROM ct_stream1 WHERE x > 10 AND x < 50 THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_stream0');
+CREATE VIEW ct1 WITH (action=transform, outputfunc=pipeline_stream_insert('ct_stream0')) AS SELECT x::int % 4 AS x FROM ct_stream1 WHERE x > 10 AND x < 50;
 CREATE TABLE ct2 (x int);
 CREATE OR REPLACE FUNCTION ct_tg()
 RETURNS trigger AS
@@ -12,7 +12,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-CREATE CONTINUOUS TRANSFORM ct3 AS SELECT x::int FROM ct_stream1 WHERE x % 2 = 0 THEN EXECUTE PROCEDURE ct_tg();
+CREATE VIEW ct3 WITH (action=transform, outputfunc=ct_tg) AS SELECT x::int FROM ct_stream1 WHERE x % 2 = 0;
 INSERT INTO ct_stream1 (x) SELECT generate_series(0, 100) AS x;
 SELECT * FROM ct0 ORDER BY x;
  x | count 
@@ -82,7 +82,7 @@ SELECT * FROM ct2 ORDER BY x;
 DROP FUNCTION ct_tg() CASCADE;
 NOTICE:  drop cascades to view ct3
 DROP TABLE ct2;
-DROP CONTINUOUS TRANSFORM ct1;
+DROP VIEW ct1;
 DROP CONTINUOUS VIEW ct0;
 DROP STREAM ct_stream0;
 DROP STREAM ct_stream1;
@@ -93,9 +93,8 @@ INSERT INTO ct_t (x, s) VALUES (1, 'one');
 CREATE STREAM ct_s0 (x text);
 CREATE STREAM ct_s1 (x int);
 CREATE CONTINUOUS VIEW ct_v AS SELECT x::text FROM ct_s0;
-CREATE CONTINUOUS TRANSFORM ct AS
-  SELECT t.s AS x FROM ct_s1 s JOIN ct_t t on t.x = s.x::integer
-  THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s0');
+CREATE VIEW ct WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s0')) AS
+  SELECT t.s AS x FROM ct_s1 s JOIN ct_t t on t.x = s.x::integer;
 NOTICE:  consider creating an index on t.x for improved stream-table join performance
 INSERT INTO ct_s1 (x) VALUES (0), (1);
 INSERT INTO ct_s1 (x) VALUES (0), (2);
@@ -107,22 +106,22 @@ SELECT * FROM ct_v ORDER BY x;
  zero
 (3 rows)
 
-DROP CONTINUOUS TRANSFORM ct;
+DROP VIEW ct;
 DROP CONTINUOUS VIEW ct_v;
 DROP TABLE ct_t;
 DROP STREAM ct_s1;
 DROP STREAM ct_s0;
 CREATE STREAM ct_s (x int, y text);
-CREATE CONTINUOUS TRANSFORM ct_invalid AS SELECT y, x FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
+CREATE VIEW ct_invalid WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s')) AS SELECT y, x FROM ct_s;
 ERROR:  "ct_s" must have the same schema as the transform
-CREATE CONTINUOUS TRANSFORM ct_invalid AS SELECT x, x AS y FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
+CREATE VIEW ct_invalid WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s')) AS SELECT x, x AS y FROM ct_s;
 ERROR:  "ct_s" must have the same schema as the transform
-CREATE CONTINUOUS TRANSFORM ct_valid AS SELECT x, 'a'::text FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
+CREATE VIEW ct_valid WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s')) AS SELECT x, 'a'::text FROM ct_s;
 DROP STREAM ct_s CASCADE;
 NOTICE:  drop cascades to view ct_valid
 CREATE STREAM ct_s0 (x int);
 CREATE STREAM ct_s1 (x int);
-CREATE CONTINUOUS TRANSFORM ct_t AS SELECT x % 4 AS x FROM ct_s0 THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s1');
+CREATE VIEW ct_t WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s1')) AS SELECT x % 4 AS x FROM ct_s0;
 CREATE CONTINUOUS VIEW ct_v0 AS SELECT x FROM ct_s1;
 CREATE CONTINUOUS VIEW ct_v1 AS SELECT x FROM output_of('ct_t');
 INSERT INTO ct_s0 SELECT generate_series(1, 10) x;
@@ -156,7 +155,7 @@ SELECT * FROM ct_v1;
  2
 (10 rows)
 
-CREATE CONTINUOUS TRANSFORM ct_ostream AS SELECT 1 AS a, 2 AS b, 3 AS c, x + 42 AS d FROM ct_s1;
+CREATE VIEW ct_ostream WITH (action=transform) AS SELECT 1 AS a, 2 AS b, 3 AS c, x + 42 AS d FROM ct_s1;
 DROP STREAM ct_s0 CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to view ct_t
@@ -166,17 +165,17 @@ NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to view ct_ostream
 drop cascades to continuous view ct_v0
 CREATE STREAM fanout (x integer);
-CREATE CONTINUOUS TRANSFORM fanout0 AS SELECT generate_series(1, 2) FROM fanout;
-CREATE CONTINUOUS TRANSFORM fanout1 AS SELECT generate_series(1, 2) FROM output_of('fanout0');
-CREATE CONTINUOUS TRANSFORM fanout2 AS SELECT generate_series(1, 2) FROM output_of('fanout1');
-CREATE CONTINUOUS TRANSFORM fanout3 AS SELECT generate_series(1, 2) FROM output_of('fanout2');
-CREATE CONTINUOUS TRANSFORM fanout4 AS SELECT generate_series(1, 2) FROM output_of('fanout3');
-CREATE CONTINUOUS TRANSFORM fanout5 AS SELECT generate_series(1, 2) FROM output_of('fanout4');
-CREATE CONTINUOUS TRANSFORM fanout6 AS SELECT generate_series(1, 2) FROM output_of('fanout5');
-CREATE CONTINUOUS TRANSFORM fanout7 AS SELECT generate_series(1, 2) FROM output_of('fanout6');
-CREATE CONTINUOUS TRANSFORM fanout8 AS SELECT generate_series(1, 2) FROM output_of('fanout7');
-CREATE CONTINUOUS TRANSFORM fanout9 AS SELECT generate_series(1, 2) FROM output_of('fanout8');
-CREATE CONTINUOUS TRANSFORM fanout10 AS SELECT generate_series(1, 2) FROM output_of('fanout9');
+CREATE VIEW fanout0 WITH (action=transform) AS SELECT generate_series(1, 2) FROM fanout;
+CREATE VIEW fanout1 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout0');
+CREATE VIEW fanout2 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout1');
+CREATE VIEW fanout3 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout2');
+CREATE VIEW fanout4 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout3');
+CREATE VIEW fanout5 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout4');
+CREATE VIEW fanout6 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout5');
+CREATE VIEW fanout7 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout6');
+CREATE VIEW fanout8 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout7');
+CREATE VIEW fanout9 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout8');
+CREATE VIEW fanout10 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout9');
 CREATE CONTINUOUS VIEW fanout11 AS SELECT count(*) FROM output_of('fanout10');
 INSERT INTO fanout (x) VALUES (0);
 SELECT * FROM fanout11;
@@ -216,16 +215,16 @@ drop cascades to continuous view fanout11
 CREATE STREAM ct_a (n int);
 CREATE STREAM ct_b (n int);
 CREATE CONTINUOUS VIEW ct_stream_insert0 AS SELECT n FROM ct_b;
-CREATE FUNCTION insert_into_b () RETURNS TRIGGER AS
+CREATE SCHEMA test_cont_transform;
+CREATE FUNCTION test_cont_transform.insert_into_b () RETURNS TRIGGER AS
 $$
 BEGIN
   INSERT INTO ct_b VALUES (NEW.n);
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
-CREATE CONTINUOUS TRANSFORM ct_stream_insert1 AS
-SELECT n FROM ct_a
-THEN EXECUTE PROCEDURE insert_into_b();
+CREATE VIEW ct_stream_insert1 WITH (action=transform, outputfunc=test_cont_transform.insert_into_b) AS
+SELECT n FROM ct_a;
 INSERT INTO ct_a SELECT generate_series(1, 100);
 INSERT INTO ct_a SELECT generate_series(1, 100);
 SELECT pg_sleep(1);
@@ -240,8 +239,9 @@ SELECT count(*) FROM ct_stream_insert0;
    200
 (1 row)
 
-DROP FUNCTION insert_into_b() CASCADE;
+DROP FUNCTION test_cont_transform.insert_into_b() CASCADE;
 NOTICE:  drop cascades to view ct_stream_insert1
+DROP SCHEMA test_cont_transform;
 DROP STREAM ct_b CASCADE;
 NOTICE:  drop cascades to continuous view ct_stream_insert0
 DROP STREAM ct_a;

--- a/src/test/regress/expected/cont_transform.out
+++ b/src/test/regress/expected/cont_transform.out
@@ -161,6 +161,10 @@ DROP STREAM ct_s0 CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to view ct_t
 drop cascades to continuous view ct_v1
+DROP STREAM ct_s1 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to view ct_ostream
+drop cascades to continuous view ct_v0
 CREATE STREAM fanout (x integer);
 CREATE CONTINUOUS TRANSFORM fanout0 AS SELECT generate_series(1, 2) FROM fanout;
 CREATE CONTINUOUS TRANSFORM fanout1 AS SELECT generate_series(1, 2) FROM output_of('fanout0');

--- a/src/test/regress/expected/cont_transform.out
+++ b/src/test/regress/expected/cont_transform.out
@@ -80,7 +80,7 @@ SELECT * FROM ct2 ORDER BY x;
 (51 rows)
 
 DROP FUNCTION ct_tg() CASCADE;
-NOTICE:  drop cascades to continuous transform ct3
+NOTICE:  drop cascades to view ct3
 DROP TABLE ct2;
 DROP CONTINUOUS TRANSFORM ct1;
 DROP CONTINUOUS VIEW ct0;
@@ -119,7 +119,7 @@ CREATE CONTINUOUS TRANSFORM ct_invalid AS SELECT x, x AS y FROM ct_s THEN EXECUT
 ERROR:  "ct_s" must have the same schema as the transform
 CREATE CONTINUOUS TRANSFORM ct_valid AS SELECT x, 'a'::text FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
 DROP STREAM ct_s CASCADE;
-NOTICE:  drop cascades to continuous transform ct_valid
+NOTICE:  drop cascades to view ct_valid
 CREATE STREAM ct_s0 (x int);
 CREATE STREAM ct_s1 (x int);
 CREATE CONTINUOUS TRANSFORM ct_t AS SELECT x % 4 AS x FROM ct_s0 THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s1');
@@ -159,7 +159,7 @@ SELECT * FROM ct_v1;
 CREATE CONTINUOUS TRANSFORM ct_ostream AS SELECT 1 AS a, 2 AS b, 3 AS c, x + 42 AS d FROM ct_s1;
 DROP STREAM ct_s0 CASCADE;
 NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to continuous transform ct_t
+DETAIL:  drop cascades to view ct_t
 drop cascades to continuous view ct_v1
 CREATE STREAM fanout (x integer);
 CREATE CONTINUOUS TRANSFORM fanout0 AS SELECT generate_series(1, 2) FROM fanout;
@@ -197,17 +197,17 @@ SELECT * FROM fanout11;
 
 DROP STREAM fanout CASCADE;
 NOTICE:  drop cascades to 12 other objects
-DETAIL:  drop cascades to continuous transform fanout0
-drop cascades to continuous transform fanout1
-drop cascades to continuous transform fanout2
-drop cascades to continuous transform fanout3
-drop cascades to continuous transform fanout4
-drop cascades to continuous transform fanout5
-drop cascades to continuous transform fanout6
-drop cascades to continuous transform fanout7
-drop cascades to continuous transform fanout8
-drop cascades to continuous transform fanout9
-drop cascades to continuous transform fanout10
+DETAIL:  drop cascades to view fanout0
+drop cascades to view fanout1
+drop cascades to view fanout2
+drop cascades to view fanout3
+drop cascades to view fanout4
+drop cascades to view fanout5
+drop cascades to view fanout6
+drop cascades to view fanout7
+drop cascades to view fanout8
+drop cascades to view fanout9
+drop cascades to view fanout10
 drop cascades to continuous view fanout11
 CREATE STREAM ct_a (n int);
 CREATE STREAM ct_b (n int);
@@ -237,7 +237,7 @@ SELECT count(*) FROM ct_stream_insert0;
 (1 row)
 
 DROP FUNCTION insert_into_b() CASCADE;
-NOTICE:  drop cascades to continuous transform ct_stream_insert1
+NOTICE:  drop cascades to view ct_stream_insert1
 DROP STREAM ct_b CASCADE;
 NOTICE:  drop cascades to continuous view ct_stream_insert0
 DROP STREAM ct_a;

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -331,9 +331,17 @@ CREATE CONTINUOUS VIEW os7 WITH (sw = '5 minutes') AS
 FROM os_stream
 GROUP BY second, y, x;
 CREATE CONTINUOUS VIEW os8 AS SELECT (new).x, (new).y FROM output_of('os7');
+BEGIN;
 INSERT INTO os_stream (ts, x, y) VALUES (now(), 'text!', 42.42);
 INSERT INTO os_stream (ts, x, y) VALUES (now(), 'text!', 42.42);
 INSERT INTO os_stream (ts, x, y) VALUES (now(), 'text!', 42.42);
+COMMIT;
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT x, y FROM os8 ORDER BY x, y;
    x   |   y   
 -------+-------

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -266,7 +266,7 @@ SELECT x, old, new FROM os3_output ORDER BY x, old, new;
 DROP CONTINUOUS VIEW os3 CASCADE;
 NOTICE:  drop cascades to continuous view os3_output
 -- Verify that transforms write to output streams
-CREATE CONTINUOUS TRANSFORM os_xform AS SELECT x, y FROM os_stream;
+CREATE VIEW os_xform WITH (action=transform) AS SELECT x, y FROM os_stream;
 CREATE CONTINUOUS VIEW os4 AS SELECT x, y FROM output_of('os_xform');
 INSERT INTO os_stream (x, y) VALUES (7, 7);
 INSERT INTO os_stream (x, y) VALUES (8, 8);

--- a/src/test/regress/expected/output_streams.out
+++ b/src/test/regress/expected/output_streams.out
@@ -281,7 +281,7 @@ SELECT * FROM os4 ORDER BY x;
 
 DROP STREAM os_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to continuous transform os_xform
+DETAIL:  drop cascades to view os_xform
 drop cascades to continuous view os4
 CREATE STREAM os_stream (x integer, y numeric);
 CREATE CONTINUOUS VIEW os5 AS

--- a/src/test/regress/expected/pipeline_regress.out
+++ b/src/test/regress/expected/pipeline_regress.out
@@ -300,11 +300,13 @@ HINT:  Explicitly cast the expression to a known type.
 CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a'::text FROM sw_ts_expr_s
   THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
 \d+ unknown_type_ct
-Continuous transform "public.unknown_type_ct"
- Column |  Type   | Storage  
---------+---------+----------
- x      | integer | plain
- text   | text    | extended
+             View "public.unknown_type_ct"
+ Column |  Type   | Modifiers | Storage  | Description 
+--------+---------+-----------+----------+-------------
+ x      | integer |           | plain    | 
+ text   | text    |           | extended | 
+View definition:
+Not a view
 
 DROP CONTINUOUS TRANSFORM unknown_type_ct;
 DROP STREAM ct_out_s;

--- a/src/test/regress/expected/pipeline_regress.out
+++ b/src/test/regress/expected/pipeline_regress.out
@@ -306,7 +306,9 @@ CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a'::text FROM sw_ts_ex
  x      | integer |           | plain    | 
  text   | text    |           | extended | 
 View definition:
-Not a view
+ SELECT sw_ts_expr_s.x,
+    'a'::text AS text
+   FROM sw_ts_expr_s;
 
 DROP CONTINUOUS TRANSFORM unknown_type_ct;
 DROP STREAM ct_out_s;

--- a/src/test/regress/expected/pipeline_regress.out
+++ b/src/test/regress/expected/pipeline_regress.out
@@ -293,12 +293,12 @@ View definition:
 
 DROP CONTINUOUS VIEW unknown_type_cv;
 CREATE STREAM ct_out_s (x integer, a text);
-CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a' FROM sw_ts_expr_s
-  THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
+CREATE VIEW unknown_type_ct WITH (action=transform, outputfunc=pipeline_stream_insert('ct_out_s')) AS
+  SELECT x, 'a' FROM sw_ts_expr_s;
 ERROR:  column 2 has an unknown type
 HINT:  Explicitly cast the expression to a known type.
-CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a'::text FROM sw_ts_expr_s
-  THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
+CREATE VIEW unknown_type_ct WITH (action=transform, outputfunc=pipeline_stream_insert('ct_out_s')) AS
+  SELECT x, 'a'::text FROM sw_ts_expr_s;
 SELECT pg_get_viewdef('unknown_type_ct');
      pg_get_viewdef      
 -------------------------
@@ -307,7 +307,7 @@ SELECT pg_get_viewdef('unknown_type_ct');
     FROM sw_ts_expr_s;
 (1 row)
 
-DROP CONTINUOUS TRANSFORM unknown_type_ct;
+DROP VIEW unknown_type_ct;
 DROP STREAM ct_out_s;
 DROP STREAM sw_ts_expr_s CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/src/test/regress/expected/pipeline_regress.out
+++ b/src/test/regress/expected/pipeline_regress.out
@@ -299,16 +299,13 @@ ERROR:  column 2 has an unknown type
 HINT:  Explicitly cast the expression to a known type.
 CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a'::text FROM sw_ts_expr_s
   THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
-\d+ unknown_type_ct
-             View "public.unknown_type_ct"
- Column |  Type   | Modifiers | Storage  | Description 
---------+---------+-----------+----------+-------------
- x      | integer |           | plain    | 
- text   | text    |           | extended | 
-View definition:
- SELECT sw_ts_expr_s.x,
-    'a'::text AS text
-   FROM sw_ts_expr_s;
+SELECT pg_get_viewdef('unknown_type_ct');
+     pg_get_viewdef      
+-------------------------
+  SELECT sw_ts_expr_s.x,+
+     'a'::text AS text  +
+    FROM sw_ts_expr_s;
+(1 row)
 
 DROP CONTINUOUS TRANSFORM unknown_type_ct;
 DROP STREAM ct_out_s;

--- a/src/test/regress/sql/analyze_cont_view.sql
+++ b/src/test/regress/sql/analyze_cont_view.sql
@@ -118,7 +118,7 @@ CREATE CONTINUOUS VIEW cqregress6 AS SELECT id, avg(x) FROM analyze_cont_stream 
 CREATE VIEW cqregress7 AS SELECT combine(avg) FROM cqregress6;
 \d+ cqregress7
 
-CREATE CONTINUOUS TRANSFORM cqregress8 AS SELECT id FROM analyze_cont_stream;
+CREATE VIEW cqregress8 WITH (action=transform) AS SELECT id FROM analyze_cont_stream;
 
 DROP STREAM analyze_cont_stream CASCADE;
 

--- a/src/test/regress/sql/analyze_cont_view.sql
+++ b/src/test/regress/sql/analyze_cont_view.sql
@@ -118,4 +118,8 @@ CREATE CONTINUOUS VIEW cqregress6 AS SELECT id, avg(x) FROM analyze_cont_stream 
 CREATE VIEW cqregress7 AS SELECT combine(avg) FROM cqregress6;
 \d+ cqregress7
 
+CREATE CONTINUOUS TRANSFORM cqregress8 AS SELECT id FROM analyze_cont_stream;
+
 DROP STREAM analyze_cont_stream CASCADE;
+
+SELECT * FROM pipeline_query;

--- a/src/test/regress/sql/cont_transform.sql
+++ b/src/test/regress/sql/cont_transform.sql
@@ -74,6 +74,7 @@ SELECT * FROM ct_v1;
 CREATE CONTINUOUS TRANSFORM ct_ostream AS SELECT 1 AS a, 2 AS b, 3 AS c, x + 42 AS d FROM ct_s1;
 
 DROP STREAM ct_s0 CASCADE;
+DROP STREAM ct_s1 CASCADE;
 
 CREATE STREAM fanout (x integer);
 

--- a/src/test/regress/sql/cont_transform.sql
+++ b/src/test/regress/sql/cont_transform.sql
@@ -2,7 +2,7 @@ CREATE STREAM ct_stream0 (x int);
 CREATE STREAM ct_stream1 (x int);
 
 CREATE CONTINUOUS VIEW ct0 AS SELECT x::int, count(*) FROM ct_stream0 GROUP BY x;
-CREATE CONTINUOUS TRANSFORM ct1 AS SELECT x::int % 4 AS x FROM ct_stream1 WHERE x > 10 AND x < 50 THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_stream0');
+CREATE VIEW ct1 WITH (action=transform, outputfunc=pipeline_stream_insert('ct_stream0')) AS SELECT x::int % 4 AS x FROM ct_stream1 WHERE x > 10 AND x < 50;
 
 CREATE TABLE ct2 (x int);
 CREATE OR REPLACE FUNCTION ct_tg()
@@ -14,7 +14,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
-CREATE CONTINUOUS TRANSFORM ct3 AS SELECT x::int FROM ct_stream1 WHERE x % 2 = 0 THEN EXECUTE PROCEDURE ct_tg();
+CREATE VIEW ct3 WITH (action=transform, outputfunc=ct_tg) AS SELECT x::int FROM ct_stream1 WHERE x % 2 = 0;
 
 INSERT INTO ct_stream1 (x) SELECT generate_series(0, 100) AS x;
 
@@ -23,7 +23,7 @@ SELECT * FROM ct2 ORDER BY x;
 
 DROP FUNCTION ct_tg() CASCADE;
 DROP TABLE ct2;
-DROP CONTINUOUS TRANSFORM ct1;
+DROP VIEW ct1;
 DROP CONTINUOUS VIEW ct0;
 DROP STREAM ct_stream0;
 DROP STREAM ct_stream1;
@@ -36,16 +36,15 @@ INSERT INTO ct_t (x, s) VALUES (1, 'one');
 CREATE STREAM ct_s0 (x text);
 CREATE STREAM ct_s1 (x int);
 CREATE CONTINUOUS VIEW ct_v AS SELECT x::text FROM ct_s0;
-CREATE CONTINUOUS TRANSFORM ct AS
-  SELECT t.s AS x FROM ct_s1 s JOIN ct_t t on t.x = s.x::integer
-  THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s0');
+CREATE VIEW ct WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s0')) AS
+  SELECT t.s AS x FROM ct_s1 s JOIN ct_t t on t.x = s.x::integer;
 
 INSERT INTO ct_s1 (x) VALUES (0), (1);
 INSERT INTO ct_s1 (x) VALUES (0), (2);
 
 SELECT * FROM ct_v ORDER BY x;
 
-DROP CONTINUOUS TRANSFORM ct;
+DROP VIEW ct;
 DROP CONTINUOUS VIEW ct_v;
 DROP TABLE ct_t;
 DROP STREAM ct_s1;
@@ -53,16 +52,16 @@ DROP STREAM ct_s0;
 
 CREATE STREAM ct_s (x int, y text);
 
-CREATE CONTINUOUS TRANSFORM ct_invalid AS SELECT y, x FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
-CREATE CONTINUOUS TRANSFORM ct_invalid AS SELECT x, x AS y FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
-CREATE CONTINUOUS TRANSFORM ct_valid AS SELECT x, 'a'::text FROM ct_s THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s');
+CREATE VIEW ct_invalid WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s')) AS SELECT y, x FROM ct_s;
+CREATE VIEW ct_invalid WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s')) AS SELECT x, x AS y FROM ct_s;
+CREATE VIEW ct_valid WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s')) AS SELECT x, 'a'::text FROM ct_s;
 
 DROP STREAM ct_s CASCADE;
 
 CREATE STREAM ct_s0 (x int);
 CREATE STREAM ct_s1 (x int);
 
-CREATE CONTINUOUS TRANSFORM ct_t AS SELECT x % 4 AS x FROM ct_s0 THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_s1');
+CREATE VIEW ct_t WITH (action=transform, outputfunc=pipeline_stream_insert('ct_s1')) AS SELECT x % 4 AS x FROM ct_s0;
 CREATE CONTINUOUS VIEW ct_v0 AS SELECT x FROM ct_s1;
 CREATE CONTINUOUS VIEW ct_v1 AS SELECT x FROM output_of('ct_t');
 
@@ -71,24 +70,24 @@ INSERT INTO ct_s0 SELECT generate_series(1, 10) x;
 SELECT * FROM ct_v0;
 SELECT * FROM ct_v1;
 
-CREATE CONTINUOUS TRANSFORM ct_ostream AS SELECT 1 AS a, 2 AS b, 3 AS c, x + 42 AS d FROM ct_s1;
+CREATE VIEW ct_ostream WITH (action=transform) AS SELECT 1 AS a, 2 AS b, 3 AS c, x + 42 AS d FROM ct_s1;
 
 DROP STREAM ct_s0 CASCADE;
 DROP STREAM ct_s1 CASCADE;
 
 CREATE STREAM fanout (x integer);
 
-CREATE CONTINUOUS TRANSFORM fanout0 AS SELECT generate_series(1, 2) FROM fanout;
-CREATE CONTINUOUS TRANSFORM fanout1 AS SELECT generate_series(1, 2) FROM output_of('fanout0');
-CREATE CONTINUOUS TRANSFORM fanout2 AS SELECT generate_series(1, 2) FROM output_of('fanout1');
-CREATE CONTINUOUS TRANSFORM fanout3 AS SELECT generate_series(1, 2) FROM output_of('fanout2');
-CREATE CONTINUOUS TRANSFORM fanout4 AS SELECT generate_series(1, 2) FROM output_of('fanout3');
-CREATE CONTINUOUS TRANSFORM fanout5 AS SELECT generate_series(1, 2) FROM output_of('fanout4');
-CREATE CONTINUOUS TRANSFORM fanout6 AS SELECT generate_series(1, 2) FROM output_of('fanout5');
-CREATE CONTINUOUS TRANSFORM fanout7 AS SELECT generate_series(1, 2) FROM output_of('fanout6');
-CREATE CONTINUOUS TRANSFORM fanout8 AS SELECT generate_series(1, 2) FROM output_of('fanout7');
-CREATE CONTINUOUS TRANSFORM fanout9 AS SELECT generate_series(1, 2) FROM output_of('fanout8');
-CREATE CONTINUOUS TRANSFORM fanout10 AS SELECT generate_series(1, 2) FROM output_of('fanout9');
+CREATE VIEW fanout0 WITH (action=transform) AS SELECT generate_series(1, 2) FROM fanout;
+CREATE VIEW fanout1 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout0');
+CREATE VIEW fanout2 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout1');
+CREATE VIEW fanout3 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout2');
+CREATE VIEW fanout4 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout3');
+CREATE VIEW fanout5 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout4');
+CREATE VIEW fanout6 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout5');
+CREATE VIEW fanout7 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout6');
+CREATE VIEW fanout8 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout7');
+CREATE VIEW fanout9 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout8');
+CREATE VIEW fanout10 WITH (action=transform) AS SELECT generate_series(1, 2) FROM output_of('fanout9');
 
 CREATE CONTINUOUS VIEW fanout11 AS SELECT count(*) FROM output_of('fanout10');
 
@@ -111,7 +110,9 @@ CREATE STREAM ct_b (n int);
 
 CREATE CONTINUOUS VIEW ct_stream_insert0 AS SELECT n FROM ct_b;
 
-CREATE FUNCTION insert_into_b () RETURNS TRIGGER AS
+CREATE SCHEMA test_cont_transform;
+
+CREATE FUNCTION test_cont_transform.insert_into_b () RETURNS TRIGGER AS
 $$
 BEGIN
   INSERT INTO ct_b VALUES (NEW.n);
@@ -119,9 +120,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE CONTINUOUS TRANSFORM ct_stream_insert1 AS
-SELECT n FROM ct_a
-THEN EXECUTE PROCEDURE insert_into_b();
+CREATE VIEW ct_stream_insert1 WITH (action=transform, outputfunc=test_cont_transform.insert_into_b) AS
+SELECT n FROM ct_a;
 
 INSERT INTO ct_a SELECT generate_series(1, 100);
 INSERT INTO ct_a SELECT generate_series(1, 100);
@@ -129,6 +129,7 @@ INSERT INTO ct_a SELECT generate_series(1, 100);
 SELECT pg_sleep(1);
 SELECT count(*) FROM ct_stream_insert0;
 
-DROP FUNCTION insert_into_b() CASCADE;
+DROP FUNCTION test_cont_transform.insert_into_b() CASCADE;
+DROP SCHEMA test_cont_transform;
 DROP STREAM ct_b CASCADE;
 DROP STREAM ct_a;

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -152,7 +152,7 @@ SELECT x, old, new FROM os3_output ORDER BY x, old, new;
 DROP CONTINUOUS VIEW os3 CASCADE;
 
 -- Verify that transforms write to output streams
-CREATE CONTINUOUS TRANSFORM os_xform AS SELECT x, y FROM os_stream;
+CREATE VIEW os_xform WITH (action=transform) AS SELECT x, y FROM os_stream;
 
 CREATE CONTINUOUS VIEW os4 AS SELECT x, y FROM output_of('os_xform');
 

--- a/src/test/regress/sql/output_streams.sql
+++ b/src/test/regress/sql/output_streams.sql
@@ -198,9 +198,13 @@ GROUP BY second, y, x;
 
 CREATE CONTINUOUS VIEW os8 AS SELECT (new).x, (new).y FROM output_of('os7');
 
+BEGIN;
 INSERT INTO os_stream (ts, x, y) VALUES (now(), 'text!', 42.42);
 INSERT INTO os_stream (ts, x, y) VALUES (now(), 'text!', 42.42);
 INSERT INTO os_stream (ts, x, y) VALUES (now(), 'text!', 42.42);
+COMMIT;
+
+SELECT pg_sleep(1);
 
 SELECT x, y FROM os8 ORDER BY x, y;
 

--- a/src/test/regress/sql/pipeline_regress.sql
+++ b/src/test/regress/sql/pipeline_regress.sql
@@ -204,14 +204,15 @@ CREATE CONTINUOUS VIEW unknown_type_cv AS SELECT x, 'a'::text FROM sw_ts_expr_s;
 DROP CONTINUOUS VIEW unknown_type_cv;
 
 CREATE STREAM ct_out_s (x integer, a text);
-CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a' FROM sw_ts_expr_s
-  THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
-CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a'::text FROM sw_ts_expr_s
-  THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
+CREATE VIEW unknown_type_ct WITH (action=transform, outputfunc=pipeline_stream_insert('ct_out_s')) AS
+  SELECT x, 'a' FROM sw_ts_expr_s;
+
+CREATE VIEW unknown_type_ct WITH (action=transform, outputfunc=pipeline_stream_insert('ct_out_s')) AS
+  SELECT x, 'a'::text FROM sw_ts_expr_s;
 
 SELECT pg_get_viewdef('unknown_type_ct');
 
-DROP CONTINUOUS TRANSFORM unknown_type_ct;
+DROP VIEW unknown_type_ct;
 DROP STREAM ct_out_s;
 
 

--- a/src/test/regress/sql/pipeline_regress.sql
+++ b/src/test/regress/sql/pipeline_regress.sql
@@ -209,7 +209,7 @@ CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a' FROM sw_ts_expr_s
 CREATE CONTINUOUS TRANSFORM unknown_type_ct AS SELECT x, 'a'::text FROM sw_ts_expr_s
   THEN EXECUTE PROCEDURE pipeline_stream_insert('ct_out_s');
 
-\d+ unknown_type_ct
+SELECT pg_get_viewdef('unknown_type_ct');
 
 DROP CONTINUOUS TRANSFORM unknown_type_ct;
 DROP STREAM ct_out_s;


### PR DESCRIPTION
Transforms are now stored as regular views. Some notes on how things work now:

* `CREATE CONTINUOUS TRANSFORM` syntax is still supported for one more release, but internally it just gets rewritten to a `CREATE VIEW` statement
* There are no more custom node types for representing transforms
* Transforms are configured by simply passing `WITH` options to a `CREATE VIEW` command
* ` WITH (action=transform)` indicates a transform
* Output functions are specified via the `outputfunc` `WITH` options

A couple of examples:

```sql
-- No output function
CREATE VIEW xform0 WITH (action=transform) AS SELECT x FROM s;

-- Use the pipeline_stream_insert function to write output to s0 and s1
CREATE VIEW xform1 WITH (action=transform, outputfunc=pipeline_stream_insert('s0', 's1')) AS
  SELECT x FROM s;

-- Custom output function with no arguments
CREATE VIEW xform2 WITH (action=transform, outputfunc=my_func) AS
  SELECT x FROM s;
```

/cc @usmanm 