### PR TITLE
Allow the dockerfile entrypoint to be reused by child images

### DIFF
--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -155,6 +155,7 @@ RUN addgroup --system pipeline \
         pipeline
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
Here's the associated issue: https://github.com/pipelinedb/pipelinedb/issues/1941